### PR TITLE
feat(dev): Streamline local development setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -494,10 +494,10 @@ the local default is `FLOCI_AZURE_ACCOUNT_NAME=devstoreaccount1`.
 For local development, the UI needs all three of these components running:
 
 1. Floci core on `http://localhost:4566`.
-2. The Floci UI API backend on `http://localhost:4501` via `pnpm dev:api`.
-3. The frontend dev server on `http://localhost:4500` via `pnpm dev`.
+2. The Floci UI API backend on `http://localhost:4501`.
+3. The frontend dev server on `http://localhost:4500`.
 
-The frontend expects `/api/*` endpoints from `packages/api`, so running only `pnpm dev` is not enough.
+The default root dev command now starts the API and frontend together.
 
 ### 2. Install Floci UI dependencies
 
@@ -526,25 +526,32 @@ PORT=4501
 
 `.env.example` already includes `VITE_MOCK_MODE=false` for real Floci usage.
 
-### 4. Start the local API
+### 4. Start local development
 
 Terminal 2:
-
-```bash
-pnpm dev:api
-```
-
-This starts `packages/api` on `http://localhost:4501` and points AWS SDK clients at `FLOCI_ENDPOINT`.
-
-### 5. Start the frontend
-
-Terminal 3:
 
 ```bash
 pnpm dev
 ```
 
-Open the UI:
+This starts:
+
+- `packages/api` on `http://localhost:4501`
+- `packages/frontend` on `http://localhost:4500`
+
+If you only want the frontend:
+
+```bash
+pnpm dev:web
+```
+
+If you only want the API:
+
+```bash
+pnpm dev:api
+```
+
+### 5. Open the UI
 
 ```text
 http://127.0.0.1:4500/
@@ -606,7 +613,7 @@ cp .env packages/api/.env
 Then restart the API server:
 
 ```bash
-pnpm dev:api
+pnpm dev
 ```
 
 #### 3. Verify connectivity

--- a/package.json
+++ b/package.json
@@ -7,12 +7,13 @@
     "packages/*"
   ],
   "scripts": {
-    "dev": "pnpm --filter @floci/frontend dev",
+    "dev": "sh -c 'PORT=4501 pnpm dev:api & pnpm dev:web'",
+    "dev:web": "pnpm --filter @floci/frontend dev",
     "build": "pnpm --filter @floci/frontend build",
     "lint": "pnpm --filter @floci/frontend lint",
     "type-check": "pnpm --filter @floci/api type-check && pnpm --filter @floci/frontend type-check",
     "test": "pnpm --filter @floci/api test",
-    "dev:api": "pnpm --filter @floci/api dev",
-    "start:api": "pnpm --filter @floci/api start"
+    "dev:api": "sh -c 'PORT=${PORT:-4501} pnpm --filter @floci/api dev'",
+    "start:api": "sh -c 'PORT=${PORT:-4501} pnpm --filter @floci/api start'"
   }
 }


### PR DESCRIPTION
Consolidate the `pnpm dev` command to start both the API and frontend development servers concurrently. Add a dedicated `pnpm dev:web` script for frontend-only development. Enhance API scripts (`dev:api`, `start:api`) to support port configuration via the `PORT` environment variable. Update documentation to reflect the simplified development workflow.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [X] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [X] Build / CI / Docker

## Verification

<!-- How did you verify this? Which cloud + service did you test against
     (e.g. AWS S3 via Floci core, Azure Blob via Floci-AZ)? -->
<!-- For UI changes, please attach before/after screenshots. -->

## Checklist

- [X] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [ ] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [X] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
