### PR TITLE
feat(serverless): add lambda environment update route

### DIFF
--- a/packages/api/src/routes/lambda.ts
+++ b/packages/api/src/routes/lambda.ts
@@ -1,11 +1,12 @@
 import {Hono} from 'hono'
 import {
+     CreateFunctionCommand,
     DeleteFunctionCommand,
     GetFunctionCommand,
     InvokeCommand,
     ListFunctionsCommand,
-    CreateFunctionCommand,
-Runtime,
+    Runtime,
+    UpdateFunctionConfigurationCommand,
 } from '@aws-sdk/client-lambda'
 import {lambda} from '../aws'
 
@@ -120,6 +121,39 @@ app.get('/functions/:name', async (c) => {
         architectures: config?.Architectures,
         role: config?.Role,
         environment: config?.Environment?.Variables,
+    })
+})
+
+app.put('/functions/:name/environment', async (c) => {
+    const name = c.req.param('name')
+    const body = await c.req.json().catch(() => ({})) as {
+        environment?: Record<string, string>
+    }
+
+    if (!body.environment || typeof body.environment !== 'object' || Array.isArray(body.environment)) {
+        return c.json({error: 'environment must be an object'}, 400)
+    }
+
+    const res = await lambda.send(new UpdateFunctionConfigurationCommand({
+        FunctionName: name,
+        Environment: {
+            Variables: body.environment,
+        },
+    }))
+
+    return c.json({
+        name: res.FunctionName ?? name,
+        functionArn: res.FunctionArn,
+        runtime: res.Runtime,
+        handler: res.Handler,
+        state: res.State,
+        stateReason: res.StateReason,
+        lastModified: res.LastModified,
+        memorySize: res.MemorySize,
+        timeout: res.Timeout,
+        description: res.Description,
+        role: res.Role,
+        environment: res.Environment?.Variables,
     })
 })
 


### PR DESCRIPTION
Summary

Adds support for updating AWS Lambda environment variables through the Lambda API.
This is the first step toward Lambda environment variable management in the unified Serverless experience.

Changes- Backend

* Added Lambda environment update route:
  * `PUT /lambda/functions/:name/environment`
* Added support for `UpdateFunctionConfigurationCommand`
* Added validation for environment variable payloads
* Returns updated Lambda configuration after successful update

Validation
* API type-check passes
* Frontend type-check passes
* Full repository type-check passes

Example Request

{
  "environment": {
    "API_KEY": "example",
    "STAGE": "dev"
  }
}

Future Work

* Add frontend environment variable editor
* Add environment variable management in Cloud Explorer Serverless panel
* Add runtime validation and testing
* Add support for secrets integration