### PR TITLE
feat(serverless): validate invoke payload before execution

### DIFF
--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -21,12 +21,14 @@ export function ServerlessInvokePanel({
   const [invokeResult, setInvokeResult] = useState<ServerlessInvokeResult | null>(null);
   const [showLog, setShowLog] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [validationError, setValidationError] = useState<string | null>(null);
 
   useEffect(() => {
     setPayload("{\n  \n}");
     setInvokeResult(null);
     setShowLog(false);
     setCopied(false);
+    setValidationError(null);
   }, [resource?.id]);
 
   const isSupportedResource =
@@ -37,7 +39,12 @@ export function ServerlessInvokePanel({
     resource.type === "gcp-function"
   );
 
-  const canInvoke = Boolean(resource && isSupportedResource && runtimeReachable);
+  const canInvoke = Boolean(
+  resource &&
+  isSupportedResource &&
+  runtimeReachable &&
+  !validationError,
+);
 
   const providerLabel =
   cloud === "aws"
@@ -99,21 +106,38 @@ export function ServerlessInvokePanel({
       <div className="resource-create-inline">
         <label>
           <span className="metric-label">Event payload JSON</span>
-          <textarea
-            className="json-editor"
-            value={payload}
-            onChange={(event) => setPayload(event.target.value)}
-            spellCheck={false}
-            placeholder="{}"
-            style={{minHeight: 140}}
+         <textarea
+  className="json-editor"
+  value={payload}
+  onChange={(event) => {
+    const value = event.target.value;
+    setPayload(value);
+
+    try {
+      JSON.parse(value);
+      setValidationError(null);
+    } catch {
+      setValidationError("Payload must be valid JSON.");
+    }
+  }}
+  spellCheck={false}
+  placeholder="{}"
+  style={{minHeight: 140}}
           />
         </label>
-
+{validationError && (
+  <p className="error-text compact-text">
+    {validationError}
+  </p>
+)}
         <button
           className="button primary"
           type="button"
           disabled={!canInvoke || invokeMutation.isPending}
-          onClick={() => invokeMutation.mutate()}
+          onClick={() => {
+  if (validationError) return;
+  invokeMutation.mutate();
+}}
         >
           {invokeMutation.isPending ? <Loader2 size={13} /> : <Play size={13} />}
           {invokeMutation.isPending ? "Invoking" : "Invoke"}

--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -32,26 +32,20 @@ export function ServerlessInvokePanel({
   }, [resource?.id]);
 
   const isSupportedResource =
-  resource?.service === "serverless" &&
-  (
-    resource.type === "lambda" ||
-    resource.type === "azure-function" ||
-    resource.type === "gcp-function"
-  );
+    resource?.service === "serverless" &&
+    (resource.type === "lambda" ||
+      resource.type === "azure-function" ||
+      resource.type === "gcp-function");
 
-  const canInvoke = Boolean(
-  resource &&
-  isSupportedResource &&
-  runtimeReachable &&
-  !validationError,
-);
+  const canInvoke = Boolean(resource && isSupportedResource && runtimeReachable);
+  const canSubmit = canInvoke && !validationError;
 
   const providerLabel =
-  cloud === "aws"
-    ? "Lambda function"
-    : cloud === "azure"
-      ? "Azure Function"
-      : "Google Cloud Function";
+    cloud === "aws"
+      ? "Lambda function"
+      : cloud === "azure"
+        ? "Azure Function"
+        : "Google Cloud Function";
 
   const invokeMutation = useMutation({
     mutationFn: () =>
@@ -79,7 +73,10 @@ export function ServerlessInvokePanel({
       <section className="table-panel">
         <div className="empty compact">
           <h3>Select a serverless function</h3>
-          <p>Select a Lambda function, Azure Function, or Google Cloud Function to invoke it from Cloud Explorer.</p>
+          <p>
+            Select a Lambda function, Azure Function, or Google Cloud Function to
+            invoke it from Cloud Explorer.
+          </p>
         </div>
       </section>
     );
@@ -106,38 +103,37 @@ export function ServerlessInvokePanel({
       <div className="resource-create-inline">
         <label>
           <span className="metric-label">Event payload JSON</span>
-         <textarea
-  className="json-editor"
-  value={payload}
-  onChange={(event) => {
-    const value = event.target.value;
-    setPayload(value);
+          <textarea
+            className="json-editor"
+            value={payload}
+            onChange={(event) => {
+              const value = event.target.value;
+              setPayload(value);
 
-    try {
-      JSON.parse(value);
-      setValidationError(null);
-    } catch {
-      setValidationError("Payload must be valid JSON.");
-    }
-  }}
-  spellCheck={false}
-  placeholder="{}"
-  style={{minHeight: 140}}
+              try {
+                JSON.parse(value);
+                setValidationError(null);
+              } catch {
+                setValidationError("Payload must be valid JSON.");
+              }
+            }}
+            spellCheck={false}
+            placeholder="{}"
+            style={{minHeight: 140}}
           />
         </label>
-{validationError && (
-  <p className="error-text compact-text">
-    {validationError}
-  </p>
-)}
+
+        {validationError && (
+          <p className="error-text compact-text">
+            {validationError}
+          </p>
+        )}
+
         <button
           className="button primary"
           type="button"
-          disabled={!canInvoke || invokeMutation.isPending}
-          onClick={() => {
-  if (validationError) return;
-  invokeMutation.mutate();
-}}
+          disabled={!canSubmit || invokeMutation.isPending}
+          onClick={() => invokeMutation.mutate()}
         >
           {invokeMutation.isPending ? <Loader2 size={13} /> : <Play size={13} />}
           {invokeMutation.isPending ? "Invoking" : "Invoke"}


### PR DESCRIPTION
## Summary
Adds client-side validation for the Serverless Invoke panel to prevent invalid JSON payloads from being sent to the runtime.

## Changes
- Validates the event payload as the user types
- Displays an inline validation message for malformed JSON
- Disables the Invoke button while the payload is invalid
- Clears validation state when switching between serverless resources

## Motivation
Previously, malformed JSON could be submitted to the runtime and would only fail after the request was sent. This provides immediate feedback and prevents unnecessary invocation requests.

## Validation
- `pnpm --filter @floci/frontend type-check`
- `pnpm build`