### PR TITLE
feat(serverless): add format payload action

### DIFF
--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -113,39 +113,35 @@ export function ServerlessInvokePanel({
       <div className="resource-create-inline">
       
   <div className="inspector-section-header">
-  <span className="metric-label">Event payload JSON</span>
+  <label className="metric-label" htmlFor="serverless-invoke-payload">
+    Event payload JSON
+  </label>
 
-  <button
-    className="button"
-    type="button"
-    onClick={formatPayload}
-  >
+  <button className="button" type="button" onClick={formatPayload}>
     <Wand2 size={13} />
     Format JSON
   </button>
 </div>
 
-<label>
-  <textarea
-    className="json-editor"
-    value={payload}
-    onChange={(event) => {
-      const value = event.target.value;
-      setPayload(value);
+<textarea
+  id="serverless-invoke-payload"
+  className="json-editor"
+  value={payload}
+  onChange={(event) => {
+    const value = event.target.value;
+    setPayload(value);
 
-      try {
-        JSON.parse(value);
-        setValidationError(null);
-      } catch {
-        setValidationError("Payload must be valid JSON.");
-      }
-    }}
-    spellCheck={false}
-    placeholder="{}"
-    style={{minHeight: 140}}
-  />
-</label>
-
+    try {
+      JSON.parse(value);
+      setValidationError(null);
+    } catch {
+      setValidationError("Payload must be valid JSON.");
+    }
+  }}
+  spellCheck={false}
+  placeholder="{}"
+  style={{minHeight: 140}}
+/>
         {validationError && (
           <p className="error-text compact-text">
             {validationError}

--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -111,31 +111,40 @@ export function ServerlessInvokePanel({
       </div>
 
       <div className="resource-create-inline">
-        <label>
+      
+  <div className="inspector-section-header">
   <span className="metric-label">Event payload JSON</span>
-  <button className="button" type="button" onClick={formatPayload}>
+
+  <button
+    className="button"
+    type="button"
+    onClick={formatPayload}
+  >
     <Wand2 size={13} />
     Format JSON
   </button>
-  <textarea
-            className="json-editor"
-            value={payload}
-            onChange={(event) => {
-              const value = event.target.value;
-              setPayload(value);
+</div>
 
-              try {
-                JSON.parse(value);
-                setValidationError(null);
-              } catch {
-                setValidationError("Payload must be valid JSON.");
-              }
-            }}
-            spellCheck={false}
-            placeholder="{}"
-            style={{minHeight: 140}}
-          />
-        </label>
+<label>
+  <textarea
+    className="json-editor"
+    value={payload}
+    onChange={(event) => {
+      const value = event.target.value;
+      setPayload(value);
+
+      try {
+        JSON.parse(value);
+        setValidationError(null);
+      } catch {
+        setValidationError("Payload must be valid JSON.");
+      }
+    }}
+    spellCheck={false}
+    placeholder="{}"
+    style={{minHeight: 140}}
+  />
+</label>
 
         {validationError && (
           <p className="error-text compact-text">

--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useState} from "react";
-import {ChevronDown, ChevronUp, Copy, Loader2, Play, Zap} from "lucide-react";
+import {ChevronDown, ChevronUp, Copy, Loader2, Play, Wand2, Zap} from "lucide-react";
 import {useMutation} from "@tanstack/react-query";
 import {invokeCloudResource} from "@/api/cloudProxyClient";
 import type {ServerlessInvokeResult} from "@/api/cloudProxyClient";
@@ -61,6 +61,16 @@ export function ServerlessInvokePanel({
     invokeResult?.functionError || (invokeResult && invokeResult.statusCode >= 400),
   );
 
+    const formatPayload = () => {
+    try {
+      const formatted = JSON.stringify(JSON.parse(payload), null, 2);
+      setPayload(formatted);
+      setValidationError(null);
+    } catch {
+      setValidationError("Payload must be valid JSON before formatting.");
+    }
+  };
+
   const copyResponse = async () => {
     if (!invokeResult) return;
     await navigator.clipboard.writeText(invokeResult.payload || "");
@@ -102,8 +112,12 @@ export function ServerlessInvokePanel({
 
       <div className="resource-create-inline">
         <label>
-          <span className="metric-label">Event payload JSON</span>
-          <textarea
+  <span className="metric-label">Event payload JSON</span>
+  <button className="button" type="button" onClick={formatPayload}>
+    <Wand2 size={13} />
+    Format JSON
+  </button>
+  <textarea
             className="json-editor"
             value={payload}
             onChange={(event) => {


### PR DESCRIPTION
## Summary
Adds a Format JSON action to the Serverless Invoke panel.

## Changes
- Adds a Format JSON button beside the event payload editor
- Pretty-prints valid JSON payloads
- Reuses the existing validation message for invalid JSON payloads
- Keeps the invoke flow unchanged

## Validation
- `pnpm --filter @floci/frontend type-check`
-`pnpm build`