### PR TITLE
feat: add serverless service schema

### DIFF
--- a/packages/api/src/cloud-spi/serverlessSchema.ts
+++ b/packages/api/src/cloud-spi/serverlessSchema.ts
@@ -1,0 +1,59 @@
+import type {CloudProvider, FieldSchema, ServiceSchema, TableColumnSchema} from './types'
+
+const serverlessColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Function Name'},
+    {name: 'type', label: 'Type'},
+    {name: 'cloud', label: 'Cloud'},
+    {name: 'region', label: 'Region'},
+    {name: 'runtime', label: 'Runtime'},
+    {name: 'status', label: 'Status'},
+    {name: 'updatedAt', label: 'Last Updated'},
+]
+
+const serverlessFilters: FieldSchema[] = [
+    {name: 'search', label: 'Search', type: 'text', required: false},
+    {name: 'runtime', label: 'Runtime', type: 'text', required: false},
+]
+
+export function awsServerlessSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'serverless',
+        displayName: 'AWS Lambda',
+        fields: [],
+        actions: ['list', 'inspect'],
+        filters: serverlessFilters,
+        columns: serverlessColumns,
+    }
+}
+
+export function azureServerlessSchema(): ServiceSchema {
+    return {
+        cloud: 'azure',
+        service: 'serverless',
+        displayName: 'Azure Functions',
+        fields: [],
+        actions: ['list', 'inspect'],
+        filters: serverlessFilters,
+        columns: serverlessColumns,
+    }
+}
+
+export function gcpServerlessSchema(): ServiceSchema {
+    return {
+        cloud: 'gcp',
+        service: 'serverless',
+        displayName: 'Cloud Functions',
+        fields: [],
+        actions: ['list', 'inspect'],
+        filters: serverlessFilters,
+        columns: serverlessColumns,
+    }
+}
+
+export function serverlessSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    if (cloud === 'aws') return awsServerlessSchema()
+    if (cloud === 'azure') return azureServerlessSchema()
+    if (cloud === 'gcp') return gcpServerlessSchema()
+    return null
+}

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -1,6 +1,6 @@
 export type CloudProvider = 'aws' | 'azure' | 'gcp'
 
-export type CloudServiceType = 'storage'
+export type CloudServiceType = 'storage' | 'serverless'
 
 export type CloudAvailability = 'available' | 'coming_soon'
 

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -146,7 +146,7 @@ function isCloudProvider(value: string): value is CloudProvider {
 }
 
 function isServiceType(value: string): value is CloudServiceType {
-    return value === 'storage'
+    return value === 'storage' || value === 'serverless'
 }
 
 async function withRuntime(c: Context, handler: () => Promise<Response>): Promise<Response> {

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -13,6 +13,7 @@ import type {
 } from '../cloud-spi/types'
 import {storageSchemaFor} from '../cloud-spi/storageSchema'
 import {CloudAdapterRegistry} from '../registry/CloudAdapterRegistry'
+import {serverlessSchemaFor} from '../cloud-spi/serverlessSchema'
 import {azureEndpoint} from '../azure'
 
 export class CloudProxyService {
@@ -28,7 +29,9 @@ export class CloudProxyService {
 
     services(cloud: CloudProvider): CloudServiceDescriptor[] {
         if (cloud === 'gcp') {
-            return [{cloud, service: 'storage', displayName: 'Storage Coming Soon', availability: 'coming_soon'}]
+            return [{cloud, service: 'storage', displayName: 'Storage Coming Soon', availability: 'coming_soon'},
+                  {cloud, service: 'serverless', displayName: 'Cloud Functions', availability: 'coming_soon'},
+            ]
         }
 
         return [{
@@ -36,14 +39,27 @@ export class CloudProxyService {
             service: 'storage',
             displayName: cloud === 'aws' ? 'S3 Storage' : 'Azure Blob Storage',
             availability: this.registry.get(cloud, 'storage') ? 'available' : 'coming_soon',
-        }]
+        },
+        {
+        cloud,
+        service: 'serverless',
+        displayName: cloud === 'aws' ? 'AWS Lambda' : 'Azure Functions',
+        availability: 'available',
+    },
+]
     }
 
     schema(cloud: CloudProvider, service: CloudServiceType): ServiceSchema | null {
-        const adapter = this.registry.get(cloud, service)
-        if (adapter) return adapter.schema()
-        return storageSchemaFor(cloud)
+    const adapter = this.registry.get(cloud, service)
+
+    if (adapter) return adapter.schema()
+
+    if (service === 'serverless') {
+        return serverlessSchemaFor(cloud)
     }
+
+    return storageSchemaFor(cloud)
+}
 
     async status(cloud: CloudProvider): Promise<CloudStatus> {
         const adapter = this.registry.get(cloud, 'storage')


### PR DESCRIPTION
Summary
Adds initial unified `serverless` service support to the cloud proxy model.

This introduces the foundational schema/service wiring needed for:
* AWS Lambda
* Azure Functions
* Google Cloud Functions
within the shared multi-cloud explorer architecture.

Changes
* Added `serverless` to `CloudServiceType`
* Added `serverlessSchema.ts`
* Added initial service schemas for:
  * AWS Lambda
  * Azure Functions
  * Cloud Functions
* Updated `CloudProxyService` to expose serverless services
* Updated schema routing to recognize `serverless`
* Enabled schema discovery through:
  `/api/clouds/:cloud/services/serverless/schema`

Current Scope
This PR only introduces the shared schema/service layer and API exposure.

It does not yet implement:
* real runtime adapters
* function execution
* deployment flows
* logs/runtime integration

Those will come in follow-up UI + adapter work.
Validation
Tested locally with:
* `pnpm type-check`
* API schema route validation

Verified:
curl http://localhost:3001/api/clouds/aws/services/serverless/schema
returns the expected AWS Lambda schema response.

Notes
`pnpm lint` currently reports pre-existing frontend warnings in EKS/RDS pages unrelated to this change.