### PR TITLE
feat(serverless): support gcp in invoke panel

### DIFF
--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -30,12 +30,21 @@ export function ServerlessInvokePanel({
   }, [resource?.id]);
 
   const isSupportedResource =
-    resource?.service === "serverless" &&
-    (resource.type === "lambda" || resource.type === "azure-function");
+  resource?.service === "serverless" &&
+  (
+    resource.type === "lambda" ||
+    resource.type === "azure-function" ||
+    resource.type === "gcp-function"
+  );
 
   const canInvoke = Boolean(resource && isSupportedResource && runtimeReachable);
 
-  const providerLabel = cloud === "azure" ? "Azure Function" : "Lambda function";
+  const providerLabel =
+  cloud === "aws"
+    ? "Lambda function"
+    : cloud === "azure"
+      ? "Azure Function"
+      : "Google Cloud Function";
 
   const invokeMutation = useMutation({
     mutationFn: () =>
@@ -63,7 +72,7 @@ export function ServerlessInvokePanel({
       <section className="table-panel">
         <div className="empty compact">
           <h3>Select a serverless function</h3>
-          <p>Select a Lambda function or Azure Function to invoke it from Cloud Explorer.</p>
+          <p>Select a Lambda function, Azure Function, or Google Cloud Function to invoke it from Cloud Explorer.</p>
         </div>
       </section>
     );

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function";
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function';
     region: string | null
     createdAt: string | null
     status?: string | null


### PR DESCRIPTION
## Summary
Extends the shared Serverless Invoke panel to support Google Cloud Functions.

## Changes
- Adds `gcp-function` to the frontend CloudResource type
- Enables invoke UI support for Google Cloud Functions
- Updates provider labels for AWS Lambda, Azure Functions, and Google Cloud Functions
- Updates empty-state messaging to include GCP

## Validation
- `pnpm --filter @floci/frontend type-check` passes