### PR TITLE
build(deps): bump GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,14 +24,14 @@ jobs:
     timeout-minutes: 15
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
 
       # ── Frontend toolchain (pnpm workspace) ────────────────────────────────
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: pnpm

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,13 +24,13 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: pnpm
@@ -59,7 +59,7 @@ jobs:
     needs: build
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
 
       # data/ is gitignored, so on a fresh runner Docker would create the
       # ./data bind-mount as root and the Floci runtime (uid 1001) can't write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 30
 
     steps:
-      - uses: actions/checkout@v6.0.2
+      - uses: actions/checkout@v6.0.3
 
       - name: Extract version
         id: version
@@ -46,11 +46,11 @@ jobs:
         run: echo "epoch=$(git log -1 --pretty=%ct)" >> "$GITHUB_OUTPUT"
 
       # ── Build the frontend bundle (arch-independent) ───────────────────────
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9.2.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: pnpm
@@ -77,7 +77,7 @@ jobs:
             src/index.ts --outfile "$GITHUB_WORKSPACE/native/arm64/server"
 
       # ── Package the prebuilt artifacts into a multi-arch image ─────────────
-      - uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
 
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
 


### PR DESCRIPTION
## Summary

Combines the open Dependabot **github-actions** PRs (#36–#39) into one branch, applied across all workflow files (`ci`, `conventional-commits`, `integration`, `release`):

- `actions/checkout` 6.0.2 → 6.0.3
- `actions/setup-node` v4 → v6
- `pnpm/action-setup` v4 → v6
- `docker/setup-qemu-action` v3.6.0 → v4.1.0 (SHA-pinned)

Applied directly to the current workflows rather than merging the stale Dependabot branches (which predate the newer workflows). Closes #36, #37, #38, #39.

## Type of change

- [x] Docs / chore (CI dependencies)

## Area

- [x] Build / CI / Docker

## Verification

- All four workflow YAML files validate.
- QEMU v4.1.0 SHA confirmed against the upstream tag.
- This PR's own CI run exercises the bumped actions.

## Checklist

- [x] No app code changed (CI workflows only)
- [x] Commit messages / PR title follow Conventional Commits
