### PR TITLE
feat(serverless): add sample and clear payload actions

### DIFF
--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -71,11 +71,6 @@ export function ServerlessInvokePanel({
     }
   };
 
-  const useSamplePayload = () => {
-  setPayload(JSON.stringify({message: "hello"}, null, 2));
-  setValidationError(null);
-};
-
 const clearPayload = () => {
   setPayload("{}");
   setValidationError(null);
@@ -131,9 +126,6 @@ const clearPayload = () => {
     <Wand2 size={13} />
     Format JSON
   </button>
-  <button className="button" type="button" onClick={useSamplePayload}>
-  Sample
-</button>
 
 <button className="button" type="button" onClick={clearPayload}>
   Clear

--- a/packages/frontend/src/components/ServerlessInvokePanel.tsx
+++ b/packages/frontend/src/components/ServerlessInvokePanel.tsx
@@ -71,6 +71,16 @@ export function ServerlessInvokePanel({
     }
   };
 
+  const useSamplePayload = () => {
+  setPayload(JSON.stringify({message: "hello"}, null, 2));
+  setValidationError(null);
+};
+
+const clearPayload = () => {
+  setPayload("{}");
+  setValidationError(null);
+};
+
   const copyResponse = async () => {
     if (!invokeResult) return;
     await navigator.clipboard.writeText(invokeResult.payload || "");
@@ -121,6 +131,13 @@ export function ServerlessInvokePanel({
     <Wand2 size={13} />
     Format JSON
   </button>
+  <button className="button" type="button" onClick={useSamplePayload}>
+  Sample
+</button>
+
+<button className="button" type="button" onClick={clearPayload}>
+  Clear
+</button>
 </div>
 
 <textarea


### PR DESCRIPTION
## Summary
Adds quick actions to the Serverless Invoke panel for setting a sample payload and clearing the editor.

## Changes
- Adds a Sample action for inserting a valid example JSON payload
- Adds a Clear action for resetting the payload editor
- Clears validation errors when either action is used
- Keeps the invoke flow unchanged

## Validation
-`pnpm --filter @floci/frontend type-check`
-`pnpm build`