### PR TITLE
fix(cloudwatch): treat ResourceAlreadyExistsException as success

### DIFF
--- a/packages/api/src/routes/cloudwatch.ts
+++ b/packages/api/src/routes/cloudwatch.ts
@@ -32,7 +32,13 @@ app.get('/log-groups', async (c) => {
 
 app.post('/log-groups', async (c) => {
     const {name, retentionInDays} = await c.req.json<{name: string; retentionInDays?: number}>()
-    await cwLogs.send(new CreateLogGroupCommand({logGroupName: name}))
+    try {
+        await cwLogs.send(new CreateLogGroupCommand({logGroupName: name}))
+    } catch (err) {
+        // An already-existing log group is an acceptable end state — the
+        // ingestor re-requests groups it created on earlier navigations.
+        if ((err as {name?: string}).name !== 'ResourceAlreadyExistsException') throw err
+    }
     if (retentionInDays) {
         await cwLogs.send(new PutRetentionPolicyCommand({logGroupName: name, retentionInDays}))
     }
@@ -60,7 +66,12 @@ app.get('/log-streams', async (c) => {
 
 app.post('/log-streams', async (c) => {
     const {group, name} = await c.req.json<{group: string; name: string}>()
-    await cwLogs.send(new CreateLogStreamCommand({logGroupName: group, logStreamName: name}))
+    try {
+        await cwLogs.send(new CreateLogStreamCommand({logGroupName: group, logStreamName: name}))
+    } catch (err) {
+        // An already-existing log stream is an acceptable end state.
+        if ((err as {name?: string}).name !== 'ResourceAlreadyExistsException') throw err
+    }
     return c.json({ok: true})
 })
 


### PR DESCRIPTION
## Summary

`POST /api/cloudwatch/log-groups` and `POST /api/cloudwatch/log-streams`
returned HTTP `500` whenever the target log group or stream already existed.

The CloudWatch ingestor re-requests the `/floci/{service}` log groups and
streams it created on earlier navigations. `CreateLogGroup` /
`CreateLogStream` then throw `ResourceAlreadyExistsException`, which neither
route handled, so the request failed with a `500`.

## Change — `packages/api/src/routes/cloudwatch.ts`

Both POST routes now swallow `ResourceAlreadyExistsException`: an existing log
group or stream is the intended end state, so the request succeeds. Any other
error still propagates. This mirrors the S3 route, which already treats an
absent tag set as an empty result.

## Verification

- Creating the same log group twice — first `200`, second `200` (was `500`).
- Creating the same log stream twice — first `200`, second `200` (was `500`).
