### PR TITLE
fix(docker): init scripts failing on Windows due to CRLF line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Force LF endings for scripts that run inside Linux containers, regardless
+# of the host OS or a contributor's core.autocrlf setting (Git for Windows
+# defaults to core.autocrlf=true, which otherwise checks these out as CRLF
+# and breaks `/bin/sh` parsing, e.g. "set -e" becoming "set -e\r").
+*.sh text eol=lf


### PR DESCRIPTION
## Summary
On Windows, Git's default `core.autocrlf=true` checks out `init/ready.d/01-setup.sh` and `init/seed-clouds.sh` with CRLF line endings. Inside the Linux container, `/bin/sh` fails to parse `set -e\r`, the ready hook errors out, and the `floci` container exits right after startup — breaking `docker compose up` for Windows users.

## Fix
Added `.gitattributes` forcing `eol=lf` for `*.sh` files, so these scripts always check out with LF regardless of OS or local Git config. No effect on Mac/Linux, since those already checkout as LF.

## Test plan
- [x] Reproduced the failure on Windows (`floci` container exits immediately, `floci-api` can't reach it)
- [x] Applied the `.gitattributes` fix and re-checked out the scripts
- [x] Ran `docker compose up` again — `floci` starts and stays healthy, init script completes