### PR TITLE
ci: validate PR commits follow Conventional Commits

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,63 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  contents: read
+
+jobs:
+  lint-commits:
+    name: Commits follow Conventional Commits
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Validate commit messages
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Conventional Commits pattern:
+          #   <type>[optional scope]: <description>
+          #
+          # Types recognised by semantic-release (commit-analyzer defaults):
+          #   feat, fix, perf, revert, docs, style, chore, refactor, test, build, ci
+          #
+          # Breaking changes are signalled by appending ! before the colon:
+          #   feat!: or feat(scope)!:
+          #
+          # Merge commits are skipped automatically via --no-merges.
+          #
+          # References:
+          #   https://www.conventionalcommits.org/en/v1.0.0/
+
+          PATTERN='^(feat|fix|perf|revert|docs|style|chore|refactor|test|build|ci)(\([-a-zA-Z0-9_.,]+\))?!?: .{1,}'
+          FAILED=0
+
+          while IFS= read -r msg; do
+            if echo "$msg" | grep -qE "$PATTERN"; then
+              echo "ok: $msg"
+            else
+              echo "::error::Commit does not follow Conventional Commits: $msg"
+              echo ""
+              echo "  Got: $msg"
+              echo ""
+              echo "  Expected format: <type>[optional scope]: <description>"
+              echo "  Examples:"
+              echo "    feat(s3): add object preview panel to the bucket explorer"
+              echo "    fix(api): handle missing region in EC2 status call"
+              echo "    chore: release 1.2.3"
+              echo "    feat!: change resource list response shape"
+              echo ""
+              echo "  Valid types: feat, fix, perf, revert, docs, style, chore, refactor, test, build, ci"
+              echo "  See: https://www.conventionalcommits.org/en/v1.0.0/"
+              FAILED=1
+            fi
+          done < <(git log --no-merges --format="%s" "$BASE_SHA".."$HEAD_SHA")
+
+          exit $FAILED


### PR DESCRIPTION
## Summary

Adds a **Conventional Commits** check (ported from `floci-io/floci`) that validates every non-merge commit subject on a PR against `<type>[optional scope]: <description>`, failing with a helpful message otherwise. Enforces the format already documented in `CONTRIBUTING.md`.

## Type of change

- [x] Docs / chore (CI)

## Area

- [x] Build / CI / Docker

## Verification

- YAML validated locally.
- Recognised types: `feat, fix, perf, revert, docs, style, chore, refactor, test, build, ci`; supports optional scope and `!` for breaking changes; merge commits are skipped (`--no-merges`).

## Checklist

- [x] No app code changed (CI workflow only)
- [x] Commit messages / PR title follow Conventional Commits
