### PR TITLE
fix: secret drawer right position change to -440px

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -2770,7 +2770,7 @@ button.console-service-card {
 .tag-drawer {
     position: fixed;
     top: 0;
-    right: -400px;
+    right: -440px;
     width: 360px;
     height: 100%;
     background: var(--surface);


### PR DESCRIPTION
## Summary
Fix SecretsDrawer right position.
Closes #59 
## Type of change

- [✔] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [✔] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/4c49a527-704b-4ef1-9e62-8f4ae315ab0e" />