### PR TITLE
feat(serverless): add google cloud functions invoke support

### DIFF
--- a/packages/api/src/adapter-gcp/GcpCloudFunctionsAdapter.test.ts
+++ b/packages/api/src/adapter-gcp/GcpCloudFunctionsAdapter.test.ts
@@ -147,4 +147,35 @@ describe('GcpCloudFunctionsAdapter', () => {
         expect(calls[0].url).toBe(`${ENDPOINT}${FUNCTIONS_PATH}/hello`)
         expect(calls[0].method).toBe('DELETE')
     })
+
+    test('invoke posts a payload to the function call endpoint and maps the response', async () => {
+    const calls: Array<{url: string; init: RequestInit}> = []
+
+    globalThis.fetch = (async (url: RequestInfo | URL, init: RequestInit) => {
+        calls.push({url: String(url), init})
+        return new Response(JSON.stringify({
+            statusCode: 200,
+            result: {message: 'hello'},
+            logResult: 'log output',
+        }), {status: 200})
+    }) as unknown as typeof fetch
+
+    const result = await adapter().invoke('hello', '{"name":"Hajira"}')
+
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toBe(`${ENDPOINT}${FUNCTIONS_PATH}/hello:call`)
+    expect(calls[0].init.method).toBe('POST')
+    expect(JSON.parse(String(calls[0].init.body))).toEqual({
+        data: '{"name":"Hajira"}',
+    })
+
+    expect(result).toEqual({
+        statusCode: 200,
+        payload: '{"message":"hello"}',
+        functionError: undefined,
+        logResult: 'log output',
+        executionDuration: expect.any(Number),
+    })
+})
+
 })

--- a/packages/api/src/adapter-gcp/GcpCloudFunctionsAdapter.ts
+++ b/packages/api/src/adapter-gcp/GcpCloudFunctionsAdapter.ts
@@ -5,6 +5,7 @@ import type {
     CloudServiceAdapter,
     CreateResourceInput,
     ResourceQuery,
+    ServerlessInvokeResult,
     ServiceSchema,
 } from '../cloud-spi/types'
 
@@ -121,6 +122,37 @@ export class GcpCloudFunctionsAdapter implements CloudServiceAdapter {
         await this.fetch(`${this.functionsPath()}/${encodeURIComponent(id)}`, {method: 'DELETE'}, true)
     }
 
+    async invoke(id: string, payload: string): Promise<ServerlessInvokeResult> {
+        const startedAt = performance.now()
+
+        const body = await this.fetchJson<{
+            statusCode?: number
+            payload?: unknown
+            body?: unknown
+            result?: unknown
+            error?: string
+            functionError?: string
+            logResult?: string
+        }>(
+            `${this.functionsPath()}/${encodeURIComponent(id)}:call`,
+            {
+                method: 'POST',
+                headers: {'content-type': 'application/json'},
+                body: JSON.stringify({
+                    data: payload?.trim() ? payload : '{}',
+                }),
+            },
+        )
+
+        return {
+            statusCode: body.statusCode ?? 200,
+            payload: stringifyPayload(body.payload ?? body.body ?? body.result ?? ''),
+            functionError: body.functionError ?? body.error,
+            logResult: body.logResult,
+            executionDuration: Math.round(performance.now() - startedAt),
+        }
+    }
+
     private functionsPath(): string {
         return `/v2/projects/${encodeURIComponent(this.project)}/locations/${encodeURIComponent(this.location)}/functions`
     }
@@ -189,6 +221,13 @@ function locationOf(resourceName: string): string | null {
 
 function stringValue(value: unknown): string {
     return typeof value === 'string' ? value.trim() : ''
+}
+ 
+
+function stringifyPayload(value: unknown): string {
+    if (typeof value === 'string') return value
+    if (value === undefined || value === null) return ''
+    return JSON.stringify(value)
 }
 
 function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {


### PR DESCRIPTION
Summary

Adds invoke support for Google Cloud Functions in the Cloud Explorer serverless adapter.

Changes
Implements invoke() in GcpCloudFunctionsAdapter
Sends function invocation requests to the Cloud Functions runtime
Maps runtime responses into ServerlessInvokeResult
Preserves payload, logs, errors, and execution duration
Adds unit tests covering invoke behavior

Validation
pnpm test  (146 tests passing)
pnpm type-check 
Frontend type-check 