### PR TITLE
feat(frontend): declutter the cloud explorer service view

### DIFF
--- a/packages/frontend/src/components/DynamicResourceView.tsx
+++ b/packages/frontend/src/components/DynamicResourceView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { ChevronDown, ChevronUp, Info, Plus, RefreshCw } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -328,7 +328,10 @@ export function DynamicResourceView({
 }
 
 function TopbarServiceInfo({ onOpenInfo }: { onOpenInfo: () => void }) {
-  const slot = document.getElementById("topbar-status");
+  const [slot, setSlot] = useState<HTMLElement | null>(null);
+  useLayoutEffect(() => {
+    setSlot(document.getElementById("topbar-status"));
+  }, []);
   if (!slot) return null;
   return createPortal(
     <button

--- a/packages/frontend/src/components/DynamicResourceView.tsx
+++ b/packages/frontend/src/components/DynamicResourceView.tsx
@@ -1,14 +1,6 @@
-import { type ElementType, useEffect, useMemo, useState } from "react";
-import {
-  ChevronDown,
-  ChevronUp,
-  Eye,
-  Filter,
-  Plus,
-  RefreshCw,
-  Table2,
-  Workflow,
-} from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
+import { ChevronDown, ChevronUp, Info, Plus, RefreshCw } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createCloudResource,
@@ -25,9 +17,9 @@ import { NetworkingPanel } from "@/components/NetworkingPanel";
 import {
   capabilityEnabled,
   capabilityFor,
-  capabilitySummary,
   normalizeCapabilities,
   withRuntimeState,
+  withServiceAvailability,
 } from "@/lib/capabilities";
 import type {
   CloudAvailability,
@@ -36,11 +28,7 @@ import type {
   CloudStatus,
 } from "@/types/cloud";
 import type { CloudResource, StorageObject } from "@/types/resource";
-import type {
-  CapabilitySchema,
-  ResourceActionName,
-  ServiceSchema,
-} from "@/types/schema";
+import type { ServiceSchema } from "@/types/schema";
 import { CosmosNoSqlPanel } from "@/components/CosmosNoSqlPanel";
 import { ServerlessInvokePanel } from "@/components/ServerlessInvokePanel";
 
@@ -50,6 +38,7 @@ interface DynamicResourceViewProps {
   serviceAvailability?: CloudAvailability;
   cloudStatus?: CloudStatus;
   statusLoading?: boolean;
+  onOpenInfo: () => void;
 }
 
 export function DynamicResourceView({
@@ -58,6 +47,7 @@ export function DynamicResourceView({
   serviceAvailability = "coming_soon",
   cloudStatus,
   statusLoading = false,
+  onOpenInfo,
 }: DynamicResourceViewProps) {
   const qc = useQueryClient();
   const [search, setSearch] = useState("");
@@ -119,42 +109,48 @@ export function DynamicResourceView({
     setSelectedObject(undefined);
   }, [selected?.id]);
 
-  useEffect(() => {
-    setSelected(undefined);
-    setSelectedObject(undefined);
-    setCreateOpen(false);
-  }, [cloud, service]);
+  const adapterAvailable = serviceAvailability === "available";
 
   if (schemaQuery.isLoading) {
     return (
-      <div className="empty compact">
-        <h3>Loading schema</h3>
+      <div className="dynamic-resource-view">
+        <TopbarServiceInfo onOpenInfo={onOpenInfo} />
+        <div className="empty compact">
+          <h3>Loading schema</h3>
+        </div>
       </div>
     );
   }
 
   if (schemaQuery.isError || !schemaQuery.data) {
     return (
-      <div className="cloud-coming-soon">
-        <div>
-          <p className="eyebrow">Coming Soon</p>
-          <h3>
-            {cloud.toUpperCase()} {service}
-          </h3>
-          <p className="muted">
-            The proxy already exposes this provider as a placeholder. No adapter
-            is registered yet.
-          </p>
-        </div>
-        <div className="coming-soon-grid">
-          <StatusTile
-            label="Cloud"
-            value={cloud.toUpperCase()}
-            state="placeholder"
-          />
-          <StatusTile label="Service" value={service} state="placeholder" />
-          <StatusTile label="Adapter" value="Not registered" state="pending" />
-          <StatusTile label="Runtime" value="Future" state="pending" />
+      <div className="dynamic-resource-view">
+        <TopbarServiceInfo onOpenInfo={onOpenInfo} />
+        <div className="cloud-coming-soon">
+          <div>
+            <p className="eyebrow">Coming Soon</p>
+            <h3>
+              {cloud.toUpperCase()} {service}
+            </h3>
+            <p className="muted">
+              The proxy already exposes this provider as a placeholder. No
+              adapter is registered yet.
+            </p>
+          </div>
+          <div className="coming-soon-grid">
+            <StatusTile
+              label="Cloud"
+              value={cloud.toUpperCase()}
+              state="placeholder"
+            />
+            <StatusTile label="Service" value={service} state="placeholder" />
+            <StatusTile
+              label="Adapter"
+              value="Not registered"
+              state="pending"
+            />
+            <StatusTile label="Runtime" value="Future" state="pending" />
+          </div>
         </div>
       </div>
     );
@@ -184,114 +180,19 @@ export function DynamicResourceView({
     ),
     serviceAvailability,
   );
-  const capabilityState = capabilitySummary([
-    ...resourceCapabilities,
-    ...objectCapabilities,
-  ]);
   const createCapability = capabilityFor(resourceCapabilities, "create");
   const createResourceLabel = resourceCreateLabel(schema);
-  const runtimeState = statusLoading
-    ? "Checking runtime"
-    : cloudStatus?.runtime === "reachable"
-      ? "Runtime reachable"
-      : cloudStatus?.runtime === "unavailable"
-        ? "Runtime unavailable"
-        : "Coming soon";
-  const runtimeClass =
-    cloudStatus?.runtime === "unavailable"
-      ? "unavailable"
-      : cloudStatus?.runtime === "reachable"
-        ? "ready"
-        : "pending";
-  const adapterAvailable = serviceAvailability === "available";
-  const adapterState = adapterAvailable ? "Adapter ready" : "Adapter pending";
-  const resourceState = resourceStateFor(
-    cloudStatus,
-    statusLoading,
-    serviceAvailability,
-    resourcesQuery.isLoading,
-    resourcesQuery.isError,
-  );
   const canUseRuntime = runtimeReachable && adapterAvailable;
   const canCreateResource =
     canUseRuntime && capabilityEnabled(createCapability);
-  const capabilitiesLabel =
-    capabilityState.blocked > 0
-      ? `${capabilityState.blocked} blocked`
-      : capabilityState.partial > 0
-        ? `${capabilityState.partial} partial`
-        : "Capabilities verified";
-  const capabilitiesClass =
-    capabilityState.blocked > 0
-      ? "unavailable"
-      : capabilityState.partial > 0
-        ? "pending"
-        : "ready";
 
   return (
     <div className="dynamic-resource-view">
-      <section className="dynamic-stage">
-        <div className="dynamic-stage-header">
-          <div>
-            <p className="eyebrow">Dynamic View</p>
-            <h3>{schema.displayName}</h3>
-          </div>
-          <div className="schema-action-list">
-            <span className={`runtime-state ${runtimeClass}`}>
-              {runtimeState}
-            </span>
-            <span
-              className={`runtime-state ${adapterAvailable ? "ready" : "pending"}`}
-            >
-              {adapterState}
-            </span>
-            <span className={`runtime-state ${capabilitiesClass}`}>
-              {capabilitiesLabel}
-            </span>
-            <span className={`runtime-state ${resourceState.className}`}>
-              {resourceState.label}
-            </span>
-            <span className="schema-action resource-count">
-              {resources.length} resources
-            </span>
-          </div>
-        </div>
+      <TopbarServiceInfo onOpenInfo={onOpenInfo} />
 
-        <div className="dynamic-stage-grid">
-          <FeatureTile
-            icon={Filter}
-            title="Dynamic Filters"
-            value={`${schema.filters.length}`}
-            detail="Schema-driven search and future filters"
-          />
-          <FeatureTile
-            icon={Table2}
-            title="Resources Table"
-            value={`${schema.columns.length} columns`}
-            detail="Normalized across AWS and Azure"
-          />
-          <FeatureTile
-            icon={Workflow}
-            title="Dynamic Actions"
-            value={`${capabilityState.ready}/${capabilityState.total} ready`}
-            detail={capabilityDetail([
-              ...resourceCapabilities,
-              ...objectCapabilities,
-            ])}
-          />
-          <FeatureTile
-            icon={Eye}
-            title="Resource Inspector"
-            value="Enabled"
-            detail="Same normalized resource contract"
-          />
-        </div>
-        <CapabilityStrip
-          capabilities={[...resourceCapabilities, ...objectCapabilities]}
-        />
-      </section>
-
-      <div className="resource-workbench">
+      <div
+        className={`resource-workbench${activeSelected ? " with-inspector" : ""}`}
+      >
         <section className="resource-main">
           <section className="table-panel">
             <div className="input-row resource-table-bar">
@@ -377,7 +278,12 @@ export function DynamicResourceView({
             })}
           </section>
         </section>
-        <ResourceInspector resource={activeSelected} object={selectedObject} />
+        {activeSelected && (
+          <ResourceInspector
+            resource={activeSelected}
+            object={selectedObject}
+          />
+        )}
       </div>
       {service === "storage" && (
         <StorageObjectBrowser
@@ -421,53 +327,19 @@ export function DynamicResourceView({
   );
 }
 
-function withServiceAvailability<
-  TAction extends
-    | ResourceActionName
-    | "upload"
-    | "download"
-    | "createFolder"
-    | "copy",
->(
-  capabilities: Array<CapabilitySchema<TAction>>,
-  serviceAvailability: CloudAvailability,
-): Array<CapabilitySchema<TAction>> {
-  if (serviceAvailability === "available") return capabilities;
-  return capabilities.map((capability) => ({
-    ...capability,
-    enabled: false,
-    status: "coming_soon",
-    reason:
-      "This provider service schema is available, but no runtime adapter is registered yet.",
-  }));
-}
-
-function capabilityDetail(
-  capabilities: ReturnType<typeof normalizeCapabilities>,
-): string {
-  const active = capabilities
-    .filter(capabilityEnabled)
-    .map((capability) => capability.label);
-  return active.length ? active.join(", ") : "No runtime actions available";
-}
-
-function CapabilityStrip({
-  capabilities,
-}: {
-  capabilities: ReturnType<typeof normalizeCapabilities>;
-}) {
-  return (
-    <div className="capability-strip">
-      {capabilities.map((capability) => (
-        <span
-          key={capability.name}
-          className={`capability-pill ${capability.status}`}
-          title={capability.reason}
-        >
-          {capability.label}
-        </span>
-      ))}
-    </div>
+function TopbarServiceInfo({ onOpenInfo }: { onOpenInfo: () => void }) {
+  const slot = document.getElementById("topbar-status");
+  if (!slot) return null;
+  return createPortal(
+    <button
+      className="icon-btn"
+      type="button"
+      onClick={onOpenInfo}
+      title="Service information"
+    >
+      <Info size={14} />
+    </button>,
+    slot,
   );
 }
 
@@ -479,28 +351,6 @@ function resourceCreateLabel(schema: ServiceSchema): string {
   if (schema.cloud === "azure" && schema.service === "database")
     return "Create database";
   return "Create resource";
-}
-
-function FeatureTile({
-  icon,
-  title,
-  value,
-  detail,
-}: {
-  icon: ElementType;
-  title: string;
-  value: string;
-  detail: string;
-}) {
-  const Icon = icon;
-  return (
-    <div className="feature-tile">
-      <Icon size={22} />
-      <span>{title}</span>
-      <strong>{value}</strong>
-      <small>{detail}</small>
-    </div>
-  );
 }
 
 function StatusTile({
@@ -518,28 +368,6 @@ function StatusTile({
       <strong>{value}</strong>
     </div>
   );
-}
-
-function resourceStateFor(
-  status: CloudStatus | undefined,
-  statusLoading: boolean,
-  serviceAvailability: CloudAvailability,
-  resourcesLoading: boolean,
-  resourcesError: boolean,
-): { label: string; className: "ready" | "pending" | "unavailable" } {
-  if (statusLoading)
-    return { label: "Checking resources", className: "pending" };
-  if (serviceAvailability !== "available")
-    return { label: "Adapter pending", className: "pending" };
-  if (status?.runtime === "unavailable")
-    return { label: "Resources blocked", className: "unavailable" };
-  if (status?.runtime === "coming_soon")
-    return { label: "Resources pending", className: "pending" };
-  if (resourcesLoading)
-    return { label: "Loading resources", className: "pending" };
-  if (resourcesError)
-    return { label: "Resource error", className: "unavailable" };
-  return { label: "Resources loaded", className: "ready" };
 }
 
 function renderResourceSurface({

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -131,6 +131,7 @@ export function Layout() {
                     <button className="icon-btn" onClick={toggle} title="Toggle theme">
                         {theme === 'dark' ? <Sun size={14}/> : <Moon size={14}/>}
                     </button>
+                    <div id="topbar-status" className="topbar-status"/>
                     <AccountSwitcher/>
                     <div className={`connection ${isConnected ? 'connected' : 'disconnected'}`}>
                         <span className={`dot ${status}`}/>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -369,6 +369,9 @@ pre,
 
 .account-switcher {
     position: relative;
+}
+
+.topbar-status:empty + .account-switcher {
     margin-left: auto;
 }
 
@@ -562,22 +565,11 @@ pre,
     gap: 8px;
 }
 
-.page-title-row {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-}
-
 .page-title h2 {
     margin: 0;
     color: var(--text);
     font-size: 20px;
     font-weight: 400;
-}
-
-.page-info-btn {
-    width: 24px;
-    height: 24px;
 }
 
 .info-link {
@@ -936,83 +928,9 @@ pre,
 
 .cloud-explorer {
     display: grid;
-    grid-template-rows: auto auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
     gap: 10px;
     min-height: calc(100vh - 92px);
-}
-
-.cloud-runtime-strip {
-    display: grid;
-    grid-template-columns: 1.5fr repeat(4, minmax(0, 1fr));
-    gap: 0;
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--elevated);
-    overflow: hidden;
-}
-
-.cloud-runtime-strip.compact {
-    grid-template-columns: repeat(5, minmax(0, 1fr));
-}
-
-.runtime-card {
-    min-height: 38px;
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    border-right: 1px solid var(--border);
-    padding: 7px 10px;
-}
-
-.cloud-runtime-strip.compact .runtime-card {
-    min-height: 28px;
-    gap: 8px;
-    padding: 8px 10px;
-}
-
-.runtime-card:last-child {
-    border-right: 0;
-}
-
-.runtime-card svg {
-    color: var(--link);
-    flex: 0 0 auto;
-}
-
-.cloud-runtime-strip span {
-    display: block;
-    color: var(--text-2);
-    font-size: 9px;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-    text-transform: uppercase;
-}
-
-.cloud-runtime-strip strong {
-    display: block;
-    min-width: 0;
-    color: var(--text-bright);
-    font-size: 10px;
-    font-weight: 500;
-    word-break: break-word;
-}
-
-.cloud-runtime-strip small {
-    display: block;
-    overflow: hidden;
-    color: var(--text-2);
-    font-size: 10px;
-    line-height: 1.35;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.cloud-runtime-strip.compact strong {
-    font-size: 11px;
-}
-
-.cloud-runtime-strip.compact small {
-    font-size: 10px;
 }
 
 .service-info-dialog {
@@ -1102,55 +1020,6 @@ pre,
     line-height: 1.6;
 }
 
-.runtime-card.ready svg,
-.runtime-card.status.ready strong {
-    color: #4ade80;
-}
-
-.runtime-card.pending svg,
-.runtime-card.status.pending strong {
-    color: #fbbf24;
-}
-
-.runtime-card.unavailable svg,
-.runtime-card.status.unavailable strong {
-    color: #f87171;
-}
-
-.runtime-card.status {
-    position: relative;
-    padding-left: 24px;
-    display: grid;
-    gap: 1px;
-    align-content: center;
-    align-items: center;
-}
-
-.runtime-card.status::before {
-    content: "";
-    position: absolute;
-    left: 10px;
-    top: 50%;
-    width: 7px;
-    height: 7px;
-    border-radius: 999px;
-    transform: translateY(-50%);
-}
-
-.runtime-card.status.ready::before {
-    background: #22c55e;
-    box-shadow: 0 0 6px #22c55e;
-}
-
-.runtime-card.status.pending::before {
-    background: #f59e0b;
-}
-
-.runtime-card.status.unavailable::before {
-    background: #ef4444;
-    box-shadow: 0 0 6px rgba(239, 68, 68, 0.8);
-}
-
 .cloud-selector {
     display: flex;
     flex-wrap: wrap;
@@ -1182,16 +1051,26 @@ pre,
 
 .dynamic-resource-view {
     display: grid;
-    grid-template-rows: auto minmax(0, 1fr);
+    grid-template-rows: minmax(0, 1fr);
     gap: 10px;
     min-height: 0;
 }
 
-.dynamic-stage {
-    border: 1px solid var(--border);
-    border-radius: 4px;
-    background: var(--elevated);
-    overflow: hidden;
+.topbar-status {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-left: auto;
+}
+
+.topbar-status:empty {
+    display: none;
+}
+
+.topbar-status .icon-btn {
+    flex: 0 0 auto;
+    width: 24px;
+    height: 24px;
 }
 
 .dynamic-stage-header {
@@ -1218,27 +1097,6 @@ pre,
     font-weight: 700;
     letter-spacing: 0.08em;
     text-transform: uppercase;
-}
-
-.schema-action-list {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: flex-end;
-    gap: 6px;
-}
-
-.schema-action {
-    display: inline-flex;
-    align-items: center;
-    min-height: 22px;
-    border: 1px solid var(--link-tint-border);
-    border-radius: 999px;
-    background: var(--link-tint);
-    color: var(--link);
-    padding: 0 9px;
-    font-size: 11px;
-    font-weight: 600;
-    text-transform: capitalize;
 }
 
 .runtime-state {
@@ -1268,16 +1126,6 @@ pre,
     color: #fbbf24;
     border-color: rgba(251, 191, 36, 0.24);
     background: rgba(251, 191, 36, 0.08);
-}
-
-.resource-count {
-    color: var(--text-bright);
-}
-
-.dynamic-stage-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 0;
 }
 
 .capability-strip {
@@ -1319,58 +1167,9 @@ pre,
     background: rgba(148, 163, 184, 0.06);
 }
 
-.feature-tile {
-    min-height: 68px;
-    display: grid;
-    grid-template-columns: 28px minmax(0, 1fr);
-    grid-template-areas:
-        "icon title"
-        "icon value"
-        "icon detail";
-    gap: 2px 10px;
-    align-content: center;
-    border-right: 1px solid var(--border);
-    color: var(--text);
-    padding: 10px 12px;
-    text-align: left;
-}
-
-.feature-tile:last-child {
-    border-right: 0;
-}
-
-.feature-tile svg {
-    grid-area: icon;
-    color: var(--link);
-    align-self: start;
-    width: 18px;
-    height: 18px;
-    margin-top: 1px;
-}
-
-.feature-tile span {
-    grid-area: title;
-    color: var(--text-2);
-    font-size: 10px;
-    font-weight: 700;
-    text-transform: uppercase;
-}
-
-.feature-tile strong {
-    grid-area: value;
-    color: var(--text-bright);
-    font-size: 11px;
-    font-weight: 600;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-}
-
-.feature-tile small {
-    grid-area: detail;
-    color: var(--text-3);
-    font-size: 10px;
-    line-height: 1.35;
+.service-info-section .capability-strip {
+    border-top: 0;
+    padding: 8px 0 0;
 }
 
 .dynamic-form {
@@ -1458,10 +1257,14 @@ pre,
 
 .resource-workbench {
     display: grid;
-    grid-template-columns: minmax(0, 1fr) minmax(380px, 30vw);
+    grid-template-columns: minmax(0, 1fr);
     gap: 10px;
     align-items: stretch;
     min-height: 0;
+}
+
+.resource-workbench.with-inspector {
+    grid-template-columns: minmax(0, 1fr) minmax(380px, 30vw);
 }
 
 .resource-main {
@@ -2611,8 +2414,7 @@ button.console-service-card {
         flex-direction: column;
     }
 
-    .cloud-runtime-strip,
-    .resource-workbench,
+    .resource-workbench.with-inspector,
     .cloud-coming-soon {
         grid-template-columns: 1fr;
     }
@@ -2621,28 +2423,9 @@ button.console-service-card {
         grid-template-columns: 1fr;
     }
 
-    .runtime-card {
-        border-right: 0;
-        border-bottom: 1px solid var(--border);
-    }
-
-    .runtime-card:last-child {
-        border-bottom: 0;
-    }
-
-    .dynamic-stage-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
     .console-summary,
     .console-service-grid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
-    }
-
-    .feature-tile {
-        grid-template-columns: 28px minmax(0, 1fr);
-        border-right: 0;
-        border-bottom: 1px solid var(--border);
     }
 
     .dynamic-form,

--- a/packages/frontend/src/lib/capabilities.ts
+++ b/packages/frontend/src/lib/capabilities.ts
@@ -1,4 +1,5 @@
 import type {CapabilitySchema, CapabilityStatus, ObjectActionName, ResourceActionName} from '@/types/schema'
+import type {CloudAvailability} from '@/types/cloud'
 
 export type CapabilityActionName = ResourceActionName | ObjectActionName
 export type AnyCapability = CapabilitySchema<CapabilityActionName>
@@ -51,15 +52,15 @@ export function withRuntimeState<TAction extends CapabilityActionName>(
     })
 }
 
-export function capabilitySummary(capabilities: AnyCapability[]): {ready: number; total: number; blocked: number; partial: number} {
-    return capabilities.reduce(
-        (summary, capability) => {
-            summary.total += 1
-            if (capability.status === 'blocked' || capability.status === 'coming_soon' || !capability.enabled) summary.blocked += 1
-            else if (capability.status === 'partial') summary.partial += 1
-            else summary.ready += 1
-            return summary
-        },
-        {ready: 0, total: 0, blocked: 0, partial: 0},
-    )
+export function withServiceAvailability<TAction extends CapabilityActionName>(
+    capabilities: Array<CapabilitySchema<TAction>>,
+    serviceAvailability: CloudAvailability,
+): Array<CapabilitySchema<TAction>> {
+    if (serviceAvailability === 'available') return capabilities
+    return capabilities.map((capability) => ({
+        ...capability,
+        enabled: false,
+        status: 'coming_soon' as CapabilityStatus,
+        reason: 'This provider service schema is available, but no runtime adapter is registered yet.',
+    }))
 }

--- a/packages/frontend/src/pages/CloudExplorerPage.tsx
+++ b/packages/frontend/src/pages/CloudExplorerPage.tsx
@@ -1,11 +1,11 @@
-import {type ElementType, useMemo, useState} from 'react'
-import {Cloud, DatabaseZap, Info, Radio, Route, ShieldCheck, X} from 'lucide-react'
+import {useMemo, useState} from 'react'
+import {Cloud, X} from 'lucide-react'
 import {Navigate, useNavigate, useParams} from 'react-router-dom'
 import {useQuery} from '@tanstack/react-query'
 import {getCloudStatus, getServiceSchema, listClouds, listCloudServices} from '@/api/cloudProxyClient'
 import {CloudSelector} from '@/components/CloudSelector'
 import {DynamicResourceView} from '@/components/DynamicResourceView'
-import {normalizeCapabilities} from '@/lib/capabilities'
+import {normalizeCapabilities, withRuntimeState, withServiceAvailability} from '@/lib/capabilities'
 import type {CloudProvider, CloudServiceDescriptor, CloudServiceType, CloudStatus} from '@/types/cloud'
 import type {ServiceSchema} from '@/types/schema'
 
@@ -53,12 +53,7 @@ export function CloudExplorerPage() {
                 <div className="page-title">
                     <Cloud size={20}/>
                     <div>
-                        <div className="page-title-row">
-                            <h2>Cloud Explorer</h2>
-                            <button className="icon-btn page-info-btn" type="button" onClick={() => setInfoOpen(true)} title="Service information">
-                                <Info size={14}/>
-                            </button>
-                        </div>
+                        <h2>Cloud Explorer</h2>
                         <p className="muted">Unified local runtime console</p>
                     </div>
                 </div>
@@ -78,19 +73,13 @@ export function CloudExplorerPage() {
                 </div>
             </div>
             <div className="content cloud-explorer">
-                <div className="cloud-runtime-strip compact">
-                    <RuntimeCard icon={Route} label="Service" value={selectedService?.displayName ?? serviceLabel(service)} detail={serviceAvailability(selectedService)}/>
-                    <RuntimeCard icon={DatabaseZap} label="Proxy API" value={`/api/clouds/${cloud}/services/${service}`} detail="Single entry point"/>
-                    <RuntimeCard icon={Radio} label="Runtime" value={runtimeValue(cloud, statusQuery.data)} detail={runtimeDetail(statusQuery.data, statusQuery.isLoading)} state={runtimeState(statusQuery.data, statusQuery.isLoading)}/>
-                    <RuntimeCard icon={ShieldCheck} label="Adapter" value={adapterValue(cloud, statusQuery.data)} detail={adapterDetail(statusQuery.data, statusQuery.isLoading)} state={adapterState(cloud, statusQuery.data)}/>
-                    <RuntimeCard icon={Cloud} label="Connection" value={connectionValue(statusQuery.data, statusQuery.isLoading)} detail={statusQuery.data?.endpoint ?? 'No runtime endpoint'} state={runtimeState(statusQuery.data, statusQuery.isLoading)}/>
-                </div>
                 <DynamicResourceView
                     cloud={cloud}
                     service={service}
                     serviceAvailability={selectedService?.availability}
                     cloudStatus={statusQuery.data}
                     statusLoading={statusQuery.isLoading}
+                    onOpenInfo={() => setInfoOpen(true)}
                 />
             </div>
             {infoOpen && (
@@ -116,32 +105,6 @@ function normalizeService(value?: string): CloudServiceType | null {
     return value === 'storage' || value === 'k8s' || value === 'database' || value === 'compute' || value === 'networking' || value === 'serverless' ? value : null
 }
 
-function RuntimeCard({
-    icon,
-    label,
-    value,
-    detail,
-    state,
-}: {
-    icon: ElementType
-    label: string
-    value: string
-    detail: string
-    state?: 'ready' | 'pending' | 'unavailable'
-}) {
-    const Icon = icon
-    return (
-        <div className={`runtime-card ${state ?? ''}`}>
-            <Icon size={16}/>
-            <div>
-                <span>{label}</span>
-                <strong>{value}</strong>
-                <small>{detail}</small>
-            </div>
-        </div>
-    )
-}
-
 function ServiceInfoDialog({
     cloud,
     service,
@@ -160,14 +123,18 @@ function ServiceInfoDialog({
     onClose: () => void
 }) {
     const capabilityList = schema?.capabilities
-        ? normalizeCapabilities([
-            ...(schema.capabilities.resourceActions ?? []),
-            ...(schema.capabilities.objectActions ?? []),
-        ])
+        ? withServiceAvailability(
+            withRuntimeState(
+                normalizeCapabilities([
+                    ...(schema.capabilities.resourceActions ?? []),
+                    ...(schema.capabilities.objectActions ?? []),
+                ]),
+                status?.runtime === 'reachable',
+            ),
+            descriptor?.availability ?? 'coming_soon',
+        )
         : []
-    const capabilityLabels = capabilityList.length
-        ? capabilityList.map((capability) => capability.label).join(', ')
-        : schema?.actions.join(', ') ?? 'Loading actions'
+    const actionFallback = schema?.actions.join(', ') ?? 'Loading actions'
 
     return (
         <div className="modal-overlay" onClick={onClose}>
@@ -187,11 +154,25 @@ function ServiceInfoDialog({
                     <InfoCard label="Runtime" value={runtimeValue(cloud, status)} detail={runtimeDetail(status, statusLoading)} state={runtimeState(status, statusLoading)}/>
                     <InfoCard label="Adapter" value={adapterValue(cloud, status)} detail={adapterDetail(status, statusLoading)} state={adapterState(cloud, status)}/>
                     <InfoCard label="Connection" value={connectionValue(status, statusLoading)} detail={status?.endpoint ?? 'No runtime endpoint'} state={runtimeState(status, statusLoading)}/>
-                    <InfoCard label="Normalized Contract" value={schema?.columns.length ? `${schema.columns.length} columns` : 'Loading schema'} detail="Shared table and resource inspector"/>
+                    <InfoCard label="Normalized Contract" value={schema?.columns.length ? `${schema.columns.length} columns · ${schema.filters.length} filters` : 'Loading schema'} detail="Shared table and resource inspector"/>
                 </div>
                 <div className="service-info-section">
                     <p className="eyebrow">Supported Actions</p>
-                    <p className="service-info-copy">{capabilityLabels}</p>
+                    {capabilityList.length ? (
+                        <div className="capability-strip">
+                            {capabilityList.map((capability) => (
+                                <span
+                                    key={capability.name}
+                                    className={`capability-pill ${capability.status}`}
+                                    title={capability.reason}
+                                >
+                                    {capability.label}
+                                </span>
+                            ))}
+                        </div>
+                    ) : (
+                        <p className="service-info-copy">{actionFallback}</p>
+                    )}
                 </div>
                 <div className="service-info-section">
                     <p className="eyebrow">Current Limitations</p>


### PR DESCRIPTION
## Summary

The Cloud Explorer service page opened with two screens of diagnostic chrome (runtime card strip, dynamic-view panel with status badges and feature tiles, capability chip row) before showing any resources. This removes all of it: the resources table is now the first thing on the page, a compact ⓘ button next to the account switcher opens the service info dialog with all the diagnostics (per-action capability pills with status colors and tooltips, runtime/adapter/connection cards, columns/filters contract summary), and the resource inspector only renders when a resource is selected — the table spans full width otherwise.

Implementation notes: the explorer portals the ⓘ button into a `#topbar-status` slot in the app shell (the slot collapses on non-explorer pages), `withServiceAvailability` moves to `lib/capabilities` for reuse by the dialog, and dead components (`RuntimeCard`, `FeatureTile`, `CapabilityStrip`) plus ~350 lines of orphaned CSS are removed. Net −406 lines.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

Playwright-driven pass over all 18 cloud×service explorer routes on the docker compose dev stack (AWS S3 via Floci core, Azure Blob via Floci-AZ, GCP Storage via Floci-GCP, all seeded): the ⓘ renders on every route with zero console errors, the dialog opens from the topbar, the table takes full width until a row is clicked and the inspector appears on selection, the storage object browser and serverless invoke panel are unaffected, and the topbar slot stays empty on non-explorer pages (account switcher keeps its position). `pnpm type-check`, `pnpm test` (145/145), and `pnpm build` pass. Before/after screenshots to follow in a comment.

Note on lint: `pnpm lint` fails on main's pre-existing `react-hooks/rules-of-hooks` violations in `NetworkingPanel.tsx` (why the CI lint step is `continue-on-error`); the files touched here lint clean. #132 fixes those violations — once both merge, `continue-on-error` can be dropped.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally — lint caveat above: touched files clean, failures are pre-existing on main
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`) — UI-only change, no API/adapter behavior touched
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)