### PR TITLE
feat(serverless): add google cloud functions adapter

### DIFF
--- a/packages/api/src/adapter-gcp/GcpServerlessAdapter.ts
+++ b/packages/api/src/adapter-gcp/GcpServerlessAdapter.ts
@@ -1,0 +1,159 @@
+import {gcpServerlessSchema} from '../cloud-spi/serverlessSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+import {gcpEndpoint, gcpProject} from '../gcp'
+
+interface GcpFunctionRecord {
+    name?: string
+    id?: string
+    description?: string
+    status?: string
+    state?: string
+    region?: string
+    location?: string
+    runtime?: string
+    entryPoint?: string
+    updateTime?: string
+    createTime?: string
+    serviceConfig?: {
+        uri?: string
+        service?: string
+        availableMemory?: string
+        timeoutSeconds?: number
+        environmentVariables?: Record<string, string>
+    }
+    buildConfig?: {
+        runtime?: string
+        entryPoint?: string
+        source?: Record<string, unknown>
+    }
+    labels?: Record<string, string>
+}
+
+interface GcpFunctionListResponse {
+    functions?: GcpFunctionRecord[]
+    value?: GcpFunctionRecord[]
+    resources?: GcpFunctionRecord[]
+}
+
+export class GcpServerlessAdapter implements CloudServiceAdapter {
+    readonly cloud = 'gcp' as const
+    readonly service = 'serverless' as const
+
+    constructor(
+        private readonly endpoint: string = gcpEndpoint(),
+        private readonly project: string = gcpProject(),
+    ) {}
+
+    schema(): ServiceSchema {
+        return gcpServerlessSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const body = await this.gcpJson<GcpFunctionListResponse | GcpFunctionRecord[]>(
+            `/projects/${encodeURIComponent(this.project)}/functions`,
+            {method: 'GET'},
+        )
+
+        const records = Array.isArray(body)
+            ? body
+            : body?.functions ?? body?.value ?? body?.resources ?? []
+
+        return filterBySearch(records.map(toFunctionResource), query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        const body = await this.gcpJson<GcpFunctionRecord | null>(
+            `/projects/${encodeURIComponent(this.project)}/functions/${encodeURIComponent(id)}`,
+            {method: 'GET'},
+            {emptyOnNotFound: true},
+        )
+
+        return body ? toFunctionResource(body) : null
+    }
+
+    async create(_input: CreateResourceInput): Promise<CloudResource> {
+        throw new Error('GCP Cloud Functions create is not supported yet')
+    }
+
+    async delete(_id: string): Promise<void> {
+        throw new Error('GCP Cloud Functions delete is not supported yet')
+    }
+
+    private async gcpJson<T>(
+        path: string,
+        init: RequestInit,
+        options?: {emptyOnNotFound?: boolean},
+    ): Promise<T | null> {
+        const res = await globalThis.fetch(`${this.endpoint}${path}`, {
+            ...init,
+            headers: {
+                accept: 'application/json',
+                'content-type': 'application/json',
+                ...(init.headers ?? {}),
+            },
+        })
+
+        if (options?.emptyOnNotFound && res.status === 404) return null
+        if (!res.ok) throw new Error(`GCP Cloud Functions request failed: HTTP ${res.status}`)
+        if (res.status === 204) return null
+
+        return await res.json() as T
+    }
+}
+
+function toFunctionResource(record: GcpFunctionRecord): CloudResource {
+    const name = functionName(record)
+    const runtime = stringValue(record.runtime)
+        || stringValue(record.buildConfig?.runtime)
+    const entryPoint = stringValue(record.entryPoint)
+        || stringValue(record.buildConfig?.entryPoint)
+
+    return {
+        id: name,
+        name,
+        cloud: 'gcp',
+        service: 'serverless',
+        type: 'gcp-function',
+        region: stringValue(record.region) || stringValue(record.location) || null,
+        createdAt: stringValue(record.createTime) || stringValue(record.updateTime) || null,
+        status: stringValue(record.status) || stringValue(record.state) || null,
+        metadata: {
+            provider: 'gcp',
+            serverlessService: 'cloud-functions',
+            description: record.description,
+            runtime,
+            entryPoint,
+            updateTime: record.updateTime,
+            createTime: record.createTime,
+            serviceUri: record.serviceConfig?.uri,
+            serviceName: record.serviceConfig?.service,
+            availableMemory: record.serviceConfig?.availableMemory,
+            timeoutSeconds: record.serviceConfig?.timeoutSeconds,
+            environmentVariables: record.serviceConfig?.environmentVariables,
+            labels: record.labels,
+            buildConfig: record.buildConfig,
+            serviceConfig: record.serviceConfig,
+        },
+    }
+}
+
+function functionName(record: GcpFunctionRecord): string {
+    const raw = stringValue(record.name ?? record.id)
+    return raw.split('/').pop() ?? raw
+}
+
+function stringValue(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : ''
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((resource) => resource.name.toLowerCase().includes(normalized))
+}

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -83,7 +83,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function'
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -14,6 +14,7 @@ import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
 import {createRdsService} from './services/rds'
+import {GcpServerlessAdapter} from './adapter-gcp/GcpServerlessAdapter'
 
 /**
  * Build a CloudProxyService whose AWS adapters are bound to a specific account.
@@ -35,6 +36,7 @@ export function createCloudProxyService(accountId?: string | null): CloudProxySe
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),
+        new GcpServerlessAdapter(),
         new AzureServerlessAdapter(),
     ])
 

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -70,7 +70,7 @@ function CloudServiceNav() {
                     || (service.name === 'secretsmanager' && cloud === 'aws')
                     || (service.name === 'database' && (cloud === 'aws' || cloud === 'azure'))
                     || ((service.name === 'k8s' || service.name === 'compute' || service.name === 'networking') && cloud === 'aws')
-                    || (service.name === 'serverless' && (cloud === 'aws' || cloud === 'azure'))
+                    || (service.name === 'serverless' && (cloud === 'aws' || cloud === 'azure'|| cloud === 'gcp'))
                 if (service.route && available) {
                     const target = service.route.startsWith('/') ? service.route : `/cloud-explorer/${cloud}/${service.route}`
                     return <NavItem key={service.name} to={target} icon={Icon} label={service.label}/>

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function";
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | "gcp-function";
     region: string | null
     createdAt: string | null
     status?: string | null


### PR DESCRIPTION
## Summary
Adds the initial Google Cloud Functions adapter to the Cloud Explorer serverless architecture.

## Changes
* Added `GcpServerlessAdapter`
* Registered the GCP serverless adapter in `cloudProxy`
* Added `gcp-function` as a normalized CloudResource type
* Enabled the Serverless nav item for GCP
* Supports Cloud Functions list and inspect flows
* Uses the existing GCP runtime endpoint/project helpers

## Scope
This PR focuses on the first GCP Serverless milestone:
* List Cloud Functions
* Inspect Cloud Function details
* Display normalized serverless resources in Cloud Explorer

Create, delete, and invoke support are intentionally left for follow-up PRs.

## Validation
* API type-check passed
* Frontend type-check was blocked locally by a duplicate `invokeCloudResource` export already present on `main`; follow-up fix PR opened separately
