### PR TITLE
feat(serverless): add azure functions invoke support

### DIFF
--- a/packages/api/src/adapter-azure/AzureServerlessAdapter.ts
+++ b/packages/api/src/adapter-azure/AzureServerlessAdapter.ts
@@ -5,6 +5,7 @@ import type {
     CloudServiceAdapter,
     CreateResourceInput,
     ResourceQuery,
+    ServerlessInvokeResult,
     ServiceSchema,
 } from '../cloud-spi/types'
 
@@ -98,7 +99,35 @@ export class AzureServerlessAdapter implements CloudServiceAdapter {
             {emptyOnNotFound: true},
         )
     }
+    async invoke(id: string, payload: string): Promise<ServerlessInvokeResult> {
+        const startedAt = performance.now()
 
+        const body = await this.azureJson<{
+            statusCode?: number
+            payload?: unknown
+            body?: unknown
+            error?: string
+            functionError?: string
+            logResult?: string
+        }>(
+            `/functions/${encodeURIComponent(id)}/invoke`,
+            {
+                method: 'POST',
+                body: JSON.stringify({
+                    payload: payload?.trim() ? payload : '{}',
+                }),
+            },
+        )
+
+        return {
+            statusCode: body?.statusCode ?? 200,
+            payload: stringifyPayload(body?.payload ?? body?.body ?? ''),
+            functionError: body?.functionError ?? body?.error,
+            logResult: body?.logResult,
+            executionDuration: Math.round(performance.now() - startedAt),
+        }
+    }
+    
     private async azureJson<T>(
         path: string,
         init: RequestInit,
@@ -152,6 +181,12 @@ function toFunctionResource(record: AzureFunctionRecord): CloudResource {
 
 function stringValue(value: unknown): string {
     return typeof value === 'string' ? value.trim() : ''
+}
+
+function stringifyPayload(value: unknown): string {
+    if (typeof value === 'string') return value
+    if (value === undefined || value === null) return ''
+    return JSON.stringify(value)
 }
 
 function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -144,7 +144,13 @@ export interface ResourceQuery {
 export interface CreateResourceInput {
     values: Record<string, unknown>
 }
-
+export interface ServerlessInvokeResult {
+    statusCode: number
+    payload: string
+    functionError?: string
+    logResult?: string
+    executionDuration?: number
+}
 export interface CloudServiceAdapter {
     readonly cloud: CloudProvider
     readonly service: CloudServiceType
@@ -157,6 +163,7 @@ export interface CloudServiceAdapter {
     putObject?(resourceId: string, key: string, body: Uint8Array, contentType: string): Promise<void>
     getObject?(resourceId: string, key: string): Promise<StorageObjectDownload>
     deleteObject?(resourceId: string, key: string): Promise<void>
+    invoke?(id: string, payload: string): Promise<ServerlessInvokeResult>
     copyObject?(srcResourceId: string, srcKey: string, destKey: string, destResourceId?: string): Promise<void>
     listCosmosContainers?(databaseId: string): Promise<CosmosContainer[]>
     createCosmosContainer?(databaseId: string, input: CreateResourceInput): Promise<CosmosContainer>

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -211,6 +211,25 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         })
     })
 
+    app.post('/:cloud/services/:service/resources/:id/invoke', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        const serviceType = c.req.param('service') as CloudServiceType
+        if (!isCloudProvider(cloud) || !isServiceType(serviceType)) {
+            return c.json({error: 'Unknown cloud or service'}, 404)
+        }
+
+        return withRuntime(c, async () => {
+            const body: {payload?: string} = await c.req.json<{payload?: string}>().catch(() => ({}))
+            const result = await svc(c).invokeResource(
+                cloud,
+                serviceType,
+                c.req.param('id'),
+                body.payload ?? '{}',
+            )
+            return c.json(result)
+        })
+    })
+
     app.post('/:cloud/services/:service/resources', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         const serviceType = c.req.param('service') as CloudServiceType

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -10,6 +10,7 @@ import type {
     CosmosQueryResult,
     CreateResourceInput,
     ResourceQuery,
+    ServerlessInvokeResult,
     ServiceSchema,
     StorageObjectDownload,
     StorageObjectList,
@@ -158,7 +159,16 @@ export class CloudProxyService {
     async deleteResource(cloud: CloudProvider, service: CloudServiceType, id: string): Promise<void> {
         await this.requireAdapter(cloud, service).delete(id)
     }
-
+async invokeResource(
+    cloud: CloudProvider,
+    service: CloudServiceType,
+    id: string,
+    payload: string,
+): Promise<ServerlessInvokeResult> {
+    const adapter = this.requireAdapter(cloud, service)
+    if (!adapter.invoke) throw new Error(`${cloud}/${service} invoke is not supported`)
+    return adapter.invoke(id, payload)
+}
     async listObjects(cloud: CloudProvider, service: CloudServiceType, resourceId: string, prefix?: string): Promise<StorageObjectList> {
         const adapter = this.requireAdapter(cloud, service)
         if (!adapter.listObjects) throw new Error(`Object listing is not supported for ${cloud}/${service}`)

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -19,6 +19,7 @@ export const apiEndpointKeys = {
       get: "clouds.services.resources.get",
       create: "clouds.services.resources.create",
       delete: "clouds.services.resources.delete",
+      invoke: "clouds.services.resources.invoke",
     },
     storage: {
       objects: {
@@ -209,6 +210,14 @@ export const endpointRegistry: EndpointRegistry = new Map([
       telemetry: { service: "cloud-proxy" },
     },
   ],
+  [
+  apiEndpointKeys.clouds.resources.invoke,
+  {
+    path: "/clouds/:cloud/services/:service/resources/:id/invoke",
+    method: "POST",
+    telemetry: { service: "cloud-proxy" },
+  },
+],
   [
     apiEndpointKeys.clouds.resources.get,
     {

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -114,6 +114,29 @@ export async function deleteCloudResource(
   );
 }
 
+export interface ServerlessInvokeResult {
+  statusCode: number;
+  payload: string;
+  functionError?: string;
+  logResult?: string;
+  executionDuration?: number;
+}
+
+export async function invokeCloudResource(
+  cloud: CloudProvider,
+  service: CloudServiceType,
+  id: string,
+  payload: string,
+  signal?: AbortSignal,
+): Promise<ServerlessInvokeResult> {
+  const res = await apiClient.call<ServerlessInvokeResult, { payload: string }>(
+    apiEndpointKeys.clouds.resources.invoke,
+    requestOptions(cloud, service, { signal, body: { payload } }),
+    { cloud, service, id },
+  );
+  return res.data;
+}
+
 export async function listStorageObjects(
   cloud: CloudProvider,
   resourceId: string,
@@ -232,6 +255,8 @@ export async function deleteCosmosContainer(
     { ...databasePathParams(cloud, databaseId), containerId },
   );
 }
+
+
 
 export async function listCosmosItems(
   cloud: CloudProvider,


### PR DESCRIPTION
# Summary
Adds Azure Functions invoke support to the Serverless Cloud Explorer workflow.

# Changes
* Added `ServerlessInvokeResult` contract for serverless execution responses
* Added `invoke()` capability to the serverless adapter interface
* Implemented Azure Functions invocation in `AzureServerlessAdapter`
* Added Cloud Proxy service support for invoking serverless resources
* Added Cloud Explorer API route for serverless invoke operations
* Added frontend client support for invoke requests and responses

# Result
Azure Functions can now be invoked through the Cloud Explorer serverless abstraction, bringing Azure serverless capabilities closer to feature parity with AWS Lambda.

# Validation
* `pnpm type-check` passes
* Azure Functions list support already available
* Azure Functions inspect support already available
* Azure Functions create/delete support already available
* Azure Functions invoke support added in this PR

# Next Steps
* Add Azure Functions invoke UI in Cloud Explorer
* Improve Azure Functions validation and error handling
* Add GCP Cloud Functions serverless adapter support
