### PR TITLE
Feat/serverless azure functions adapter

### DIFF
--- a/packages/api/src/adapter-azure/AzureServerlessAdapter.ts
+++ b/packages/api/src/adapter-azure/AzureServerlessAdapter.ts
@@ -1,0 +1,33 @@
+import {azureServerlessSchema} from '../cloud-spi/serverlessSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+
+export class AzureServerlessAdapter implements CloudServiceAdapter {
+    readonly cloud = 'azure' as const
+    readonly service = 'serverless' as const
+
+    schema(): ServiceSchema {
+        return azureServerlessSchema()
+    }
+
+    async list(_query: ResourceQuery = {}): Promise<CloudResource[]> {
+        return []
+    }
+
+    async get(_id: string): Promise<CloudResource | null> {
+        return null
+    }
+
+    async create(_input: CreateResourceInput): Promise<CloudResource> {
+        throw new Error('Azure Functions adapter not implemented yet')
+    }
+
+    async delete(_id: string): Promise<void> {
+        throw new Error('Azure Functions adapter not implemented yet')
+    }
+}

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -8,6 +8,7 @@ import {AzureDatabaseAdapter} from './adapter-azure/AzureDatabaseAdapter'
 import {AzureStorageAdapter} from './adapter-azure/AzureStorageAdapter'
 import {GcpStorageAdapter} from './adapter-gcp/GcpStorageAdapter'
 import {CloudProxyService} from './service/CloudProxyService'
+import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
 
 export function createCloudProxyService(): CloudProxyService {
@@ -21,6 +22,7 @@ export function createCloudProxyService(): CloudProxyService {
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),
+        new AzureServerlessAdapter(),
     ])
 
     return new CloudProxyService(registry)


### PR DESCRIPTION
Summary

Adds the initial Azure Functions adapter scaffold for the Serverless category in Cloud Explorer.

Changes

* Added `AzureServerlessAdapter`
* Registered Azure Serverless support in `cloudProxy.ts`
* Reuses the existing Serverless schema and `CloudServiceAdapter` contract
* Establishes the foundation for Azure Functions integration

Validation

* Full repository type-check passes

Notes
This PR introduces the adapter scaffold only. Runtime-backed Azure Functions operations (list, inspect, create, delete, invoke) will be implemented in follow-up PRs once the Azure Functions runtime contract is finalized.
