### PR TITLE
chore: add CI/release workflows, GitHub templates, CODEOWNERS, dependabot, and CONTRIBUTING

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,20 @@
+# CODEOWNERS for floci-ui
+#
+# Scopes release-sensitive paths to the primary maintainer so CI, release
+# config, and container/build changes always trigger a review ping. Add more
+# owners as the maintainer roster grows.
+#
+# Docs: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default: no global owner (unowned files fall through to normal review rules).
+
+# CI, release automation, workflow hygiene
+/.github/                @hectorvent
+
+# Container build surface
+/docker/                 @hectorvent
+/docker-compose.yml      @hectorvent
+
+# Workspace / build manifests
+/package.json            @hectorvent
+/pnpm-lock.yaml          @hectorvent

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,43 @@
+---
+name: Bug report
+about: Something in the console behaves incorrectly or throws an error
+title: '[BUG] '
+labels: bug
+assignees: ''
+---
+
+## Area
+
+<!-- Frontend page / Cloud Explorer / API proxy / Setup -->
+
+## Cloud & Service
+
+<!-- e.g. AWS S3, Azure Blob Storage, AWS Compute (EC2) — or "n/a" -->
+
+## Expected behavior
+
+<!-- What you expected the console to do -->
+
+## Actual behavior
+
+<!-- What actually happened — include any UI error, toast, or console/network error -->
+
+## Reproduction
+
+<!-- Steps to reproduce in the UI, or a request that misbehaves -->
+
+```bash
+# e.g. the proxy response that looks wrong
+curl http://localhost:4501/api/clouds/aws/status
+```
+
+## Screenshots
+
+<!-- If applicable, attach screenshots or the browser devtools console/network output -->
+
+## Environment
+
+- Floci UI version / image tag:
+- How you're running it (`docker compose` / `pnpm dev` + `pnpm dev:api`):
+- Floci core version / image tag:
+- Browser:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,30 @@
+---
+name: Feature request
+about: A missing console feature or a service to wire into the Cloud Explorer
+title: '[FEAT] '
+labels: enhancement
+assignees: ''
+---
+
+## Cloud & Service / Area
+
+<!-- e.g. GCP Storage, Azure Compute, a new Cloud Explorer category, a UX improvement -->
+
+## What would you like?
+
+<!-- Describe the console feature or service UI you need -->
+
+## Why is this needed?
+
+<!-- Describe your use case — what's painful or impossible without it? -->
+
+## Backing API
+
+<!-- Which Floci-compatible endpoint(s) would power this? The UI renders only real
+     data, so a feature needs a runtime that can serve it. Link the relevant
+     Floci / cloud API reference if you have it. -->
+
+## Are you willing to contribute a PR?
+
+- [ ] Yes
+- [ ] No

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,37 @@
+version: 2
+updates:
+  # JS/TS dependencies across the pnpm workspace (root, frontend, api).
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
+    labels:
+      - "dependencies"
+      - "javascript"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    cooldown:
+      default-days: 7
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,30 @@
+## Summary
+
+<!-- What does this PR do? Link any related issues with "Closes #N" -->
+
+## Type of change
+
+- [ ] Bug fix (`fix:`)
+- [ ] New feature / service UI (`feat:`)
+- [ ] Breaking change (`feat!:` or `fix!:`)
+- [ ] Docs / chore
+
+## Area
+
+- [ ] Frontend (`packages/frontend`)
+- [ ] API / Cloud Proxy (`packages/api`)
+- [ ] Cloud Explorer adapter / schema
+- [ ] Build / CI / Docker
+
+## Verification
+
+<!-- How did you verify this? Which cloud + service did you test against
+     (e.g. AWS S3 via Floci core, Azure Blob via Floci-AZ)? -->
+<!-- For UI changes, please attach before/after screenshots. -->
+
+## Checklist
+
+- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
+- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
+- [ ] No fake/mock data added — unwired states stay empty or show an explicit placeholder
+- [ ] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+# Runs on every pull request and on pushes to main. The API tests are
+# self-contained unit tests (mocked clients) and do NOT require the Floci
+# emulators to be running.
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: Lint, type-check, test, build
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      # ── Frontend toolchain (pnpm workspace) ────────────────────────────────
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.2.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Install workspace dependencies
+        run: pnpm install --frozen-lockfile
+
+      # ── API toolchain (bun) — needed for tests and type-check ──────────────
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1'
+
+      - name: Install API dependencies
+        working-directory: packages/api
+        run: bun install --frozen-lockfile
+
+      # ── Checks ─────────────────────────────────────────────────────────────
+      - name: Type-check
+        run: pnpm type-check
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      # Lint is non-blocking for now: main has pre-existing
+      # react-hooks/rules-of-hooks violations in NetworkingPanel.tsx. Drop
+      # continue-on-error once those are fixed to make lint gate PRs.
+      - name: Lint
+        run: pnpm lint
+        continue-on-error: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+# Triggered when a version tag (e.g. 1.2.3) is pushed.
+# Builds the frontend bundle and the API binary in the workflow, then packages
+# them into a multi-platform (amd64 + arm64) Docker image pushed to Docker Hub.
+# Nothing is compiled inside the Dockerfile — see docker/Dockerfile.package.
+#
+# Published tags:
+#   floci/floci-ui:1.2.3   floci/floci-ui:latest
+#
+# Required secrets: DOCKERHUB_USERNAME, DOCKERHUB_TOKEN
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: read
+
+# Per-tag concurrency. Re-runs of the same tag supersede in-flight builds of
+# that tag; distinct tags run in parallel.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  push-image:
+    name: Build and push multi-arch image
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Set created timestamp
+        id: created
+        run: echo "created=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_OUTPUT"
+
+      - name: Set SOURCE_DATE_EPOCH
+        id: source_date
+        run: echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
+
+      # ── Build the frontend bundle (arch-independent) ───────────────────────
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9.2.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: pnpm
+
+      - name: Build frontend
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm --filter @floci/frontend build
+          rm -rf public
+          mv packages/frontend/dist public
+
+      # ── Cross-compile the API binary for each arch (no QEMU needed) ────────
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: '1'
+
+      - name: Compile API binaries
+        working-directory: packages/api
+        run: |
+          bun install
+          bun build --compile --minify --target=bun-linux-x64-musl \
+            src/index.ts --outfile "$GITHUB_WORKSPACE/native/amd64/server"
+          bun build --compile --minify --target=bun-linux-arm64-musl \
+            src/index.ts --outfile "$GITHUB_WORKSPACE/native/arm64/server"
+
+      # ── Package the prebuilt artifacts into a multi-arch image ─────────────
+      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push multi-arch image
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        env:
+          SOURCE_DATE_EPOCH: ${{ steps.source_date.outputs.epoch }}
+        with:
+          context: .
+          file: docker/Dockerfile.package
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            floci/floci-ui:${{ steps.version.outputs.version }}
+            floci/floci-ui:latest
+          labels: |
+            org.opencontainers.image.version=${{ steps.version.outputs.version }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.created=${{ steps.created.outputs.created }}
+            version=${{ steps.version.outputs.version }}
+            build-date=${{ steps.created.outputs.created }}
+            vcs-ref=${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,207 @@
+# Contributing to Floci UI
+
+Thank you for your interest in contributing! Floci UI is the web console / DevTools
+for the [Floci](https://floci.io) local cloud emulator. It is a community-driven
+project and all contributions are welcome.
+
+## Ways to Contribute
+
+- **Bug reports** — open an issue with a minimal reproduction (steps, expected vs. actual)
+- **Feature requests** — open an issue describing the console feature or service page you need
+- **Pull requests** — bug fixes, new service UI, or UX improvements
+- **Service coverage** — wire a new Floci-backed service into the console
+
+## Project Layout
+
+This is a pnpm workspace monorepo with two packages:
+
+| Package | Stack | Responsibility |
+|---|---|---|
+| `packages/frontend` | React + Vite + TypeScript | The console UI served on port `4500` |
+| `packages/api` | Bun + Hono + AWS SDK v3 | Backend on port `4501` that translates the UI's REST/JSON requests into AWS SDK calls against Floci core |
+
+The frontend talks only to `/api/*` (proxied to `packages/api`); the API talks to the
+Floci emulators. Never have the frontend reach a cloud endpoint directly.
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- pnpm 9+
+- [Bun](https://bun.sh/) (required by `packages/api`)
+- Docker (optional — only for running the full stack via `docker compose`)
+
+### Install
+
+```bash
+git clone https://github.com/floci-io/floci-ui.git
+cd floci-ui
+pnpm install
+```
+
+### Run
+
+The UI needs three components running: Floci core (`:4566`), the API (`:4501`), and the
+frontend (`:4500`).
+
+**Option A — Docker Compose (recommended):**
+
+```bash
+docker compose up                        # AWS-only
+docker compose --profile multicloud up   # adds Azure + GCP emulators
+```
+
+**Option B — local dev (three terminals):**
+
+```bash
+# 1. Floci core (see README for the docker run / local-clone options)
+# 2. API backend
+pnpm dev:api
+# 3. Frontend
+pnpm dev
+```
+
+Open the UI at http://127.0.0.1:4500/. See [README.md](README.md) for full setup,
+environment variables, and troubleshooting.
+
+### Checks
+
+Run these before opening a PR:
+
+```bash
+pnpm lint          # eslint (frontend)
+pnpm type-check    # tsc on both packages
+pnpm test          # bun test (api)
+pnpm build         # production build
+```
+
+## Branching Model
+
+Floci UI uses a **tag-driven release model**. Docker images are never published on PR
+merge — only when a maintainer pushes a version tag.
+
+| Branch / ref | Purpose | Docker published? |
+|---|---|---|
+| `main` | Integration branch — all PRs merge here. Treated as unstable. | No |
+| `X.Y.Z` tag | Signals a release. Triggers the multi-arch Docker publish pipeline. | Yes (`floci/floci-ui:x.y.z`, `floci/floci-ui:latest`) |
+
+## Commit Message Format
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org/).
+
+> **The PR title should follow this format**, since it becomes the squash-merge commit message.
+
+### Format
+
+```
+<type>[optional scope]: <description>
+```
+
+- **type** — one of the values in the table below (lowercase)
+- **scope** — optional, in parentheses, identifies the package or service area
+  (e.g. `frontend`, `api`, `s3`, `ec2`, `serverless`, `docker`, `ci`)
+- **description** — short summary in the imperative mood, no trailing period
+- Append `!` before the colon to signal a breaking change: `feat(api)!:`
+
+| Type | When to use | Version bump |
+|------|-------------|--------------|
+| `feat` | New console feature, service page, or API route | minor |
+| `fix` | Bug fix or compatibility correction | patch |
+| `perf` | Performance improvement | patch |
+| `revert` | Reverts a previous commit | patch |
+| `docs` | Documentation only | none |
+| `style` | Formatting, whitespace — no logic change | none |
+| `chore` | Build, CI, dependencies, housekeeping | none |
+| `refactor` | Code restructure without behavior change | none |
+| `test` | Adding or updating tests | none |
+| `build` | Build system or tooling changes | none |
+| `ci` | CI workflow changes | none |
+| `BREAKING CHANGE` | Footer or `!` suffix — incompatible change | major |
+
+### Valid examples ✅
+
+```
+feat(s3): add object preview panel to the bucket explorer
+fix(api): handle missing region in EC2 status call
+perf(frontend): memoize the service catalog query
+chore: bump vite to 5.4
+docs: update README with multicloud compose profile
+refactor(serverless): extract lambda env-var mapping
+test(api): cover the clouds/aws/status route
+feat(api)!: change resource list response shape
+ci: add multi-arch release workflow
+```
+
+### Invalid examples ❌
+
+```
+Add object preview                   # missing type
+Feature: add something               # "Feature" is not a valid type
+feat : space before colon            # space before colon
+feat(s3)add missing colon            # missing colon
+FIX(api): uppercase type             # type must be lowercase
+feat(my scope): scope has spaces     # scope cannot contain spaces
+wip: still working on this           # "wip" is not a recognised type
+```
+
+Do not include `Co-Authored-By` trailers for AI tools in commit messages. Attribution
+should be limited to human contributors.
+
+## Adding a New Service UI
+
+When wiring a new service into the console, follow these rules:
+
+- Use existing Floci AWS-compatible endpoints. Do not add custom backend endpoints
+  just for the UI unless the core project explicitly accepts that contract.
+- In `packages/api`, add a route that calls the appropriate AWS SDK v3 client against
+  Floci core — never invent a custom protocol.
+- In `packages/frontend`, add the service page and register it in the navigation.
+- Prefer real empty states over sample data; show placeholders when a service is not
+  wired yet. No decorative data or fake operational metrics.
+- Keep service status notes in the README accurate.
+- Add verification notes for any newly wired operations.
+
+## Pull Request Guidelines
+
+1. Branch off `main`: `git checkout -b feat/my-feature`
+2. Open a PR targeting `main`.
+3. Make sure `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` all pass before requesting review.
+4. Keep PRs focused — one feature or fix per PR.
+5. Reference any related issues in the PR description.
+
+Docker images are never built on contributor PRs, so merging to `main` is always cheap.
+
+## Release Process (maintainers)
+
+Releases are triggered by pushing a version tag matching `X.Y.Z`:
+
+```bash
+git checkout main && git pull
+git tag 1.2.3
+git push origin 1.2.3
+```
+
+The tag push triggers `.github/workflows/release.yml`, which builds the frontend bundle
+and the API binary, then packages and pushes a multi-arch (`linux/amd64,linux/arm64`)
+image as `floci/floci-ui:1.2.3` and `floci/floci-ui:latest`.
+
+Publishing requires the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
+
+## Testing Policy for Pull Requests
+
+As a project policy:
+
+- Pull requests that introduce new behavior should include tests that validate it
+  (`bun test` in `packages/api`), or a clear note on why they can't be tested in isolation.
+- Pull requests that fix bugs should include a regression test whenever realistic.
+- Documentation, formatting, dependency housekeeping, or low-risk refactors may not
+  require new tests — but `pnpm lint`, `pnpm type-check`, and the existing suite must
+  still pass.
+
+All checks (`pnpm lint`, `pnpm type-check`, `pnpm test`, `pnpm build`) must pass before merge.
+
+## Reporting Security Issues
+
+Please do **not** open public issues for security vulnerabilities. Report them privately
+using [GitHub private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability).


### PR DESCRIPTION
## Summary

Repo scaffolding and automation.

- **CI** (`ci.yml`): lint / type-check / test / build on PRs and pushes to `main` (lint non-blocking for now — `NetworkingPanel.tsx` has pre-existing `react-hooks/rules-of-hooks` errors).
- **Release** (`release.yml`): multi-arch (`amd64`+`arm64`) image publish to Docker Hub on version tags.
- Issue + PR templates, `CODEOWNERS`, `dependabot.yml`, and `CONTRIBUTING.md`.

## Type of change

- [x] Build / chore

## Note

`release.yml` packages `docker/Dockerfile.package`, which is added in the `build/compose-dockerfiles-ports` PR — merge that one before cutting a release tag.
