### PR TITLE
feat(serverless): add azure functions invoke ui

### DIFF
--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -19,6 +19,7 @@ export const apiEndpointKeys = {
       get: "clouds.services.resources.get",
       create: "clouds.services.resources.create",
       delete: "clouds.services.resources.delete",
+      invoke: "clouds.services.resources.invoke",
     },
     storage: {
       objects: {
@@ -233,6 +234,16 @@ export const endpointRegistry: EndpointRegistry = new Map([
       telemetry: { service: "cloud-proxy" },
     },
   ],
+
+[
+  apiEndpointKeys.clouds.resources.invoke,
+  {
+    path: "/clouds/:cloud/services/:service/resources/:id/invoke",
+    method: "POST",
+    telemetry: { service: "cloud-proxy" },
+  },
+],
+
   [
     apiEndpointKeys.clouds.storage.objects.list,
     {

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -113,6 +113,28 @@ export async function deleteCloudResource(
     { cloud, service, id },
   );
 }
+export interface ServerlessInvokeResult {
+  statusCode: number;
+  payload: string;
+  functionError?: string;
+  logResult?: string;
+  executionDuration?: number;
+}
+
+export async function invokeCloudResource(
+  cloud: CloudProvider,
+  service: CloudServiceType,
+  id: string,
+  payload: string,
+  signal?: AbortSignal,
+): Promise<ServerlessInvokeResult> {
+  const res = await apiClient.call<ServerlessInvokeResult, { payload: string }>(
+    apiEndpointKeys.clouds.resources.invoke,
+    requestOptions(cloud, service, { signal, body: { payload } }),
+    { cloud, service, id },
+  );
+  return res.data;
+}
 
 export async function listStorageObjects(
   cloud: CloudProvider,

--- a/packages/frontend/src/components/DynamicResourceView.tsx
+++ b/packages/frontend/src/components/DynamicResourceView.tsx
@@ -42,6 +42,7 @@ import type {
   ServiceSchema,
 } from "@/types/schema";
 import { CosmosNoSqlPanel } from "@/components/CosmosNoSqlPanel";
+import { ServerlessInvokePanel } from "@/components/ServerlessInvokePanel";
 
 interface DynamicResourceViewProps {
   cloud: CloudProvider;
@@ -409,6 +410,13 @@ export function DynamicResourceView({
           runtimeReachable={canUseRuntime}
         />
       )}
+      {service === "serverless" && (
+  <ServerlessInvokePanel
+    cloud={cloud}
+    resource={activeSelected}
+    runtimeReachable={canUseRuntime}
+  />
+)}
     </div>
   );
 }

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -69,7 +69,8 @@ function CloudServiceNav() {
                 const available = service.name === 'storage'
                     || (service.name === 'secretsmanager' && cloud === 'aws')
                     || (service.name === 'database' && (cloud === 'aws' || cloud === 'azure'))
-                    || ((service.name === 'k8s' || service.name === 'compute' || service.name === 'networking' || service.name === 'serverless') && cloud === 'aws')
+                    || ((service.name === 'k8s' || service.name === 'compute' || service.name === 'networking') && cloud === 'aws')
+                    || (service.name === 'serverless' && (cloud === 'aws' || cloud === 'azure'))
                 if (service.route && available) {
                     const target = service.route.startsWith('/') ? service.route : `/cloud-explorer/${cloud}/${service.route}`
                     return <NavItem key={service.name} to={target} icon={Icon} label={service.label}/>

--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -1,0 +1,177 @@
+import {useEffect, useState} from "react";
+import {ChevronDown, ChevronUp, Copy, Loader2, Play, Zap} from "lucide-react";
+import {useMutation} from "@tanstack/react-query";
+import {invokeCloudResource} from "@/api/cloudProxyClient";
+import type {ServerlessInvokeResult} from "@/api/cloudProxyClient";
+import type {CloudProvider} from "@/types/cloud";
+import type {CloudResource} from "@/types/resource";
+
+interface ServerlessInvokePanelProps {
+  cloud: CloudProvider;
+  resource?: CloudResource;
+  runtimeReachable: boolean;
+}
+
+export function ServerlessInvokePanel({
+  cloud,
+  resource,
+  runtimeReachable,
+}: ServerlessInvokePanelProps) {
+  const [payload, setPayload] = useState("{\n  \n}");
+  const [invokeResult, setInvokeResult] = useState<ServerlessInvokeResult | null>(null);
+  const [showLog, setShowLog] = useState(false);
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    setPayload("{\n  \n}");
+    setInvokeResult(null);
+    setShowLog(false);
+    setCopied(false);
+  }, [resource?.id]);
+
+  const isSupportedResource =
+    resource?.service === "serverless" &&
+    (resource.type === "lambda" || resource.type === "azure-function");
+
+  const canInvoke = Boolean(resource && isSupportedResource && runtimeReachable);
+
+  const providerLabel = cloud === "azure" ? "Azure Function" : "Lambda function";
+
+  const invokeMutation = useMutation({
+    mutationFn: () =>
+      invokeCloudResource(cloud, "serverless", resource!.id, payload),
+    onSuccess: (result) => {
+      setInvokeResult(result);
+      setShowLog(false);
+      setCopied(false);
+    },
+  });
+
+  const isInvokeError = Boolean(
+    invokeResult?.functionError || (invokeResult && invokeResult.statusCode >= 400),
+  );
+
+  const copyResponse = async () => {
+    if (!invokeResult) return;
+    await navigator.clipboard.writeText(invokeResult.payload || "");
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 1200);
+  };
+
+  if (!resource || resource.service !== "serverless") {
+    return (
+      <section className="table-panel">
+        <div className="empty compact">
+          <h3>Select a serverless function</h3>
+          <p>Select a Lambda function or Azure Function to invoke it from Cloud Explorer.</p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="table-panel">
+      <div className="dynamic-stage-header">
+        <div>
+          <p className="eyebrow">Serverless Actions</p>
+          <h3>
+            <Zap size={15} />
+            Invoke {providerLabel}
+          </h3>
+          <p className="muted compact-text">
+            Send a JSON event payload to the selected serverless function.
+          </p>
+        </div>
+        <span className={`runtime-state ${canInvoke ? "ready" : "pending"}`}>
+          {canInvoke ? "Ready" : "Runtime unavailable"}
+        </span>
+      </div>
+
+      <div className="resource-create-inline">
+        <label>
+          <span className="metric-label">Event payload JSON</span>
+          <textarea
+            className="json-editor"
+            value={payload}
+            onChange={(event) => setPayload(event.target.value)}
+            spellCheck={false}
+            placeholder="{}"
+            style={{minHeight: 140}}
+          />
+        </label>
+
+        <button
+          className="button primary"
+          type="button"
+          disabled={!canInvoke || invokeMutation.isPending}
+          onClick={() => invokeMutation.mutate()}
+        >
+          {invokeMutation.isPending ? <Loader2 size={13} /> : <Play size={13} />}
+          {invokeMutation.isPending ? "Invoking" : "Invoke"}
+        </button>
+
+        {invokeMutation.isError && (
+          <p className="error-text compact-text">
+            {invokeMutation.error instanceof Error
+              ? invokeMutation.error.message
+              : "Invocation failed"}
+          </p>
+        )}
+
+        {invokeResult && (
+          <div className="inspector-section">
+            <div className="inspector-section-header">
+              <p className="metric-label">Invocation Result</p>
+              <span className={`runtime-state ${isInvokeError ? "unavailable" : "ready"}`}>
+                HTTP {invokeResult.statusCode}
+              </span>
+            </div>
+
+            {invokeResult.executionDuration !== undefined && (
+              <p className="muted compact-text">
+                Completed in {invokeResult.executionDuration}ms
+              </p>
+            )}
+
+            {invokeResult.functionError && (
+              <p className="error-text compact-text">
+                {invokeResult.functionError}
+              </p>
+            )}
+
+            <button className="button" type="button" onClick={copyResponse}>
+              <Copy size={13} />
+              {copied ? "Copied" : "Copy response"}
+            </button>
+
+            <pre className={`invoke-result ${isInvokeError ? "error" : "success"}`}>
+              {tryFormatJson(invokeResult.payload) || "(empty)"}
+            </pre>
+
+            {invokeResult.logResult && (
+              <div>
+                <button
+                  className="button"
+                  type="button"
+                  onClick={() => setShowLog((open) => !open)}
+                >
+                  Log tail
+                  {showLog ? <ChevronUp size={13} /> : <ChevronDown size={13} />}
+                </button>
+                {showLog && <div className="log-tail">{invokeResult.logResult}</div>}
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function tryFormatJson(raw: string): string {
+  try {
+    return JSON.stringify(JSON.parse(raw), null, 2);
+  } catch {
+    return raw;
+  }
+}

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function";
     region: string | null
     createdAt: string | null
     status?: string | null


### PR DESCRIPTION
Summary
Adds an invocation UI for Azure Functions within Cloud Explorer, allowing users to execute serverless functions directly from the frontend.
What's Included
Added a reusable ServerlessInvokePanel component.
Added Azure Functions invoke support to the Cloud Proxy client.
Registered the serverless invoke API endpoint.
Integrated the invoke panel into DynamicResourceView.
Extended frontend resource types to support Azure Functions.
Updated navigation to expose the Serverless experience for Azure.


User Experience
Users can now:
Select an Azure Function from Cloud Explorer.
Provide a JSON payload.
Invoke the function directly from the UI.
View the returned payload.
View execution duration.
Copy the response.
Inspect invocation logs when available.

Notes
This PR builds on the existing Azure Functions adapter and backend invoke support, completing the frontend invocation workflow for Azure serverless resources.