### PR TITLE
feat(serverless): add aws lambda cloud adapter

### DIFF
--- a/packages/api/src/adapter-aws/AwsServerlessAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsServerlessAdapter.ts
@@ -1,0 +1,103 @@
+import {ListFunctionsCommand, GetFunctionCommand} from '@aws-sdk/client-lambda'
+import {awsServerlessSchema} from '../cloud-spi/serverlessSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+import {lambda} from '../aws'
+
+export class AwsServerlessAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'serverless' as const
+
+    schema(): ServiceSchema {
+        return awsServerlessSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const res = await lambda.send(new ListFunctionsCommand({}))
+        const resources: CloudResource[] = (res.Functions ?? []).map((fn) => ({
+            id: fn.FunctionName ?? fn.FunctionArn ?? '',
+            name: fn.FunctionName ?? '',
+            cloud: 'aws' as const,
+            service: 'serverless' as const,
+            type: 'lambda',
+            region: null,
+            createdAt: null,
+            status: fn.State ?? null,
+            metadata: {
+                arn: fn.FunctionArn,
+                runtime: fn.Runtime,
+                handler: fn.Handler,
+                lastModified: fn.LastModified,
+                memorySize: fn.MemorySize,
+                timeout: fn.Timeout,
+                codeSize: fn.CodeSize,
+                packageType: fn.PackageType,
+                description: fn.Description,
+            },
+        }))
+
+        return filterBySearch(resources, query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        try {
+            const res = await lambda.send(new GetFunctionCommand({FunctionName: id}))
+            const config = res.Configuration
+
+            if (!config) return null
+
+            return {
+                id: config.FunctionName ?? config.FunctionArn ?? id,
+                name: config.FunctionName ?? id,
+                cloud: 'aws',
+                service: 'serverless',
+                type: 'lambda',
+                region: null,
+                createdAt: null,
+                status: config.State ?? null,
+                metadata: {
+                    arn: config.FunctionArn,
+                    runtime: config.Runtime,
+                    handler: config.Handler,
+                    lastModified: config.LastModified,
+                    memorySize: config.MemorySize,
+                    timeout: config.Timeout,
+                    codeSize: config.CodeSize,
+                    packageType: config.PackageType,
+                    description: config.Description,
+                    role: config.Role,
+                    version: config.Version,
+                    codeSha256: config.CodeSha256,
+                },
+            }
+        } catch (error) {
+            if (hasHttpStatus(error, 404)) return null
+            throw error
+        }
+    }
+
+    async create(_input: CreateResourceInput): Promise<CloudResource> {
+        throw new Error('Creating Lambda functions through the unified serverless adapter is not implemented yet')
+    }
+
+    async delete(_id: string): Promise<void> {
+        throw new Error('Deleting Lambda functions through the unified serverless adapter is not implemented yet')
+    }
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((r) => r.name.toLowerCase().includes(normalized))
+}
+
+function hasHttpStatus(error: unknown, status: number): boolean {
+    if (typeof error !== 'object' || error === null) return false
+    const metadata = (error as {$metadata?: {httpStatusCode?: number}}).$metadata
+    return metadata?.httpStatusCode === status
+}

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -83,7 +83,7 @@ export interface CloudResource {
     name: string
     cloud: Extract<CloudProvider, 'aws' | 'azure'>
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'instance' | 'image' | 'vpc'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'instance' | 'image' | 'vpc' | 'lambda'
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -6,6 +6,7 @@ import {AwsEksAdapter} from './adapter-aws/AwsEksAdapter'
 import {AwsStorageAdapter} from './adapter-aws/AwsStorageAdapter'
 import {AzureStorageAdapter} from './adapter-azure/AzureStorageAdapter'
 import {CloudProxyService} from './service/CloudProxyService'
+import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
 
 export function createCloudProxyService(): CloudProxyService {
     const registry = new CloudAdapterRegistry([
@@ -14,6 +15,7 @@ export function createCloudProxyService(): CloudProxyService {
         new AwsDatabaseAdapter(),
         new AwsComputeAdapter(),
         new AwsNetworkingAdapter(),
+        new AwsServerlessAdapter(),
         new AzureStorageAdapter(),
     ])
 


### PR DESCRIPTION
Adds the AWS serverless adapter for the unified Cloud Explorer.

Changes:
- Registers AWS serverless adapter in the cloud proxy registry
- Lists Lambda functions through ListFunctionsCommand
- Maps Lambda functions into normalized CloudResource objects
- Supports Lambda inspect/details through GetFunctionCommand
- Adds lambda as a supported CloudResource type

Validation:
- pnpm type-check passes
- pnpm lint currently fails on existing unrelated frontend files