### PR TITLE
feat(serverless): expose serverless service in cloud explorer

### DIFF
--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -65,6 +65,7 @@ const CLOUD_SERVICE_ICONS = {
     database: Table2,
     compute: Server,
     networking: Network,
+    serverless: Zap,
 } satisfies Record<string, React.ElementType>
 
 type CloudSidebarService = keyof typeof CLOUD_SERVICE_ICONS
@@ -75,6 +76,7 @@ const CLOUD_SERVICE_ITEMS: Array<{name: CloudSidebarService; label: string; rout
     {name: 'database', label: 'Database', route: 'database'},
     {name: 'compute', label: 'Compute', route: 'compute'},
     {name: 'networking', label: 'Networking', route: 'networking'},
+    {name: 'serverless', label: 'Serverless', route: 'serverless'},
     {name: 'queue', label: 'Queue'},
     {name: 'function', label: 'Function'},
 ]
@@ -89,7 +91,7 @@ function CloudServiceNav() {
             <span className="nav-label">Cloud Services · {cloudLabel}</span>
             {CLOUD_SERVICE_ITEMS.map((service) => {
                 const Icon = CLOUD_SERVICE_ICONS[service.name]
-                const available = service.name === 'storage' || ((service.name === 'k8s' || service.name === 'database' || service.name === 'compute' || service.name === 'networking') && cloud === 'aws')
+               const available = service.name === 'storage' || ((service.name === 'k8s' || service.name === 'database' || service.name === 'compute' || service.name === 'networking' || service.name === 'serverless') && cloud === 'aws')
                 if (service.route && available) {
                     return <NavItem key={service.name} to={`/cloud-explorer/${cloud}/${service.route}`} icon={Icon} label={service.label}/>
                 }

--- a/packages/frontend/src/pages/CloudExplorerPage.tsx
+++ b/packages/frontend/src/pages/CloudExplorerPage.tsx
@@ -90,7 +90,7 @@ function normalizeCloud(value?: string): CloudProvider | null {
 }
 
 function normalizeService(value?: string): CloudServiceType | null {
-    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'compute' || value === 'networking' ? value : null
+    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'compute' || value === 'networking' || value === 'serverless' ? value : null
 }
 
 function RuntimeCard({

--- a/packages/frontend/src/types/cloud.ts
+++ b/packages/frontend/src/types/cloud.ts
@@ -1,6 +1,6 @@
 export type CloudProvider = 'aws' | 'azure' | 'gcp'
 export type CloudAvailability = 'available' | 'coming_soon'
-export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'compute' | 'networking'
+export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'compute' | 'networking' | 'serverless'
 
 export interface CloudDescriptor {
     id: CloudProvider


### PR DESCRIPTION
This PR exposes Serverless as a first-class Cloud Explorer service.

Changes:
- Added serverless CloudServiceType support
- Added serverless route handling in Cloud Explorer
- Added Serverless navigation entry in Cloud Services
- Enabled navigation to /cloud-explorer/:cloud/serverless

Current state:
- Service schema is available
- Navigation and routing are functional
- Placeholder page is shown until provider adapters are implemented