### PR TITLE
feat: scope Cloud Explorer to a selectable AWS account

### DIFF
--- a/packages/api/src/adapter-aws/AwsDatabaseAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsDatabaseAdapter.ts
@@ -1,5 +1,5 @@
-import {ListTagsForResourceCommand} from '@aws-sdk/client-rds'
-import {rds} from '../aws'
+import {ListTagsForResourceCommand, type RDSClient} from '@aws-sdk/client-rds'
+import {rds as defaultRds} from '../aws'
 import {awsDatabaseSchema} from '../cloud-spi/databaseSchema'
 import type {
     CloudResource,
@@ -10,23 +10,30 @@ import type {
 } from '../cloud-spi/types'
 import {rdsService, type RdsInstance} from '../services/rds'
 
+type RdsServiceShape = Pick<typeof rdsService, 'listInstances' | 'describeInstance'>
+
 export class AwsDatabaseAdapter implements CloudServiceAdapter {
     readonly cloud = 'aws' as const
     readonly service = 'database' as const
+
+    constructor(
+        private readonly rdsService_: RdsServiceShape = rdsService,
+        private readonly rds: RDSClient = defaultRds,
+    ) {}
 
     schema(): ServiceSchema {
         return awsDatabaseSchema()
     }
 
     async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
-        const instances = await rdsService.listInstances()
-        const resources = await Promise.all(instances.map(toResource))
+        const instances = await this.rdsService_.listInstances()
+        const resources = await Promise.all(instances.map((instance) => this.toResource(instance)))
         return filterBySearch(resources, query.search)
     }
 
     async get(id: string): Promise<CloudResource | null> {
         try {
-            return toResource(await rdsService.describeInstance(id))
+            return await this.toResource(await this.rdsService_.describeInstance(id))
         } catch (error) {
             if (hasHttpStatus(error, 404)) return null
             throw error
@@ -40,12 +47,11 @@ export class AwsDatabaseAdapter implements CloudServiceAdapter {
     async delete(_id: string): Promise<void> {
         throw new Error('Database deletion is not supported from the dynamic Cloud Explorer.')
     }
-}
 
-async function toResource(instance: RdsInstance): Promise<CloudResource> {
-    const tags = instance.arn ? await getTags(instance.arn) : []
+    private async toResource(instance: RdsInstance): Promise<CloudResource> {
+        const tags = instance.arn ? await this.getTags(instance.arn) : []
 
-    return {
+        return {
         id: instance.identifier,
         name: instance.identifier,
         cloud: 'aws',
@@ -74,19 +80,20 @@ async function toResource(instance: RdsInstance): Promise<CloudResource> {
             subnetGroup: instance.subnetGroup,
             tags,
         },
+        }
     }
-}
 
-async function getTags(arn: string): Promise<Array<{key: string; value: string}>> {
-    try {
-        const res = await rds.send(new ListTagsForResourceCommand({ResourceName: arn}))
-        return (res.TagList ?? []).map((tag) => ({
-            key: tag.Key ?? '',
-            value: tag.Value ?? '',
-        }))
-    } catch (error) {
-        if (error instanceof Error && error.message.includes('ListTagsForResource is not supported')) return []
-        throw error
+    private async getTags(arn: string): Promise<Array<{key: string; value: string}>> {
+        try {
+            const res = await this.rds.send(new ListTagsForResourceCommand({ResourceName: arn}))
+            return (res.TagList ?? []).map((tag) => ({
+                key: tag.Key ?? '',
+                value: tag.Value ?? '',
+            }))
+        } catch (error) {
+            if (error instanceof Error && error.message.includes('ListTagsForResource is not supported')) return []
+            throw error
+        }
     }
 }
 

--- a/packages/api/src/adapter-aws/AwsEksAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsEksAdapter.ts
@@ -8,22 +8,26 @@ import type {
 } from '../cloud-spi/types'
 import {eksService, type EksCluster} from '../services/eks'
 
+type EksServiceShape = Pick<typeof eksService, 'listClusters' | 'describeCluster'>
+
 export class AwsEksAdapter implements CloudServiceAdapter {
     readonly cloud = 'aws' as const
     readonly service = 'k8s' as const
+
+    constructor(private readonly eks: EksServiceShape = eksService) {}
 
     schema(): ServiceSchema {
         return awsEksSchema()
     }
 
     async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
-        const clusters = await eksService.listClusters()
+        const clusters = await this.eks.listClusters()
         return filterBySearch(clusters.map(toResource), query.search)
     }
 
     async get(id: string): Promise<CloudResource | null> {
         try {
-            return toResource(await eksService.describeCluster(id))
+            return toResource(await this.eks.describeCluster(id))
         } catch (error) {
             if (hasHttpStatus(error, 404)) return null
             throw error

--- a/packages/api/src/adapter-aws/AwsServerlessAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsServerlessAdapter.ts
@@ -3,6 +3,7 @@ import {
   DeleteFunctionCommand,
   GetFunctionCommand,
   ListFunctionsCommand,
+  type LambdaClient,
 } from "@aws-sdk/client-lambda";
 import { awsServerlessSchema } from "../cloud-spi/serverlessSchema";
 import type {
@@ -12,18 +13,20 @@ import type {
   ResourceQuery,
   ServiceSchema,
 } from "../cloud-spi/types";
-import { lambda } from "../aws";
+import { lambda as defaultLambda } from "../aws";
 
 export class AwsServerlessAdapter implements CloudServiceAdapter {
   readonly cloud = "aws" as const;
   readonly service = "serverless" as const;
+
+  constructor(private readonly lambda: LambdaClient = defaultLambda) {}
 
   schema(): ServiceSchema {
     return awsServerlessSchema();
   }
 
   async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
-    const res = await lambda.send(new ListFunctionsCommand({}));
+    const res = await this.lambda.send(new ListFunctionsCommand({}));
     const resources: CloudResource[] = (res.Functions ?? []).map((fn) => ({
       id: fn.FunctionName ?? fn.FunctionArn ?? "",
       name: fn.FunctionName ?? "",
@@ -51,7 +54,7 @@ export class AwsServerlessAdapter implements CloudServiceAdapter {
 
   async get(id: string): Promise<CloudResource | null> {
     try {
-      const res = await lambda.send(
+      const res = await this.lambda.send(
         new GetFunctionCommand({ FunctionName: id }),
       );
       const config = res.Configuration;
@@ -120,7 +123,7 @@ exports.handler = async (event) => {
     if (!handler) throw new Error("handler is required");
     if (!role) throw new Error("role is required");
 
-    const res = await lambda.send(
+    const res = await this.lambda.send(
       new CreateFunctionCommand({
         FunctionName: functionName,
         Runtime: runtime as never,
@@ -162,7 +165,7 @@ exports.handler = async (event) => {
   }
 
   async delete(id: string): Promise<void> {
-    await lambda.send(new DeleteFunctionCommand({ FunctionName: id }));
+    await this.lambda.send(new DeleteFunctionCommand({ FunctionName: id }));
   }
 }
 

--- a/packages/api/src/adapter-aws/AwsStorageAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsStorageAdapter.ts
@@ -7,8 +7,9 @@ import {
     ListBucketsCommand,
     ListObjectsV2Command,
     PutObjectCommand,
+    type S3Client,
 } from '@aws-sdk/client-s3'
-import {s3} from '../aws'
+import {s3 as defaultS3} from '../aws'
 import {awsStorageSchema} from '../cloud-spi/storageSchema'
 import type {
     CloudResource,
@@ -24,12 +25,14 @@ export class AwsStorageAdapter implements CloudServiceAdapter {
     readonly cloud = 'aws' as const
     readonly service = 'storage' as const
 
+    constructor(private readonly s3: S3Client = defaultS3) {}
+
     schema(): ServiceSchema {
         return awsStorageSchema()
     }
 
     async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
-        const res = await s3.send(new ListBucketsCommand({}))
+        const res = await this.s3.send(new ListBucketsCommand({}))
         const resources = (res.Buckets ?? []).map((bucket): CloudResource => ({
             id: bucket.Name ?? '',
             name: bucket.Name ?? '',
@@ -59,7 +62,7 @@ export class AwsStorageAdapter implements CloudServiceAdapter {
             throw new Error('Use a valid S3 bucket name: 3-63 lowercase characters, numbers, dots, or hyphens.')
         }
 
-        await s3.send(new CreateBucketCommand({Bucket: bucketName}))
+        await this.s3.send(new CreateBucketCommand({Bucket: bucketName}))
         return {
             id: bucketName,
             name: bucketName,
@@ -76,11 +79,11 @@ export class AwsStorageAdapter implements CloudServiceAdapter {
     }
 
     async delete(id: string): Promise<void> {
-        await s3.send(new DeleteBucketCommand({Bucket: id}))
+        await this.s3.send(new DeleteBucketCommand({Bucket: id}))
     }
 
     async listObjects(resourceId: string, prefix = ''): Promise<StorageObjectList> {
-        const res = await s3.send(new ListObjectsV2Command({
+        const res = await this.s3.send(new ListObjectsV2Command({
             Bucket: resourceId,
             Prefix: prefix || undefined,
             Delimiter: '/',
@@ -124,11 +127,11 @@ export class AwsStorageAdapter implements CloudServiceAdapter {
     }
 
     async putObject(resourceId: string, key: string, body: Uint8Array, contentType: string): Promise<void> {
-        await s3.send(new PutObjectCommand({Bucket: resourceId, Key: key, Body: body, ContentType: contentType}))
+        await this.s3.send(new PutObjectCommand({Bucket: resourceId, Key: key, Body: body, ContentType: contentType}))
     }
 
     async getObject(resourceId: string, key: string): Promise<StorageObjectDownload> {
-        const res = await s3.send(new GetObjectCommand({Bucket: resourceId, Key: key}))
+        const res = await this.s3.send(new GetObjectCommand({Bucket: resourceId, Key: key}))
         return {
             body: res.Body as BodyInit,
             contentType: res.ContentType ?? 'application/octet-stream',
@@ -137,12 +140,12 @@ export class AwsStorageAdapter implements CloudServiceAdapter {
     }
 
     async deleteObject(resourceId: string, key: string): Promise<void> {
-        await s3.send(new DeleteObjectCommand({Bucket: resourceId, Key: key}))
+        await this.s3.send(new DeleteObjectCommand({Bucket: resourceId, Key: key}))
     }
 
     async copyObject(srcResourceId: string, srcKey: string, destKey: string, destResourceId?: string): Promise<void> {
         const destBucket = destResourceId ?? srcResourceId
-        await s3.send(new CopyObjectCommand({
+        await this.s3.send(new CopyObjectCommand({
             Bucket: destBucket,
             Key: destKey,
             CopySource: `${srcResourceId}/${srcKey}`,

--- a/packages/api/src/aws.ts
+++ b/packages/api/src/aws.ts
@@ -4,28 +4,84 @@ import { EKSClient } from "@aws-sdk/client-eks";
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { RDSClient } from "@aws-sdk/client-rds";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+
 const endpoint = process.env.FLOCI_ENDPOINT;
 const region = process.env.AWS_REGION || "us-east-1";
-const credentials = {
-  accessKeyId: process.env.AWS_ACCESS_KEY_ID || "test",
-  secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY || "test",
-};
-const base = {
-  region,
-  credentials,
-  ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+
+// Floci derives the AWS account from AWS_ACCESS_KEY_ID: a value that is exactly
+// 12 digits is used verbatim as the account id, and resources are isolated per
+// account. Any other key (e.g. "test", "AKIA...") falls back to
+// FLOCI_DEFAULT_ACCOUNT_ID (000000000000). We lean on that contract to scope the
+// console to an account: the access key *is* the account id and the secret can
+// be any non-empty string (Floci does not validate it).
+const DEFAULT_ACCOUNT_ID = process.env.FLOCI_DEFAULT_ACCOUNT_ID || "000000000000";
+const SECRET_ACCESS_KEY = process.env.AWS_SECRET_ACCESS_KEY || "floci";
+
+export function isAccountId(value: string | null | undefined): value is string {
+  return typeof value === "string" && /^\d{12}$/.test(value);
+}
+
+/** The account used when a request does not (validly) specify one. */
+export function defaultAccountId(): string {
+  const envKey = process.env.AWS_ACCESS_KEY_ID;
+  return isAccountId(envKey) ? envKey : DEFAULT_ACCOUNT_ID;
+}
+
+/** Normalize a caller-supplied account id, falling back to the default. */
+export function resolveAccountId(raw?: string | null): string {
+  return isAccountId(raw) ? raw : defaultAccountId();
+}
+
+export type AwsClients = {
+  s3: S3Client;
+  lambda: LambdaClient;
+  eks: EKSClient;
+  ec2: EC2Client;
+  rds: RDSClient;
+  secretsManager: SecretsManagerClient;
 };
 
-export const awsClients = {
-  s3: new S3Client({ ...base, forcePathStyle: true }),
-  lambda: new LambdaClient(base),
-  eks: new EKSClient(base),
-  ec2: new EC2Client(base),
-  rds: new RDSClient(base),
-  secretsManager: new SecretsManagerClient(base),
-} as const;
+export type AwsClientName = keyof AwsClients;
 
-export type AwsClientName = keyof typeof awsClients;
+const clientCache = new Map<string, AwsClients>();
+
+function buildClients(accountId: string): AwsClients {
+  const base = {
+    region,
+    credentials: { accessKeyId: accountId, secretAccessKey: SECRET_ACCESS_KEY },
+    ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+  };
+  return {
+    s3: new S3Client({ ...base, forcePathStyle: true }),
+    lambda: new LambdaClient(base),
+    eks: new EKSClient(base),
+    ec2: new EC2Client(base),
+    rds: new RDSClient(base),
+    secretsManager: new SecretsManagerClient(base),
+  };
+}
+
+/**
+ * Return the cached AWS SDK client set bound to a given account. Clients are
+ * cheap to build but each holds connection state, so we memoize one set per
+ * resolved account id.
+ */
+export function awsClientsForAccount(accountId?: string | null): AwsClients {
+  const id = resolveAccountId(accountId);
+  let clients = clientCache.get(id);
+  if (!clients) {
+    clients = buildClients(id);
+    clientCache.set(id, clients);
+  }
+  return clients;
+}
+
+// Default-account singletons, kept for surfaces that are not yet account-aware:
+// the dedicated EC2, EKS, RDS and Secrets Manager routes. These ignore the
+// x-floci-account-id header and always serve the default account, so they do not
+// follow the console's active account. The Cloud Explorer proxy resolves clients
+// per request via awsClientsForAccount() instead.
+export const awsClients = awsClientsForAccount(defaultAccountId());
 
 export const s3 = awsClients.s3;
 export const lambda = awsClients.lambda;

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -10,15 +10,28 @@ import {GcpStorageAdapter} from './adapter-gcp/GcpStorageAdapter'
 import {CloudProxyService} from './service/CloudProxyService'
 import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
+import {awsClientsForAccount, resolveAccountId} from './aws'
+import {createEc2Service} from './services/ec2'
+import {createEksService} from './services/eks'
+import {createRdsService} from './services/rds'
 
-export function createCloudProxyService(): CloudProxyService {
+/**
+ * Build a CloudProxyService whose AWS adapters are bound to a specific account.
+ * The account id drives the AWS SDK credentials (see aws.ts), so every AWS call
+ * the returned service makes is isolated to that account. Azure and GCP adapters
+ * use their own runtime auth model and are account-neutral.
+ */
+export function createCloudProxyService(accountId?: string | null): CloudProxyService {
+    const clients = awsClientsForAccount(accountId)
+    const ec2Service = createEc2Service(clients.ec2)
+
     const registry = new CloudAdapterRegistry([
-        new AwsStorageAdapter(),
-        new AwsEksAdapter(),
-        new AwsDatabaseAdapter(),
-        new AwsComputeAdapter(),
-        new AwsNetworkingAdapter(),
-        new AwsServerlessAdapter(),
+        new AwsStorageAdapter(clients.s3),
+        new AwsEksAdapter(createEksService(clients.eks)),
+        new AwsDatabaseAdapter(createRdsService(clients.rds), clients.rds),
+        new AwsComputeAdapter(ec2Service),
+        new AwsNetworkingAdapter(ec2Service),
+        new AwsServerlessAdapter(clients.lambda),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),
@@ -26,4 +39,17 @@ export function createCloudProxyService(): CloudProxyService {
     ])
 
     return new CloudProxyService(registry)
+}
+
+const serviceCache = new Map<string, CloudProxyService>()
+
+/** Return a cached account-scoped CloudProxyService, building it on first use. */
+export function serviceForAccount(accountId?: string | null): CloudProxyService {
+    const id = resolveAccountId(accountId)
+    let service = serviceCache.get(id)
+    if (!service) {
+        service = createCloudProxyService(id)
+        serviceCache.set(id, service)
+    }
+    return service
 }

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -1,24 +1,33 @@
 import {Hono} from 'hono'
 import type {Context} from 'hono'
 import type {CloudProvider, CloudServiceType} from '../cloud-spi/types'
-import {createCloudProxyService} from '../cloudProxy'
+import {serviceForAccount} from '../cloudProxy'
 import {CloudProxyService} from '../service/CloudProxyService'
 
-export function createCloudRoutes(service: CloudProxyService = createCloudProxyService()) {
+// Header (and query-param fallback for direct links such as object downloads)
+// used by the frontend to scope every request to an AWS account.
+export const ACCOUNT_HEADER = 'x-floci-account-id'
+
+export function createCloudRoutes(injectedService?: CloudProxyService) {
     const app = new Hono()
 
-    app.get('/', (c) => c.json(service.clouds()))
+    // Resolve the account-scoped service per request. An explicitly injected
+    // service (used by tests) always wins and ignores the account header.
+    const svc = (c: Context): CloudProxyService =>
+        injectedService ?? serviceForAccount(c.req.header(ACCOUNT_HEADER) ?? c.req.query('account'))
+
+    app.get('/', (c) => c.json(svc(c).clouds()))
 
     app.get('/:cloud/services', (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
-        return c.json(service.services(cloud))
+        return c.json(svc(c).services(cloud))
     })
 
     app.get('/:cloud/status', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
-        return c.json(await service.status(cloud))
+        return c.json(await svc(c).status(cloud))
     })
 
     app.get('/:cloud/services/:service/schema', (c) => {
@@ -26,7 +35,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         const serviceType = c.req.param('service') as CloudServiceType
         if (!isCloudProvider(cloud) || !isServiceType(serviceType)) return c.json({error: 'Unknown cloud or service'}, 404)
 
-        const schema = service.schema(cloud, serviceType)
+        const schema = svc(c).schema(cloud, serviceType)
         if (!schema) {
             return c.json({error: 'Schema not available'}, 404)
         }
@@ -40,7 +49,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud) || !isServiceType(serviceType)) return c.json({error: 'Unknown cloud or service'}, 404)
 
         return withRuntime(c, async () => {
-            const resources = await service.listResources(cloud, serviceType, {search: c.req.query('search')})
+            const resources = await svc(c).listResources(cloud, serviceType, {search: c.req.query('search')})
             return c.json(resources)
         })
     })
@@ -50,7 +59,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
 
         return withRuntime(c, async () => {
-            const containers = await service.listCosmosContainers(cloud, c.req.param('id'))
+            const containers = await svc(c).listCosmosContainers(cloud, c.req.param('id'))
             return c.json(containers)
         })
     })
@@ -61,7 +70,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
 
         return withRuntime(c, async () => {
             const values = await c.req.json<Record<string, unknown>>()
-            const container = await service.createCosmosContainer(cloud, c.req.param('id'), {values})
+            const container = await svc(c).createCosmosContainer(cloud, c.req.param('id'), {values})
             return c.json(container, 201)
         })
     })
@@ -71,7 +80,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
 
         return withRuntime(c, async () => {
-            await service.deleteCosmosContainer(cloud, c.req.param('id'), c.req.param('containerId'))
+            await svc(c).deleteCosmosContainer(cloud, c.req.param('id'), c.req.param('containerId'))
             return c.json({ok: true})
         })
     })
@@ -81,7 +90,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
 
         return withRuntime(c, async () => {
-            const items = await service.listCosmosItems(cloud, c.req.param('id'), c.req.param('containerId'))
+            const items = await svc(c).listCosmosItems(cloud, c.req.param('id'), c.req.param('containerId'))
             return c.json(items)
         })
     })
@@ -92,7 +101,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
 
         return withRuntime(c, async () => {
             const document = await c.req.json<Record<string, unknown>>()
-            const item = await service.upsertCosmosItem(cloud, c.req.param('id'), c.req.param('containerId'), document)
+            const item = await svc(c).upsertCosmosItem(cloud, c.req.param('id'), c.req.param('containerId'), document)
             return c.json(item, 201)
         })
     })
@@ -102,7 +111,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
 
         return withRuntime(c, async () => {
-            await service.deleteCosmosItem(cloud, c.req.param('id'), c.req.param('containerId'), c.req.param('itemId'), c.req.query('partitionKey') ?? null)
+            await svc(c).deleteCosmosItem(cloud, c.req.param('id'), c.req.param('containerId'), c.req.param('itemId'), c.req.query('partitionKey') ?? null)
             return c.json({ok: true})
         })
     })
@@ -113,7 +122,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
 
         return withRuntime(c, async () => {
             const body = await c.req.json<{query?: string}>()
-            const result = await service.queryCosmosItems(cloud, c.req.param('id'), c.req.param('containerId'), body.query ?? '')
+            const result = await svc(c).queryCosmosItems(cloud, c.req.param('id'), c.req.param('containerId'), body.query ?? '')
             return c.json(result)
         })
     })
@@ -124,7 +133,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud) || !isServiceType(serviceType)) return c.json({error: 'Unknown cloud or service'}, 404)
 
         return withRuntime(c, async () => {
-            const resource = await service.getResource(cloud, serviceType, c.req.param('id'))
+            const resource = await svc(c).getResource(cloud, serviceType, c.req.param('id'))
             if (!resource) return c.json({error: 'Resource not found'}, 404)
             return c.json(resource)
         })
@@ -136,7 +145,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud) || !isServiceType(serviceType)) return c.json({error: 'Unknown cloud or service'}, 404)
 
         return withRuntime(c, async () => {
-            const objects = await service.listObjects(cloud, serviceType, c.req.param('id'), c.req.query('prefix') ?? '')
+            const objects = await svc(c).listObjects(cloud, serviceType, c.req.param('id'), c.req.query('prefix') ?? '')
             return c.json(objects)
         })
     })
@@ -151,7 +160,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         const body = new Uint8Array(await c.req.arrayBuffer())
         const contentType = c.req.header('content-type') ?? 'application/octet-stream'
         return withRuntime(c, async () => {
-            await service.putObject(cloud, serviceType, c.req.param('id'), key, body, contentType)
+            await svc(c).putObject(cloud, serviceType, c.req.param('id'), key, body, contentType)
             return c.json({ok: true})
         })
     })
@@ -164,7 +173,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         const key = c.req.query('key') ?? ''
         if (!key) return c.json({error: 'Object key is required'}, 400)
         return withRuntime(c, async () => {
-            const object = await service.getObject(cloud, serviceType, c.req.param('id'), key)
+            const object = await svc(c).getObject(cloud, serviceType, c.req.param('id'), key)
             return new Response(object.body, {
                 headers: {
                     'content-type': object.contentType,
@@ -183,7 +192,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         const key = c.req.query('key') ?? ''
         if (!key) return c.json({error: 'Object key is required'}, 400)
         return withRuntime(c, async () => {
-            await service.deleteObject(cloud, serviceType, c.req.param('id'), key)
+            await svc(c).deleteObject(cloud, serviceType, c.req.param('id'), key)
             return c.json({ok: true})
         })
     })
@@ -197,7 +206,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!srcKey || !destKey) return c.json({error: 'srcKey and destKey are required'}, 400)
 
         return withRuntime(c, async () => {
-            await service.copyObject(cloud, serviceType, c.req.param('id'), srcKey, destKey, destResourceId)
+            await svc(c).copyObject(cloud, serviceType, c.req.param('id'), srcKey, destKey, destResourceId)
             return c.json({ok: true})
         })
     })
@@ -209,7 +218,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
 
         return withRuntime(c, async () => {
             const values = await c.req.json<Record<string, unknown>>()
-            const resource = await service.createResource(cloud, serviceType, {values})
+            const resource = await svc(c).createResource(cloud, serviceType, {values})
             return c.json(resource, 201)
         })
     })
@@ -220,7 +229,7 @@ export function createCloudRoutes(service: CloudProxyService = createCloudProxyS
         if (!isCloudProvider(cloud) || !isServiceType(serviceType)) return c.json({error: 'Unknown cloud or service'}, 404)
 
         return withRuntime(c, async () => {
-            await service.deleteResource(cloud, serviceType, c.req.param('id'))
+            await svc(c).deleteResource(cloud, serviceType, c.req.param('id'))
             return c.json({ok: true})
         })
     })

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -1,4 +1,5 @@
 import { EndpointRegistry, HttpClient } from "./HttpClient";
+import { ACCOUNT_HEADER, getAccountId } from "@/lib/accountStore";
 
 export class AuthenticationRequiredError extends Error {
   constructor() {
@@ -566,6 +567,15 @@ export function createApiClient(
     },
     endpointRegistry,
   );
+
+  // Account scope — every request carries the active AWS account so Floci can
+  // isolate resources per account (the API maps this header to its SDK creds).
+  client.addRequestInterceptor((url, init) => {
+    const headers = (init.headers ?? {}) as Record<string, string>;
+    headers[ACCOUNT_HEADER] = getAccountId();
+    init.headers = headers;
+    return { url, init };
+  });
 
   // Auth interceptor — attaches Bearer token if available
   if (getToken) {

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -8,6 +8,7 @@ import type {
 } from "@/types/cloud";
 import type { CloudResource, CosmosContainer, CosmosItem, CosmosQueryResult, StorageObjectList } from "@/types/resource";
 import type { ServiceSchema } from "@/types/schema";
+import { getAccountId } from "@/lib/accountStore";
 
 type CloudPathParams = Record<string, string>;
 
@@ -154,7 +155,11 @@ export function storageObjectDownloadUrl(
   const path = `/clouds/${encodeURIComponent(
     cloud,
   )}/services/storage/resources/${encodeURIComponent(resourceId)}/object`;
-  return `${API_BASE_URL}${path}?key=${encodeURIComponent(key)}`;
+  // This URL is opened directly by the browser (anchor/img), so it bypasses the
+  // request interceptor — pass the account as a query param the API also reads.
+  return `${API_BASE_URL}${path}?key=${encodeURIComponent(
+    key,
+  )}&account=${encodeURIComponent(getAccountId())}`;
 }
 
 export async function deleteStorageObject(

--- a/packages/frontend/src/components/AccountSwitcher.tsx
+++ b/packages/frontend/src/components/AccountSwitcher.tsx
@@ -1,0 +1,128 @@
+import {useEffect, useRef, useState} from 'react'
+import {useQueryClient} from '@tanstack/react-query'
+import {Check, ChevronDown, UserRound} from 'lucide-react'
+import {
+    DEFAULT_ACCOUNT_ID,
+    isAccountId,
+    setAccountId,
+    useAccountId,
+    useAccountRecents,
+} from '@/lib/accountStore'
+
+function formatAccount(id: string): string {
+    // 000000000000 -> 0000-0000-0000, matching how AWS groups account ids.
+    return id.replace(/(\d{4})(\d{4})(\d{4})/, '$1-$2-$3')
+}
+
+export function AccountSwitcher() {
+    const accountId = useAccountId()
+    const recents = useAccountRecents()
+    const queryClient = useQueryClient()
+    const [open, setOpen] = useState(false)
+    const [draft, setDraft] = useState('')
+    const [error, setError] = useState<string | null>(null)
+    const containerRef = useRef<HTMLDivElement>(null)
+
+    useEffect(() => {
+        if (!open) return
+        const onClick = (event: MouseEvent) => {
+            if (!containerRef.current?.contains(event.target as Node)) setOpen(false)
+        }
+        const onKey = (event: KeyboardEvent) => {
+            if (event.key === 'Escape') setOpen(false)
+        }
+        document.addEventListener('mousedown', onClick)
+        document.addEventListener('keydown', onKey)
+        return () => {
+            document.removeEventListener('mousedown', onClick)
+            document.removeEventListener('keydown', onKey)
+        }
+    }, [open])
+
+    function applyAccount(id: string) {
+        if (!setAccountId(id)) {
+            setError('Account id must be exactly 12 digits.')
+            return
+        }
+        setDraft('')
+        setError(null)
+        setOpen(false)
+        // Resources are account-scoped, so anything cached under the previous
+        // account must not leak into the new view.
+        void queryClient.invalidateQueries()
+    }
+
+    function submitDraft() {
+        const trimmed = draft.trim()
+        if (!isAccountId(trimmed)) {
+            setError('Account id must be exactly 12 digits.')
+            return
+        }
+        applyAccount(trimmed)
+    }
+
+    return (
+        <div className="account-switcher" ref={containerRef}>
+            <button
+                type="button"
+                className="account-trigger"
+                onClick={() => setOpen((v) => !v)}
+                title="Switch AWS account"
+                aria-haspopup="listbox"
+                aria-expanded={open}
+            >
+                <UserRound size={14}/>
+                <span className="account-meta">
+                    <span className="account-label">Account</span>
+                    <span className="account-value">{formatAccount(accountId)}</span>
+                </span>
+                <ChevronDown size={14}/>
+            </button>
+
+            {open && (
+                <div className="account-popover" role="listbox">
+                    <div className="account-popover-title">Switch account</div>
+                    <div className="account-recents">
+                        {recents.map((id) => (
+                            <button
+                                key={id}
+                                type="button"
+                                className={`account-option${id === accountId ? ' active' : ''}`}
+                                role="option"
+                                aria-selected={id === accountId}
+                                onClick={() => applyAccount(id)}
+                            >
+                                <span className="account-option-id">{formatAccount(id)}</span>
+                                {id === DEFAULT_ACCOUNT_ID && <span className="account-tag">default</span>}
+                                {id === accountId && <Check size={13}/>}
+                            </button>
+                        ))}
+                    </div>
+                    <form
+                        className="account-entry"
+                        onSubmit={(event) => {
+                            event.preventDefault()
+                            submitDraft()
+                        }}
+                    >
+                        <input
+                            value={draft}
+                            inputMode="numeric"
+                            maxLength={12}
+                            placeholder="12-digit account id"
+                            aria-label="New account id"
+                            onChange={(event) => {
+                                setDraft(event.target.value.replace(/\D/g, ''))
+                                setError(null)
+                            }}
+                        />
+                        <button type="submit" disabled={!isAccountId(draft.trim())}>
+                            Switch
+                        </button>
+                    </form>
+                    {error && <div className="account-error">{error}</div>}
+                </div>
+            )}
+        </div>
+    )
+}

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -18,6 +18,7 @@ import flociBlack from '@/assets/floci-black.svg'
 import {useTheme} from '@/lib/useTheme'
 import {useQuery} from '@tanstack/react-query'
 import {getCloudStatus} from '@/api/cloudProxyClient'
+import {AccountSwitcher} from '@/components/AccountSwitcher'
 
 function NavItem({to, icon, label}: { to: string; icon: React.ElementType; label: string }) {
     const Icon = icon
@@ -129,6 +130,7 @@ export function Layout() {
                     <button className="icon-btn" onClick={toggle} title="Toggle theme">
                         {theme === 'dark' ? <Sun size={14}/> : <Moon size={14}/>}
                     </button>
+                    <AccountSwitcher/>
                     <div className={`connection ${isConnected ? 'connected' : 'disconnected'}`}>
                         <span className={`dot ${status}`}/>
                         <span className="connection-state">{connectionLabel}</span>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -332,7 +332,6 @@ pre,
 }
 
 .connection {
-    margin-left: auto;
     display: inline-flex;
     align-items: center;
     gap: 7px;
@@ -366,6 +365,159 @@ pre,
     color: var(--text-2);
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+.account-switcher {
+    position: relative;
+    margin-left: auto;
+}
+
+.account-trigger {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 30px;
+    padding: 0 8px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--connection-bg);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.account-trigger:hover {
+    border-color: var(--text-2);
+}
+
+.account-meta {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.15;
+}
+
+.account-label {
+    font-size: 9px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-2);
+}
+
+.account-value {
+    font-variant-numeric: tabular-nums;
+    font-weight: 600;
+}
+
+.account-popover {
+    position: absolute;
+    top: calc(100% + 6px);
+    right: 0;
+    width: 248px;
+    padding: 8px;
+    border: 1px solid var(--border);
+    border-radius: 6px;
+    background: var(--surface);
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.25);
+    z-index: 30;
+}
+
+.account-popover-title {
+    font-size: 10px;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    padding: 2px 4px 6px;
+}
+
+.account-recents {
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.account-option {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    width: 100%;
+    padding: 6px 8px;
+    border: 0;
+    border-radius: 4px;
+    background: transparent;
+    color: var(--text);
+    cursor: pointer;
+    font-size: 12px;
+    text-align: left;
+}
+
+.account-option:hover {
+    background: var(--input-bg);
+}
+
+.account-option.active {
+    background: var(--input-bg);
+}
+
+.account-option-id {
+    font-variant-numeric: tabular-nums;
+    flex: 1;
+}
+
+.account-tag {
+    font-size: 9px;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text-2);
+    border: 1px solid var(--border);
+    border-radius: 3px;
+    padding: 1px 4px;
+}
+
+.account-entry {
+    display: flex;
+    gap: 6px;
+    margin-top: 8px;
+    padding-top: 8px;
+    border-top: 1px solid var(--border);
+}
+
+.account-entry input {
+    flex: 1;
+    min-width: 0;
+    height: 28px;
+    padding: 0 8px;
+    border: 1px solid var(--input-border);
+    border-radius: 4px;
+    background: var(--input-bg);
+    color: var(--text);
+    font-size: 12px;
+    font-variant-numeric: tabular-nums;
+    outline: none;
+}
+
+.account-entry button {
+    height: 28px;
+    padding: 0 10px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: var(--connection-bg);
+    color: var(--text);
+    cursor: pointer;
+    font-size: 12px;
+}
+
+.account-entry button:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+}
+
+.account-error {
+    margin-top: 6px;
+    color: #ef4444;
+    font-size: 11px;
 }
 
 .dot {

--- a/packages/frontend/src/lib/accountStore.ts
+++ b/packages/frontend/src/lib/accountStore.ts
@@ -1,0 +1,102 @@
+import {useSyncExternalStore} from 'react'
+
+// Floci isolates resources per AWS account, and selects the account from the
+// 12-digit access key it is given (see the API's aws.ts). The console mirrors
+// that: a single active account at a time, sent on every request via the
+// `x-floci-account-id` header. This is a context switch, not a filter — accounts
+// do not overlap in Floci.
+
+export const DEFAULT_ACCOUNT_ID = '000000000000'
+/** Request header the API reads to scope a request to an account. */
+export const ACCOUNT_HEADER = 'x-floci-account-id'
+const ACCOUNT_KEY = 'floci.accountId'
+const RECENTS_KEY = 'floci.accountId.recents'
+const MAX_RECENTS = 8
+
+export function isAccountId(value: string | null | undefined): value is string {
+    return typeof value === 'string' && /^\d{12}$/.test(value)
+}
+
+function readAccount(): string {
+    try {
+        const stored = localStorage.getItem(ACCOUNT_KEY)
+        if (isAccountId(stored)) return stored
+    } catch {
+        // localStorage unavailable (private mode / SSR) — fall back to default.
+    }
+    return DEFAULT_ACCOUNT_ID
+}
+
+function readRecents(): string[] {
+    try {
+        const raw = localStorage.getItem(RECENTS_KEY)
+        if (raw) {
+            const parsed = JSON.parse(raw)
+            if (Array.isArray(parsed)) return parsed.filter(isAccountId).slice(0, MAX_RECENTS)
+        }
+    } catch {
+        // ignore malformed storage
+    }
+    return [DEFAULT_ACCOUNT_ID]
+}
+
+let currentAccount = readAccount()
+let recents = readRecents()
+if (!recents.includes(currentAccount)) recents = [currentAccount, ...recents].slice(0, MAX_RECENTS)
+
+const listeners = new Set<() => void>()
+
+function persist(): void {
+    try {
+        localStorage.setItem(ACCOUNT_KEY, currentAccount)
+        localStorage.setItem(RECENTS_KEY, JSON.stringify(recents))
+    } catch {
+        // ignore persistence failures
+    }
+}
+
+function emit(): void {
+    for (const listener of listeners) listener()
+}
+
+/** Current account id — read synchronously by the API request interceptor. */
+export function getAccountId(): string {
+    return currentAccount
+}
+
+export function getRecents(): string[] {
+    return recents
+}
+
+/**
+ * Switch the active account. Returns false for invalid ids (not 12 digits).
+ * The reference of getRecents()/getAccountId() only changes when something
+ * actually changed, keeping useSyncExternalStore snapshots stable.
+ */
+export function setAccountId(id: string): boolean {
+    if (!isAccountId(id)) return false
+    const sameAccount = id === currentAccount
+    const alreadyTop = recents[0] === id
+    if (sameAccount && alreadyTop) return true
+
+    currentAccount = id
+    recents = [id, ...recents.filter((r) => r !== id)].slice(0, MAX_RECENTS)
+    persist()
+    emit()
+    return true
+}
+
+function subscribe(listener: () => void): () => void {
+    listeners.add(listener)
+    return () => {
+        listeners.delete(listener)
+    }
+}
+
+export function useAccountId(): string {
+    return useSyncExternalStore(subscribe, getAccountId, getAccountId)
+}
+
+export function useAccountRecents(): string[] {
+    return useSyncExternalStore(subscribe, getRecents, getRecents)
+}


### PR DESCRIPTION
## Summary

Scopes the Cloud Explorer to a selectable AWS account so every request is isolated to the account chosen in the console. The frontend sends the active account via an `x-floci-account-id` header (with a query-param fallback for direct object downloads) and adds an account switcher that remembers recent accounts, while the API threads per-account AWS SDK clients through the Cloud Proxy by injecting clients/services into the AWS adapters and memoizing them per account. The dedicated EC2/EKS/RDS/Secrets Manager routes remain on the default account (documented in `aws.ts`).

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [x] API / Cloud Proxy (`packages/api`)
- [x] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

Not yet verified in the running app — please switch accounts in the Cloud Explorer against Floci core (e.g. AWS S3) to confirm resources isolate per account and direct object downloads carry the account. `pnpm type-check`, `pnpm test` (137/137), and `pnpm build` pass locally.

## Checklist

- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally — type-check, test, and build pass; `pnpm lint` has pre-existing failures in `NetworkingPanel.tsx` and `SgRuleTable.tsx` (untouched by this PR, present on `main`). No lint issues in the files this PR changes.
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
