### PR TITLE
feat(cloud-explorer): Add service information dialog

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -410,11 +410,22 @@ pre,
     gap: 8px;
 }
 
+.page-title-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
 .page-title h2 {
     margin: 0;
     color: var(--text);
     font-size: 20px;
     font-weight: 400;
+}
+
+.page-info-btn {
+    width: 24px;
+    height: 24px;
 }
 
 .info-link {
@@ -757,6 +768,20 @@ pre,
     text-transform: uppercase;
 }
 
+.service-selector-readonly {
+    min-width: 164px;
+    height: 34px;
+    display: inline-flex;
+    align-items: center;
+    padding: 0 12px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--raised);
+    color: var(--text-bright);
+    font-size: 12px;
+    font-weight: 500;
+}
+
 .cloud-explorer {
     display: grid;
     grid-template-rows: auto auto minmax(0, 1fr);
@@ -774,6 +799,10 @@ pre,
     overflow: hidden;
 }
 
+.cloud-runtime-strip.compact {
+    grid-template-columns: repeat(5, minmax(0, 1fr));
+}
+
 .runtime-card {
     min-height: 38px;
     display: flex;
@@ -781,6 +810,12 @@ pre,
     gap: 10px;
     border-right: 1px solid var(--border);
     padding: 7px 10px;
+}
+
+.cloud-runtime-strip.compact .runtime-card {
+    min-height: 28px;
+    gap: 8px;
+    padding: 8px 10px;
 }
 
 .runtime-card:last-child {
@@ -818,6 +853,101 @@ pre,
     line-height: 1.35;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.cloud-runtime-strip.compact strong {
+    font-size: 11px;
+}
+
+.cloud-runtime-strip.compact small {
+    font-size: 10px;
+}
+
+.service-info-dialog {
+    width: min(880px, calc(100vw - 48px));
+    max-height: calc(100vh - 64px);
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: 0 24px 80px rgba(0, 0, 0, 0.45);
+}
+
+.service-info-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 18px 20px 12px;
+    border-bottom: 1px solid var(--border);
+}
+
+.service-info-header h3 {
+    margin: 4px 0 0;
+    color: var(--text-bright);
+    font-size: 24px;
+    font-weight: 600;
+}
+
+.service-info-grid {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 12px;
+    padding: 16px 20px;
+}
+
+.service-info-card {
+    display: grid;
+    gap: 6px;
+    min-height: 92px;
+    padding: 14px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--elevated);
+}
+
+.service-info-card span {
+    color: var(--text-2);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+}
+
+.service-info-card strong {
+    color: var(--text-bright);
+    font-size: 14px;
+    font-weight: 600;
+    word-break: break-word;
+}
+
+.service-info-card small {
+    color: var(--text-2);
+    font-size: 12px;
+    line-height: 1.4;
+}
+
+.service-info-card.ready {
+    border-color: rgba(74, 222, 128, 0.28);
+}
+
+.service-info-card.pending {
+    border-color: rgba(245, 158, 11, 0.28);
+}
+
+.service-info-card.unavailable {
+    border-color: rgba(239, 68, 68, 0.28);
+}
+
+.service-info-section {
+    padding: 0 20px 18px;
+}
+
+.service-info-copy {
+    margin: 8px 0 0;
+    color: var(--text);
+    font-size: 13px;
+    line-height: 1.6;
 }
 
 .runtime-card.ready svg,
@@ -2332,6 +2462,10 @@ button.console-service-card {
     .cloud-runtime-strip,
     .resource-workbench,
     .cloud-coming-soon {
+        grid-template-columns: 1fr;
+    }
+
+    .service-info-grid {
         grid-template-columns: 1fr;
     }
 

--- a/packages/frontend/src/pages/CloudExplorerPage.tsx
+++ b/packages/frontend/src/pages/CloudExplorerPage.tsx
@@ -1,11 +1,13 @@
-import {type ElementType, useMemo} from 'react'
-import {Cloud, DatabaseZap, Radio, Route, ShieldCheck} from 'lucide-react'
+import {type ElementType, useMemo, useState} from 'react'
+import {Cloud, DatabaseZap, Info, Radio, Route, ShieldCheck, X} from 'lucide-react'
 import {Navigate, useNavigate, useParams} from 'react-router-dom'
 import {useQuery} from '@tanstack/react-query'
-import {getCloudStatus, listClouds, listCloudServices} from '@/api/cloudProxyClient'
+import {getCloudStatus, getServiceSchema, listClouds, listCloudServices} from '@/api/cloudProxyClient'
 import {CloudSelector} from '@/components/CloudSelector'
 import {DynamicResourceView} from '@/components/DynamicResourceView'
+import {normalizeCapabilities} from '@/lib/capabilities'
 import type {CloudProvider, CloudServiceDescriptor, CloudServiceType, CloudStatus} from '@/types/cloud'
+import type {ServiceSchema} from '@/types/schema'
 
 export function CloudExplorerPage() {
     const navigate = useNavigate()
@@ -14,6 +16,7 @@ export function CloudExplorerPage() {
     const routeService = normalizeService(params.service)
     const cloud = routeCloud ?? 'aws'
     const service = routeService ?? 'storage'
+    const [infoOpen, setInfoOpen] = useState(false)
 
     const cloudsQuery = useQuery({
         queryKey: ['clouds'],
@@ -29,6 +32,10 @@ export function CloudExplorerPage() {
         queryKey: ['cloud-status', cloud],
         queryFn: ({signal}) => getCloudStatus(cloud, signal),
         refetchInterval: 10_000,
+    })
+    const schemaQuery = useQuery({
+        queryKey: ['cloud-schema', cloud, service],
+        queryFn: ({signal}) => getServiceSchema(cloud, service, signal),
     })
 
     const selectedService = useMemo(
@@ -46,11 +53,20 @@ export function CloudExplorerPage() {
                 <div className="page-title">
                     <Cloud size={20}/>
                     <div>
-                        <h2>Cloud Explorer</h2>
+                        <div className="page-title-row">
+                            <h2>Cloud Explorer</h2>
+                            <button className="icon-btn page-info-btn" type="button" onClick={() => setInfoOpen(true)} title="Service information">
+                                <Info size={14}/>
+                            </button>
+                        </div>
                         <p className="muted">Unified local runtime console</p>
                     </div>
                 </div>
                 <div className="cloud-header-selectors">
+                    <label>
+                        <span>Service</span>
+                        <div className="service-selector-readonly">{selectedService?.displayName ?? serviceLabel(service)}</div>
+                    </label>
                     <label>
                         <span>Cloud</span>
                         <CloudSelector
@@ -62,22 +78,12 @@ export function CloudExplorerPage() {
                 </div>
             </div>
             <div className="content cloud-explorer">
-                <div className="cloud-runtime-strip">
-                    <div className="runtime-card">
-                        <DatabaseZap size={16}/>
-                        <div>
-                            <span>Proxy API</span>
-                            <strong>/api/clouds/{cloud}/services/{service}</strong>
-                        </div>
-                    </div>
-                    <RuntimeCard icon={Route} label="Service" value={selectedService?.displayName ?? service} detail={serviceAvailability(selectedService)}/>
+                <div className="cloud-runtime-strip compact">
+                    <RuntimeCard icon={Route} label="Service" value={selectedService?.displayName ?? serviceLabel(service)} detail={serviceAvailability(selectedService)}/>
+                    <RuntimeCard icon={DatabaseZap} label="Proxy API" value={`/api/clouds/${cloud}/services/${service}`} detail="Single entry point"/>
                     <RuntimeCard icon={Radio} label="Runtime" value={runtimeValue(cloud, statusQuery.data)} detail={runtimeDetail(statusQuery.data, statusQuery.isLoading)} state={runtimeState(statusQuery.data, statusQuery.isLoading)}/>
                     <RuntimeCard icon={ShieldCheck} label="Adapter" value={adapterValue(cloud, statusQuery.data)} detail={adapterDetail(statusQuery.data, statusQuery.isLoading)} state={adapterState(cloud, statusQuery.data)}/>
-                    <div className={`runtime-card status ${runtimeState(statusQuery.data, statusQuery.isLoading)}`}>
-                        <span>Connection</span>
-                        <strong>{connectionValue(statusQuery.data, statusQuery.isLoading)}</strong>
-                        <small>{statusQuery.data?.endpoint ?? 'No runtime endpoint'}</small>
-                    </div>
+                    <RuntimeCard icon={Cloud} label="Connection" value={connectionValue(statusQuery.data, statusQuery.isLoading)} detail={statusQuery.data?.endpoint ?? 'No runtime endpoint'} state={runtimeState(statusQuery.data, statusQuery.isLoading)}/>
                 </div>
                 <DynamicResourceView
                     cloud={cloud}
@@ -87,6 +93,17 @@ export function CloudExplorerPage() {
                     statusLoading={statusQuery.isLoading}
                 />
             </div>
+            {infoOpen && (
+                <ServiceInfoDialog
+                    cloud={cloud}
+                    service={service}
+                    descriptor={selectedService}
+                    status={statusQuery.data}
+                    statusLoading={statusQuery.isLoading}
+                    schema={schemaQuery.data}
+                    onClose={() => setInfoOpen(false)}
+                />
+            )}
         </>
     )
 }
@@ -121,6 +138,86 @@ function RuntimeCard({
                 <strong>{value}</strong>
                 <small>{detail}</small>
             </div>
+        </div>
+    )
+}
+
+function ServiceInfoDialog({
+    cloud,
+    service,
+    descriptor,
+    status,
+    statusLoading,
+    schema,
+    onClose,
+}: {
+    cloud: CloudProvider
+    service: CloudServiceType
+    descriptor?: CloudServiceDescriptor
+    status?: CloudStatus
+    statusLoading: boolean
+    schema?: ServiceSchema
+    onClose: () => void
+}) {
+    const capabilityList = schema?.capabilities
+        ? normalizeCapabilities([
+            ...(schema.capabilities.resourceActions ?? []),
+            ...(schema.capabilities.objectActions ?? []),
+        ])
+        : []
+    const capabilityLabels = capabilityList.length
+        ? capabilityList.map((capability) => capability.label).join(', ')
+        : schema?.actions.join(', ') ?? 'Loading actions'
+
+    return (
+        <div className="modal-overlay" onClick={onClose}>
+            <div className="service-info-dialog" onClick={(event) => event.stopPropagation()}>
+                <div className="service-info-header">
+                    <div>
+                        <p className="eyebrow">Service Information</p>
+                        <h3>{schema?.displayName ?? descriptor?.displayName ?? serviceLabel(service)}</h3>
+                    </div>
+                    <button className="icon-btn" type="button" onClick={onClose}>
+                        <X size={14}/>
+                    </button>
+                </div>
+                <div className="service-info-grid">
+                    <InfoCard label="Proxy API" value={`/api/clouds/${cloud}/services/${service}`} detail="Single entry point used by the UI"/>
+                    <InfoCard label="Service" value={descriptor?.displayName ?? serviceLabel(service)} detail={serviceAvailability(descriptor)}/>
+                    <InfoCard label="Runtime" value={runtimeValue(cloud, status)} detail={runtimeDetail(status, statusLoading)} state={runtimeState(status, statusLoading)}/>
+                    <InfoCard label="Adapter" value={adapterValue(cloud, status)} detail={adapterDetail(status, statusLoading)} state={adapterState(cloud, status)}/>
+                    <InfoCard label="Connection" value={connectionValue(status, statusLoading)} detail={status?.endpoint ?? 'No runtime endpoint'} state={runtimeState(status, statusLoading)}/>
+                    <InfoCard label="Normalized Contract" value={schema?.columns.length ? `${schema.columns.length} columns` : 'Loading schema'} detail="Shared table and resource inspector"/>
+                </div>
+                <div className="service-info-section">
+                    <p className="eyebrow">Supported Actions</p>
+                    <p className="service-info-copy">{capabilityLabels}</p>
+                </div>
+                <div className="service-info-section">
+                    <p className="eyebrow">Current Limitations</p>
+                    <p className="service-info-copy">{limitationCopy(cloud, service)}</p>
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function InfoCard({
+    label,
+    value,
+    detail,
+    state,
+}: {
+    label: string
+    value: string
+    detail: string
+    state?: 'ready' | 'pending' | 'unavailable'
+}) {
+    return (
+        <div className={`service-info-card ${state ?? ''}`}>
+            <span>{label}</span>
+            <strong>{value}</strong>
+            <small>{detail}</small>
         </div>
     )
 }
@@ -173,4 +270,19 @@ function connectionValue(status?: CloudStatus, loading?: boolean): string {
     if (status.runtime === 'reachable') return 'Connected'
     if (status.runtime === 'unavailable') return 'Not connected'
     return 'Coming soon'
+}
+
+function serviceLabel(service: CloudServiceType): string {
+    if (service === 'k8s') return 'k8s Engine'
+    if (service === 'serverless') return 'Serverless'
+    return service.charAt(0).toUpperCase() + service.slice(1)
+}
+
+function limitationCopy(cloud: CloudProvider, service: CloudServiceType): string {
+    if (cloud === 'aws' && service === 'storage') return 'Advanced S3 workflows such as bulk actions, version browsing, and richer object lifecycle controls still live outside the normalized surface.'
+    if (cloud === 'azure' && service === 'storage') return 'Blob Storage is wired through the normalized contract, but advanced metadata, tags, and access-policy workflows are still limited.'
+    if (cloud === 'azure' && service === 'database') return 'Cosmos DB uses a richer panel below for databases, containers, items, and SQL queries; a fully normalized database model is still evolving.'
+    if (cloud === 'aws' && service === 'compute') return 'Compute workflows still rely on AWS-specific forms for dependent infrastructure choices such as VPC, subnet, and security group.'
+    if (cloud === 'aws' && service === 'networking') return 'Networking uses AWS-specific operational panels because many actions require nested workflows instead of a flat generic form.'
+    return 'This service is available through the current adapter, but the normalized contract is still expanding.'
 }


### PR DESCRIPTION
Display detailed service status, capabilities, and limitations. Refactor runtime status strip for a more compact layout.

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [X] Frontend (`packages/frontend`)
- [X] API / Cloud Proxy (`packages/api`)
- [X] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

<!-- How did you verify this? Which cloud + service did you test against
     (e.g. AWS S3 via Floci core, Azure Blob via Floci-AZ)? -->
<!-- For UI changes, please attach before/after screenshots. -->

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [X] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [ ] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [X] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
