### PR TITLE
Feat/adding UI for aws sqs

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-rds": "^3.1076.0",
     "@aws-sdk/client-s3": "^3.1076.0",
     "@aws-sdk/client-secrets-manager": "^3.1076.0",
+    "@aws-sdk/client-sqs": "^3.1090.0",
     "dotenv": "^17.4.2",
     "hono": "^4.12.27"
   },

--- a/packages/api/src/adapter-aws/AwsQueueAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsQueueAdapter.test.ts
@@ -116,4 +116,65 @@ describe('AwsQueueAdapter', () => {
         await expect(adapter.deleteMessage(QUEUE_URL, 'receipt-1')).resolves.toBeUndefined()
         await expect(adapter.purgeQueue(QUEUE_URL)).resolves.toBeUndefined()
     })
+
+    test('list follows NextToken across multiple pages', async () => {
+        const pageTwoUrl = `${QUEUE_URL}-page2`
+        let call = 0
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            ListQueuesCommand: () => {
+                call += 1
+                if (call === 1) return {QueueUrls: [QUEUE_URL], NextToken: 'token-2'}
+                return {QueueUrls: [pageTwoUrl]}
+            },
+        }))
+
+        const result = await adapter.list()
+
+        expect(call).toBe(2)
+        expect(result.map((r) => r.id)).toEqual([QUEUE_URL, pageTwoUrl])
+    })
+
+    test('sendMessage rejects a FIFO queue without a messageGroupId', async () => {
+        const fifoUrl = `${QUEUE_URL}.fifo`
+        const adapter = new AwsQueueAdapter(fakeSqs())
+
+        await expect(adapter.sendMessage(fifoUrl, 'body')).rejects.toThrow(
+            'messageGroupId is required to send a message to a FIFO queue',
+        )
+    })
+
+    test('sendMessage passes messageGroupId and messageDeduplicationId for a FIFO queue', async () => {
+        const fifoUrl = `${QUEUE_URL}.fifo`
+        let captured: {MessageGroupId?: string; MessageDeduplicationId?: string} | undefined
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            SendMessageCommand: (input) => {
+                captured = input as typeof captured
+                return {MessageId: 'msg-1'}
+            },
+        }))
+
+        await adapter.sendMessage(fifoUrl, 'body', {
+            messageGroupId: 'group-1',
+            messageDeduplicationId: 'dedup-1',
+        })
+
+        expect(captured?.MessageGroupId).toBe('group-1')
+        expect(captured?.MessageDeduplicationId).toBe('dedup-1')
+    })
+
+    test('a malformed RedrivePolicy does not break list()', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            GetQueueAttributesCommand: () => ({
+                Attributes: {
+                    QueueArn: 'arn:aws:sqs:us-east-1:000000000000:orders',
+                    RedrivePolicy: 'not-valid-json{',
+                },
+            }),
+        }))
+
+        const result = await adapter.list()
+
+        expect(result).toHaveLength(1)
+        expect(result[0].metadata.redrivePolicy).toBeNull()
+    })
 })

--- a/packages/api/src/adapter-aws/AwsQueueAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsQueueAdapter.test.ts
@@ -1,0 +1,119 @@
+import {describe, expect, test} from 'bun:test'
+import {AwsQueueAdapter} from './AwsQueueAdapter'
+
+const QUEUE_URL = 'http://localhost:4566/000000000000/orders'
+
+function fakeSqs(overrides: Record<string, (input: unknown) => unknown> = {}) {
+    return {
+        async send(command: {constructor: {name: string}; input: unknown}) {
+            const handler = overrides[command.constructor.name]
+            if (handler) return handler(command.input)
+
+            switch (command.constructor.name) {
+                case 'ListQueuesCommand':
+                    return {QueueUrls: [QUEUE_URL]}
+                case 'GetQueueAttributesCommand':
+                    return {
+                        Attributes: {
+                            QueueArn: 'arn:aws:sqs:us-east-1:000000000000:orders',
+                            ApproximateNumberOfMessages: '3',
+                            ApproximateNumberOfMessagesNotVisible: '1',
+                            ApproximateNumberOfMessagesDelayed: '0',
+                            CreatedTimestamp: '1700000000',
+                            FifoQueue: 'false',
+                        },
+                    }
+                default:
+                    throw new Error(`Unhandled command: ${command.constructor.name}`)
+            }
+        },
+    } as never
+}
+
+describe('AwsQueueAdapter', () => {
+    test('list returns mapped CloudResource array with message counts in metadata', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs())
+        const result = await adapter.list()
+
+        expect(result).toHaveLength(1)
+        expect(result[0].id).toBe(QUEUE_URL)
+        expect(result[0].name).toBe('orders')
+        expect(result[0].cloud).toBe('aws')
+        expect(result[0].service).toBe('queue')
+        expect(result[0].type).toBe('queue')
+        expect(result[0].metadata.messagesAvailable).toBe(3)
+        expect(result[0].metadata.messagesInFlight).toBe(1)
+    })
+
+    test('list filters results by search term', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            ListQueuesCommand: () => ({QueueUrls: [QUEUE_URL, `${QUEUE_URL}-dlq`]}),
+        }))
+
+        const result = await adapter.list({search: 'orders-dlq'})
+
+        expect(result).toHaveLength(1)
+        expect(result[0].name).toBe('orders-dlq')
+    })
+
+    test('create builds a queue and returns the mapped resource', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            CreateQueueCommand: () => ({QueueUrl: QUEUE_URL}),
+        }))
+
+        const resource = await adapter.create({values: {queueName: 'orders'}})
+
+        expect(resource.id).toBe(QUEUE_URL)
+        expect(resource.name).toBe('orders')
+    })
+
+    test('create rejects a missing queueName', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs())
+        await expect(adapter.create({values: {}})).rejects.toThrow('queueName is required')
+    })
+
+    test('sendMessage returns the message id from the SDK response', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            SendMessageCommand: () => ({MessageId: 'msg-1'}),
+        }))
+
+        const message = await adapter.sendMessage(QUEUE_URL, '{"hello":"world"}')
+
+        expect(message.id).toBe('msg-1')
+        expect(message.body).toBe('{"hello":"world"}')
+    })
+
+    test('receiveMessages maps SDK messages into QueueMessage records', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            ReceiveMessageCommand: () => ({
+                Messages: [
+                    {
+                        MessageId: 'msg-1',
+                        ReceiptHandle: 'receipt-1',
+                        Body: '{"hello":"world"}',
+                        Attributes: {SentTimestamp: '1700000000000', ApproximateReceiveCount: '2'},
+                        MessageAttributes: {source: {StringValue: 'flow-panel', DataType: 'String'}},
+                    },
+                ],
+            }),
+        }))
+
+        const messages = await adapter.receiveMessages(QUEUE_URL)
+
+        expect(messages).toHaveLength(1)
+        expect(messages[0].id).toBe('msg-1')
+        expect(messages[0].receiptHandle).toBe('receipt-1')
+        expect(messages[0].receiveCount).toBe(2)
+        expect(messages[0].messageAttributes.source).toBe('flow-panel')
+    })
+
+    test('deleteMessage and purgeQueue delegate to the SDK without throwing', async () => {
+        const adapter = new AwsQueueAdapter(fakeSqs({
+            DeleteMessageCommand: () => ({}),
+            PurgeQueueCommand: () => ({}),
+        }))
+
+        await expect(adapter.deleteMessage(QUEUE_URL, 'receipt-1')).resolves.toBeUndefined()
+        await expect(adapter.purgeQueue(QUEUE_URL)).resolves.toBeUndefined()
+    })
+})

--- a/packages/api/src/adapter-aws/AwsQueueAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsQueueAdapter.ts
@@ -17,6 +17,7 @@ import type {
     CreateResourceInput,
     QueueMessage,
     ResourceQuery,
+    SendMessageOptions,
     ServiceSchema,
 } from '../cloud-spi/types'
 import {sqs as defaultSqs} from '../aws'
@@ -45,8 +46,14 @@ export class AwsQueueAdapter implements CloudServiceAdapter {
     }
 
     async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
-        const res = await this.sqs.send(new ListQueuesCommand({}))
-        const urls = res.QueueUrls ?? []
+        const urls: string[] = []
+        let nextToken: string | undefined
+
+        do {
+            const res = await this.sqs.send(new ListQueuesCommand({NextToken: nextToken}))
+            urls.push(...(res.QueueUrls ?? []))
+            nextToken = res.NextToken
+        } while (nextToken)
 
         const resources = await Promise.all(
             urls.map((url) => this.toResource(url)),
@@ -94,10 +101,19 @@ export class AwsQueueAdapter implements CloudServiceAdapter {
         await this.sqs.send(new DeleteQueueCommand({QueueUrl: id}))
     }
 
-    async sendMessage(queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage> {
+    async sendMessage(queueId: string, body: string, options: SendMessageOptions = {}): Promise<QueueMessage> {
+        const {messageAttributes, messageGroupId, messageDeduplicationId} = options
+        const isFifo = queueId.endsWith('.fifo')
+
+        if (isFifo && !messageGroupId) {
+            throw new Error('messageGroupId is required to send a message to a FIFO queue')
+        }
+
         const res = await this.sqs.send(new SendMessageCommand({
             QueueUrl: queueId,
             MessageBody: body,
+            MessageGroupId: messageGroupId,
+            MessageDeduplicationId: messageDeduplicationId,
             MessageAttributes: messageAttributes
                 ? Object.fromEntries(
                     Object.entries(messageAttributes).map(([key, value]) => [
@@ -182,7 +198,7 @@ export class AwsQueueAdapter implements CloudServiceAdapter {
                 visibilityTimeout: numberOr(attrs.VisibilityTimeout, null),
                 delaySeconds: numberOr(attrs.DelaySeconds, null),
                 messageRetentionPeriod: numberOr(attrs.MessageRetentionPeriod, null),
-                redrivePolicy: attrs.RedrivePolicy ? JSON.parse(attrs.RedrivePolicy) : null,
+                redrivePolicy: attrs.RedrivePolicy ? parseJsonSafe(attrs.RedrivePolicy) : null,
             },
         }
     }
@@ -207,6 +223,14 @@ function filterBySearch(resources: CloudResource[], search?: string): CloudResou
     const normalized = search?.trim().toLowerCase()
     if (!normalized) return resources
     return resources.filter((r) => r.name.toLowerCase().includes(normalized))
+}
+
+function parseJsonSafe(raw: string): unknown {
+    try {
+        return JSON.parse(raw)
+    } catch {
+        return null
+    }
 }
 
 function isQueueMissing(error: unknown): boolean {

--- a/packages/api/src/adapter-aws/AwsQueueAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsQueueAdapter.ts
@@ -1,0 +1,216 @@
+import {
+    CreateQueueCommand,
+    DeleteMessageCommand,
+    DeleteQueueCommand,
+    GetQueueAttributesCommand,
+    ListQueuesCommand,
+    PurgeQueueCommand,
+    QueueAttributeName,
+    ReceiveMessageCommand,
+    SendMessageCommand,
+    type SQSClient,
+} from '@aws-sdk/client-sqs'
+import {awsQueueSchema} from '../cloud-spi/queueSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    QueueMessage,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+import {sqs as defaultSqs} from '../aws'
+
+const ATTRIBUTES_FOR_LIST: QueueAttributeName[] = [
+    QueueAttributeName.QueueArn,
+    QueueAttributeName.ApproximateNumberOfMessages,
+    QueueAttributeName.ApproximateNumberOfMessagesNotVisible,
+    QueueAttributeName.ApproximateNumberOfMessagesDelayed,
+    QueueAttributeName.CreatedTimestamp,
+    QueueAttributeName.VisibilityTimeout,
+    QueueAttributeName.DelaySeconds,
+    QueueAttributeName.MessageRetentionPeriod,
+    QueueAttributeName.RedrivePolicy,
+    QueueAttributeName.FifoQueue,
+]
+
+export class AwsQueueAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'queue' as const
+
+    constructor(private readonly sqs: SQSClient = defaultSqs) {}
+
+    schema(): ServiceSchema {
+        return awsQueueSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const res = await this.sqs.send(new ListQueuesCommand({}))
+        const urls = res.QueueUrls ?? []
+
+        const resources = await Promise.all(
+            urls.map((url) => this.toResource(url)),
+        )
+
+        return filterBySearch(resources, query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        try {
+            return await this.toResource(id)
+        } catch (error) {
+            if (isQueueMissing(error)) return null
+            throw error
+        }
+    }
+
+    async create(input: CreateResourceInput): Promise<CloudResource> {
+        const values = input.values
+        const queueName = stringValue(values.queueName)
+        if (!queueName) throw new Error('queueName is required')
+
+        const fifo = String(values.fifo ?? '') === 'fifo' || queueName.endsWith('.fifo')
+        const name = fifo && !queueName.endsWith('.fifo') ? `${queueName}.fifo` : queueName
+
+        const attributes: Record<string, string> = {}
+        if (fifo) attributes.FifoQueue = 'true'
+        const visibilityTimeout = stringValue(values.visibilityTimeout)
+        if (visibilityTimeout) attributes.VisibilityTimeout = visibilityTimeout
+        const delaySeconds = stringValue(values.delaySeconds)
+        if (delaySeconds) attributes.DelaySeconds = delaySeconds
+        const messageRetentionPeriod = stringValue(values.messageRetentionPeriod)
+        if (messageRetentionPeriod) attributes.MessageRetentionPeriod = messageRetentionPeriod
+
+        const res = await this.sqs.send(new CreateQueueCommand({
+            QueueName: name,
+            Attributes: Object.keys(attributes).length ? attributes : undefined,
+        }))
+
+        if (!res.QueueUrl) throw new Error('Floci runtime did not return a queue URL')
+        return this.toResource(res.QueueUrl)
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.sqs.send(new DeleteQueueCommand({QueueUrl: id}))
+    }
+
+    async sendMessage(queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage> {
+        const res = await this.sqs.send(new SendMessageCommand({
+            QueueUrl: queueId,
+            MessageBody: body,
+            MessageAttributes: messageAttributes
+                ? Object.fromEntries(
+                    Object.entries(messageAttributes).map(([key, value]) => [
+                        key,
+                        {DataType: 'String', StringValue: value},
+                    ]),
+                )
+                : undefined,
+        }))
+
+        return {
+            id: res.MessageId ?? '',
+            receiptHandle: '',
+            body,
+            attributes: {},
+            messageAttributes: messageAttributes ?? {},
+            sentAt: new Date().toISOString(),
+            receiveCount: null,
+        }
+    }
+
+    async receiveMessages(queueId: string, maxMessages = 5, waitTimeSeconds = 0): Promise<QueueMessage[]> {
+        const res = await this.sqs.send(new ReceiveMessageCommand({
+            QueueUrl: queueId,
+            MaxNumberOfMessages: clamp(maxMessages, 1, 10),
+            WaitTimeSeconds: clamp(waitTimeSeconds, 0, 20),
+            MessageAttributeNames: ['All'],
+            AttributeNames: [QueueAttributeName.All],
+        }))
+
+        return (res.Messages ?? []).map((message) => ({
+            id: message.MessageId ?? '',
+            receiptHandle: message.ReceiptHandle ?? '',
+            body: message.Body ?? '',
+            attributes: message.Attributes ?? {},
+            messageAttributes: Object.fromEntries(
+                Object.entries(message.MessageAttributes ?? {}).map(([key, value]) => [key, value.StringValue ?? '']),
+            ),
+            sentAt: message.Attributes?.SentTimestamp
+                ? new Date(Number(message.Attributes.SentTimestamp)).toISOString()
+                : null,
+            receiveCount: message.Attributes?.ApproximateReceiveCount
+                ? Number(message.Attributes.ApproximateReceiveCount)
+                : null,
+        }))
+    }
+
+    async deleteMessage(queueId: string, receiptHandle: string): Promise<void> {
+        await this.sqs.send(new DeleteMessageCommand({QueueUrl: queueId, ReceiptHandle: receiptHandle}))
+    }
+
+    async purgeQueue(queueId: string): Promise<void> {
+        await this.sqs.send(new PurgeQueueCommand({QueueUrl: queueId}))
+    }
+
+    private async toResource(queueUrl: string): Promise<CloudResource> {
+        const res = await this.sqs.send(new GetQueueAttributesCommand({
+            QueueUrl: queueUrl,
+            AttributeNames: ATTRIBUTES_FOR_LIST,
+        }))
+        const attrs = res.Attributes ?? {}
+        const name = queueUrl.split('/').pop() ?? queueUrl
+
+        return {
+            id: queueUrl,
+            name,
+            cloud: 'aws',
+            service: 'queue',
+            type: 'queue',
+            region: null,
+            createdAt: attrs.CreatedTimestamp
+                ? new Date(Number(attrs.CreatedTimestamp) * 1000).toISOString()
+                : null,
+            status: 'Active',
+            metadata: {
+                queueUrl,
+                queueArn: attrs.QueueArn,
+                fifo: attrs.FifoQueue === 'true',
+                messagesAvailable: numberOr(attrs.ApproximateNumberOfMessages, 0),
+                messagesInFlight: numberOr(attrs.ApproximateNumberOfMessagesNotVisible, 0),
+                messagesDelayed: numberOr(attrs.ApproximateNumberOfMessagesDelayed, 0),
+                visibilityTimeout: numberOr(attrs.VisibilityTimeout, null),
+                delaySeconds: numberOr(attrs.DelaySeconds, null),
+                messageRetentionPeriod: numberOr(attrs.MessageRetentionPeriod, null),
+                redrivePolicy: attrs.RedrivePolicy ? JSON.parse(attrs.RedrivePolicy) : null,
+            },
+        }
+    }
+}
+
+function numberOr(value: string | undefined, fallback: number | null): number | null {
+    if (value === undefined) return fallback
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : fallback
+}
+
+function clamp(value: number, min: number, max: number): number {
+    if (!Number.isFinite(value)) return min
+    return Math.min(max, Math.max(min, value))
+}
+
+function stringValue(value: unknown): string {
+    return typeof value === 'string' ? value.trim() : ''
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((r) => r.name.toLowerCase().includes(normalized))
+}
+
+function isQueueMissing(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) return false
+    const name = (error as {name?: string}).name
+    return name === 'QueueDoesNotExist' || name === 'AWS.SimpleQueueService.NonExistentQueue'
+}

--- a/packages/api/src/aws.ts
+++ b/packages/api/src/aws.ts
@@ -4,6 +4,7 @@ import { EKSClient } from "@aws-sdk/client-eks";
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { RDSClient } from "@aws-sdk/client-rds";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { SQSClient } from "@aws-sdk/client-sqs";
 
 const endpoint = process.env.FLOCI_ENDPOINT;
 const region = process.env.AWS_REGION || "us-east-1";
@@ -39,6 +40,7 @@ export type AwsClients = {
   ec2: EC2Client;
   rds: RDSClient;
   secretsManager: SecretsManagerClient;
+  sqs: SQSClient;
 };
 
 export type AwsClientName = keyof AwsClients;
@@ -58,6 +60,7 @@ function buildClients(accountId: string): AwsClients {
     ec2: new EC2Client(base),
     rds: new RDSClient(base),
     secretsManager: new SecretsManagerClient(base),
+    sqs: new SQSClient(base),
   };
 }
 
@@ -89,3 +92,4 @@ export const eks = awsClients.eks;
 export const ec2 = awsClients.ec2;
 export const rds = awsClients.rds;
 export const secretsManager = awsClients.secretsManager;
+export const sqs = awsClients.sqs;

--- a/packages/api/src/cloud-spi/queueSchema.ts
+++ b/packages/api/src/cloud-spi/queueSchema.ts
@@ -1,0 +1,69 @@
+import type {CloudProvider, FieldSchema, ServiceSchema, TableColumnSchema} from './types'
+
+const queueColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Queue Name'},
+    {name: 'type', label: 'Type'},
+    {name: 'cloud', label: 'Cloud'},
+    {name: 'status', label: 'Status'},
+    {name: 'createdAt', label: 'Created At'},
+]
+
+const queueFilters: FieldSchema[] = [
+    {name: 'search', label: 'Search', type: 'text', required: false},
+]
+
+export function awsQueueSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'queue',
+        displayName: 'Amazon SQS',
+        fields: [
+            {
+                name: 'queueName',
+                label: 'Queue Name',
+                type: 'text',
+                required: true,
+                description: 'Up to 80 characters: alphanumeric, hyphens, and underscores. FIFO queues must end in ".fifo".',
+            },
+            {
+                name: 'fifo',
+                label: 'Queue Type',
+                type: 'select',
+                required: false,
+                options: [
+                    {label: 'Standard', value: 'standard'},
+                    {label: 'FIFO', value: 'fifo'},
+                ],
+            },
+            {
+                name: 'visibilityTimeout',
+                label: 'Visibility Timeout (seconds)',
+                type: 'text',
+                required: false,
+                description: 'Default: 30.',
+            },
+            {
+                name: 'delaySeconds',
+                label: 'Delivery Delay (seconds)',
+                type: 'text',
+                required: false,
+                description: 'Default: 0.',
+            },
+            {
+                name: 'messageRetentionPeriod',
+                label: 'Message Retention (seconds)',
+                type: 'text',
+                required: false,
+                description: 'Default: 345600 (4 days).',
+            },
+        ],
+        actions: ['list', 'create', 'inspect', 'delete'],
+        filters: queueFilters,
+        columns: queueColumns,
+    }
+}
+
+export function queueSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    if (cloud === 'aws') return awsQueueSchema()
+    return null
+}

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -147,6 +147,12 @@ export interface QueueMessage {
     receiveCount: number | null
 }
 
+export interface SendMessageOptions {
+    messageAttributes?: Record<string, string>
+    messageGroupId?: string
+    messageDeduplicationId?: string
+}
+
 export interface ResourceQuery {
     search?: string
 }
@@ -182,7 +188,7 @@ export interface CloudServiceAdapter {
     upsertCosmosItem?(databaseId: string, containerId: string, document: Record<string, unknown>): Promise<CosmosItem>
     deleteCosmosItem?(databaseId: string, containerId: string, itemId: string, partitionKey?: string | null): Promise<void>
     queryCosmosItems?(databaseId: string, containerId: string, query: string): Promise<CosmosQueryResult>
-    sendMessage?(queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage>
+    sendMessage?(queueId: string, body: string, options?: SendMessageOptions): Promise<QueueMessage>
     receiveMessages?(queueId: string, maxMessages?: number, waitTimeSeconds?: number): Promise<QueueMessage[]>
     deleteMessage?(queueId: string, receiptHandle: string): Promise<void>
     purgeQueue?(queueId: string): Promise<void>

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -1,6 +1,6 @@
 export type CloudProvider = 'aws' | 'azure' | 'gcp'
 
-export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'serverless' | 'compute' | 'networking'
+export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'serverless' | 'compute' | 'networking' | 'queue'
 
 export type CloudAvailability = 'available' | 'coming_soon'
 
@@ -83,7 +83,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'queue'
     region: string | null
     createdAt: string | null
     status?: string | null
@@ -137,6 +137,16 @@ export interface CosmosQueryResult {
     count: number
 }
 
+export interface QueueMessage {
+    id: string
+    receiptHandle: string
+    body: string
+    attributes: Record<string, string>
+    messageAttributes: Record<string, string>
+    sentAt: string | null
+    receiveCount: number | null
+}
+
 export interface ResourceQuery {
     search?: string
 }
@@ -172,4 +182,8 @@ export interface CloudServiceAdapter {
     upsertCosmosItem?(databaseId: string, containerId: string, document: Record<string, unknown>): Promise<CosmosItem>
     deleteCosmosItem?(databaseId: string, containerId: string, itemId: string, partitionKey?: string | null): Promise<void>
     queryCosmosItems?(databaseId: string, containerId: string, query: string): Promise<CosmosQueryResult>
+    sendMessage?(queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage>
+    receiveMessages?(queueId: string, maxMessages?: number, waitTimeSeconds?: number): Promise<QueueMessage[]>
+    deleteMessage?(queueId: string, receiptHandle: string): Promise<void>
+    purgeQueue?(queueId: string): Promise<void>
 }

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -11,6 +11,7 @@ import {GcpCloudFunctionsAdapter} from './adapter-gcp/GcpCloudFunctionsAdapter'
 import {CloudProxyService} from './service/CloudProxyService'
 import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
+import {AwsQueueAdapter} from './adapter-aws/AwsQueueAdapter'
 import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
@@ -33,6 +34,7 @@ export function createCloudProxyService(accountId?: string | null): CloudProxySe
         new AwsComputeAdapter(ec2Service),
         new AwsNetworkingAdapter(ec2Service),
         new AwsServerlessAdapter(clients.lambda),
+        new AwsQueueAdapter(clients.sqs),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -235,9 +235,18 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
 
         return withRuntime(c, async () => {
-            const body = await c.req.json<{body?: string; messageAttributes?: Record<string, string>}>()
+            const body = await c.req.json<{
+                body?: string
+                messageAttributes?: Record<string, string>
+                messageGroupId?: string
+                messageDeduplicationId?: string
+            }>()
             if (!body.body) return c.json({error: 'body is required', code: 'invalid_request', message: 'body is required'}, 400)
-            const message = await svc(c).sendQueueMessage(cloud, c.req.param('id'), body.body, body.messageAttributes)
+            const message = await svc(c).sendQueueMessage(cloud, c.req.param('id'), body.body, {
+                messageAttributes: body.messageAttributes,
+                messageGroupId: body.messageGroupId,
+                messageDeduplicationId: body.messageDeduplicationId,
+            })
             return c.json(message, 201)
         })
     })

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -230,6 +230,54 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         })
     })
 
+    app.post('/:cloud/services/queue/resources/:id/messages', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const body = await c.req.json<{body?: string; messageAttributes?: Record<string, string>}>()
+            if (!body.body) return c.json({error: 'body is required', code: 'invalid_request', message: 'body is required'}, 400)
+            const message = await svc(c).sendQueueMessage(cloud, c.req.param('id'), body.body, body.messageAttributes)
+            return c.json(message, 201)
+        })
+    })
+
+    app.get('/:cloud/services/queue/resources/:id/messages', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const maxMessages = Number(c.req.query('maxMessages') ?? '5')
+            const waitTimeSeconds = Number(c.req.query('waitTimeSeconds') ?? '0')
+            const messages = await svc(c).receiveQueueMessages(cloud, c.req.param('id'), maxMessages, waitTimeSeconds)
+            return c.json(messages)
+        })
+    })
+
+    app.post('/:cloud/services/queue/resources/:id/messages/delete', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const body = await c.req.json<{receiptHandle?: string}>()
+            if (!body.receiptHandle) {
+                return c.json({error: 'receiptHandle is required', code: 'invalid_request', message: 'receiptHandle is required'}, 400)
+            }
+            await svc(c).deleteQueueMessage(cloud, c.req.param('id'), body.receiptHandle)
+            return c.json({ok: true})
+        })
+    })
+
+    app.post('/:cloud/services/queue/resources/:id/purge', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            await svc(c).purgeQueue(cloud, c.req.param('id'))
+            return c.json({ok: true})
+        })
+    })
+
     app.post('/:cloud/services/:service/resources', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         const serviceType = c.req.param('service') as CloudServiceType
@@ -261,7 +309,7 @@ function isCloudProvider(value: string): value is CloudProvider {
 }
 
 function isServiceType(value: string): value is CloudServiceType {
-    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'serverless' || value === 'compute' || value === 'networking'
+    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'serverless' || value === 'compute' || value === 'networking' || value === 'queue'
 }
 
 async function withRuntime(c: Context, handler: () => Promise<Response>): Promise<Response> {

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -9,6 +9,7 @@ import type {
     CosmosItem,
     CosmosQueryResult,
     CreateResourceInput,
+    QueueMessage,
     ResourceQuery,
     ServerlessInvokeResult,
     ServiceSchema,
@@ -18,6 +19,7 @@ import type {
 import {storageSchemaFor} from '../cloud-spi/storageSchema'
 import {CloudAdapterRegistry} from '../registry/CloudAdapterRegistry'
 import {serverlessSchemaFor} from '../cloud-spi/serverlessSchema'
+import {queueSchemaFor} from '../cloud-spi/queueSchema'
 import {k8sSchemaFor} from '../cloud-spi/eksSchema'
 import {databaseSchemaFor} from '../cloud-spi/databaseSchema'
 import {azureEndpoint} from '../azure'
@@ -73,6 +75,12 @@ export class CloudProxyService {
             displayName: 'Networking',
             availability: this.registry.get(cloud, 'networking') ? 'available' : 'coming_soon',
         })
+        services.push({
+            cloud,
+            service: 'queue',
+            displayName: 'Queue',
+            availability: this.registry.get(cloud, 'queue') ? 'available' : 'coming_soon',
+        })
         return services
     }
 
@@ -83,6 +91,7 @@ export class CloudProxyService {
         if (service === 'k8s') return k8sSchemaFor(cloud)
         if (service === 'database') return databaseSchemaFor(cloud)
         if (service === 'serverless') return serverlessSchemaFor(cloud)
+        if (service === 'queue') return queueSchemaFor(cloud)
         return null
     }
 
@@ -169,6 +178,30 @@ async invokeResource(
     if (!adapter.invoke) throw new Error(`${cloud}/${service} invoke is not supported`)
     return adapter.invoke(id, payload)
 }
+    async sendQueueMessage(cloud: CloudProvider, queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage> {
+        const adapter = this.requireAdapter(cloud, 'queue')
+        if (!adapter.sendMessage) throw new Error(`${cloud}/queue send message is not supported`)
+        return adapter.sendMessage(queueId, body, messageAttributes)
+    }
+
+    async receiveQueueMessages(cloud: CloudProvider, queueId: string, maxMessages?: number, waitTimeSeconds?: number): Promise<QueueMessage[]> {
+        const adapter = this.requireAdapter(cloud, 'queue')
+        if (!adapter.receiveMessages) throw new Error(`${cloud}/queue receive messages is not supported`)
+        return adapter.receiveMessages(queueId, maxMessages, waitTimeSeconds)
+    }
+
+    async deleteQueueMessage(cloud: CloudProvider, queueId: string, receiptHandle: string): Promise<void> {
+        const adapter = this.requireAdapter(cloud, 'queue')
+        if (!adapter.deleteMessage) throw new Error(`${cloud}/queue delete message is not supported`)
+        await adapter.deleteMessage(queueId, receiptHandle)
+    }
+
+    async purgeQueue(cloud: CloudProvider, queueId: string): Promise<void> {
+        const adapter = this.requireAdapter(cloud, 'queue')
+        if (!adapter.purgeQueue) throw new Error(`${cloud}/queue purge is not supported`)
+        await adapter.purgeQueue(queueId)
+    }
+
     async listObjects(cloud: CloudProvider, service: CloudServiceType, resourceId: string, prefix?: string): Promise<StorageObjectList> {
         const adapter = this.requireAdapter(cloud, service)
         if (!adapter.listObjects) throw new Error(`Object listing is not supported for ${cloud}/${service}`)

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -11,6 +11,7 @@ import type {
     CreateResourceInput,
     QueueMessage,
     ResourceQuery,
+    SendMessageOptions,
     ServerlessInvokeResult,
     ServiceSchema,
     StorageObjectDownload,
@@ -178,10 +179,10 @@ async invokeResource(
     if (!adapter.invoke) throw new Error(`${cloud}/${service} invoke is not supported`)
     return adapter.invoke(id, payload)
 }
-    async sendQueueMessage(cloud: CloudProvider, queueId: string, body: string, messageAttributes?: Record<string, string>): Promise<QueueMessage> {
+    async sendQueueMessage(cloud: CloudProvider, queueId: string, body: string, options?: SendMessageOptions): Promise<QueueMessage> {
         const adapter = this.requireAdapter(cloud, 'queue')
         if (!adapter.sendMessage) throw new Error(`${cloud}/queue send message is not supported`)
-        return adapter.sendMessage(queueId, body, messageAttributes)
+        return adapter.sendMessage(queueId, body, options)
     }
 
     async receiveQueueMessages(cloud: CloudProvider, queueId: string, maxMessages?: number, waitTimeSeconds?: number): Promise<QueueMessage[]> {

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -21,6 +21,14 @@ export const apiEndpointKeys = {
       delete: "clouds.services.resources.delete",
       invoke: "clouds.services.resources.invoke",
     },
+    queue: {
+      messages: {
+        send: "clouds.services.queue.messages.send",
+        receive: "clouds.services.queue.messages.receive",
+        delete: "clouds.services.queue.messages.delete",
+      },
+      purge: "clouds.services.queue.purge",
+    },
     storage: {
       objects: {
         list: "clouds.services.storage.objects.list",
@@ -252,6 +260,38 @@ export const endpointRegistry: EndpointRegistry = new Map([
   },
 ],
 
+  [
+    apiEndpointKeys.clouds.queue.messages.send,
+    {
+      path: "/clouds/:cloud/services/queue/resources/:id/messages",
+      method: "POST",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.queue.messages.receive,
+    {
+      path: "/clouds/:cloud/services/queue/resources/:id/messages",
+      method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.queue.messages.delete,
+    {
+      path: "/clouds/:cloud/services/queue/resources/:id/messages/delete",
+      method: "POST",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.queue.purge,
+    {
+      path: "/clouds/:cloud/services/queue/resources/:id/purge",
+      method: "POST",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
   [
     apiEndpointKeys.clouds.storage.objects.list,
     {

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -6,7 +6,7 @@ import type {
   CloudServiceType,
   CloudStatus,
 } from "@/types/cloud";
-import type { CloudResource, CosmosContainer, CosmosItem, CosmosQueryResult, StorageObjectList } from "@/types/resource";
+import type { CloudResource, CosmosContainer, CosmosItem, CosmosQueryResult, QueueMessage, StorageObjectList } from "@/types/resource";
 import type { ServiceSchema } from "@/types/schema";
 import { getAccountId } from "@/lib/accountStore";
 
@@ -142,6 +142,70 @@ export async function invokeCloudResource(
     { cloud, service, id },
   );
   return res.data;
+}
+
+export async function sendQueueMessage(
+  cloud: CloudProvider,
+  queueId: string,
+  body: string,
+  messageAttributes?: Record<string, string>,
+  signal?: AbortSignal,
+): Promise<QueueMessage> {
+  const res = await apiClient.call<
+    QueueMessage,
+    { body: string; messageAttributes?: Record<string, string> }
+  >(
+    apiEndpointKeys.clouds.queue.messages.send,
+    requestOptions(cloud, "queue", {
+      signal,
+      body: { body, messageAttributes },
+    }),
+    { cloud, id: queueId },
+  );
+  return res.data;
+}
+
+export async function receiveQueueMessages(
+  cloud: CloudProvider,
+  queueId: string,
+  maxMessages?: number,
+  waitTimeSeconds?: number,
+  signal?: AbortSignal,
+): Promise<QueueMessage[]> {
+  const res = await apiClient.call<QueueMessage[]>(
+    apiEndpointKeys.clouds.queue.messages.receive,
+    requestOptions(cloud, "queue", {
+      signal,
+      params: { maxMessages, waitTimeSeconds },
+    }),
+    { cloud, id: queueId },
+  );
+  return res.data;
+}
+
+export async function deleteQueueMessage(
+  cloud: CloudProvider,
+  queueId: string,
+  receiptHandle: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiClient.call<void, { receiptHandle: string }>(
+    apiEndpointKeys.clouds.queue.messages.delete,
+    requestOptions(cloud, "queue", { signal, body: { receiptHandle } }),
+    { cloud, id: queueId },
+  );
+}
+
+export async function purgeQueue(
+  cloud: CloudProvider,
+  queueId: string,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiClient.call<void>(
+    apiEndpointKeys.clouds.queue.purge,
+    requestOptions(cloud, "queue", { signal }),
+    { cloud, id: queueId },
+  );
 }
 
 export async function listStorageObjects(

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -144,21 +144,27 @@ export async function invokeCloudResource(
   return res.data;
 }
 
+export interface SendQueueMessageOptions {
+  messageAttributes?: Record<string, string>;
+  messageGroupId?: string;
+  messageDeduplicationId?: string;
+}
+
 export async function sendQueueMessage(
   cloud: CloudProvider,
   queueId: string,
   body: string,
-  messageAttributes?: Record<string, string>,
+  options?: SendQueueMessageOptions,
   signal?: AbortSignal,
 ): Promise<QueueMessage> {
   const res = await apiClient.call<
     QueueMessage,
-    { body: string; messageAttributes?: Record<string, string> }
+    { body: string } & SendQueueMessageOptions
   >(
     apiEndpointKeys.clouds.queue.messages.send,
     requestOptions(cloud, "queue", {
       signal,
-      body: { body, messageAttributes },
+      body: { body, ...options },
     }),
     { cloud, id: queueId },
   );

--- a/packages/frontend/src/components/DynamicResourceView.tsx
+++ b/packages/frontend/src/components/DynamicResourceView.tsx
@@ -31,6 +31,7 @@ import type { CloudResource, StorageObject } from "@/types/resource";
 import type { ServiceSchema } from "@/types/schema";
 import { CosmosNoSqlPanel } from "@/components/CosmosNoSqlPanel";
 import { ServerlessInvokePanel } from "@/components/ServerlessInvokePanel";
+import { QueueFlowPanel } from "@/components/QueueFlowPanel";
 
 interface DynamicResourceViewProps {
   cloud: CloudProvider;
@@ -325,6 +326,13 @@ export function DynamicResourceView({
     runtimeReachable={canUseRuntime}
   />
 )}
+      {service === "queue" && (
+        <QueueFlowPanel
+          cloud={cloud}
+          resource={activeSelected}
+          runtimeReachable={canUseRuntime}
+        />
+      )}
     </div>
   );
 }
@@ -355,6 +363,7 @@ function resourceCreateLabel(schema: ServiceSchema): string {
     return "Create container";
   if (schema.cloud === "azure" && schema.service === "database")
     return "Create database";
+  if (schema.service === "queue") return "Create queue";
   return "Create resource";
 }
 

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -52,7 +52,7 @@ const CLOUD_SERVICE_ITEMS: Array<{name: CloudSidebarService; label: string; rout
     {name: 'networking', label: 'Networking', route: 'networking'},
     {name: 'secretsmanager', label: 'Secrets Manager', route: '/secretsmanager'},
     {name: 'serverless', label: 'Serverless', route: 'serverless'},
-    {name: 'queue', label: 'Queue'},
+    {name: 'queue', label: 'Queue', route: 'queue'},
     {name: 'function', label: 'Function'},
 ]
 
@@ -71,6 +71,7 @@ function CloudServiceNav() {
                     || (service.name === 'database' && (cloud === 'aws' || cloud === 'azure'))
                     || ((service.name === 'k8s' || service.name === 'compute' || service.name === 'networking') && cloud === 'aws')
                     || (service.name === 'serverless' && (cloud === 'aws' || cloud === 'azure'))
+                    || (service.name === 'queue' && cloud === 'aws')
                 if (service.route && available) {
                     const target = service.route.startsWith('/') ? service.route : `/cloud-explorer/${cloud}/${service.route}`
                     return <NavItem key={service.name} to={target} icon={Icon} label={service.label}/>

--- a/packages/frontend/src/components/QueueFlowPanel.tsx
+++ b/packages/frontend/src/components/QueueFlowPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   Eraser,
@@ -29,6 +29,7 @@ interface QueueFlowPanelProps {
 }
 
 interface AttributeRow {
+  id: number;
   key: string;
   value: string;
 }
@@ -48,15 +49,20 @@ export function QueueFlowPanel({
 
   const [sendBody, setSendBody] = useState('{\n  \n}');
   const [attributeRows, setAttributeRows] = useState<AttributeRow[]>([]);
+  const [messageGroupId, setMessageGroupId] = useState("");
+  const [messageDeduplicationId, setMessageDeduplicationId] = useState("");
   const [longPoll, setLongPoll] = useState(false);
   const [maxMessages, setMaxMessages] = useState(5);
   const [messages, setMessages] = useState<QueueMessage[]>([]);
   const [purgeConfirm, setPurgeConfirm] = useState(false);
   const [lastSentId, setLastSentId] = useState<string | null>(null);
+  const nextAttrId = useRef(0);
 
   useEffect(() => {
     setSendBody('{\n  \n}');
     setAttributeRows([]);
+    setMessageGroupId("");
+    setMessageDeduplicationId("");
     setMessages([]);
     setPurgeConfirm(false);
     setLastSentId(null);
@@ -74,9 +80,17 @@ export function QueueFlowPanel({
   const live = detailQuery.data ?? resource;
   const isQueue = resource?.service === "queue";
 
+  const isFifoQueue = Boolean(queueId?.endsWith(".fifo"));
+
   const sendMut = useMutation({
     mutationFn: () =>
-      sendQueueMessage(cloud, queueId ?? "", sendBody, attributesRecord(attributeRows)),
+      sendQueueMessage(cloud, queueId ?? "", sendBody, {
+        messageAttributes: attributesRecord(attributeRows),
+        messageGroupId: isFifoQueue ? messageGroupId.trim() : undefined,
+        messageDeduplicationId: isFifoQueue
+          ? messageDeduplicationId.trim() || undefined
+          : undefined,
+      }),
     onSuccess: (message) => {
       setLastSentId(message.id);
       void qc.invalidateQueries({ queryKey: detailKey });
@@ -152,15 +166,25 @@ export function QueueFlowPanel({
             {canOperate ? "Ready" : "Runtime unavailable"}
           </span>
           {purgeConfirm ? (
-            <button
-              className="button danger compact"
-              type="button"
-              disabled={purgeMut.isPending}
-              onClick={() => purgeMut.mutate()}
-            >
-              {purgeMut.isPending ? <Loader2 size={13} className="spin" /> : <Eraser size={13} />}
-              Confirm purge
-            </button>
+            <>
+              <button
+                className="button danger compact"
+                type="button"
+                disabled={purgeMut.isPending}
+                onClick={() => purgeMut.mutate()}
+              >
+                {purgeMut.isPending ? <Loader2 size={13} className="spin" /> : <Eraser size={13} />}
+                Confirm purge
+              </button>
+              <button
+                className="button"
+                type="button"
+                disabled={purgeMut.isPending}
+                onClick={() => setPurgeConfirm(false)}
+              >
+                Cancel
+              </button>
+            </>
           ) : (
             <button
               className="button"
@@ -257,25 +281,41 @@ export function QueueFlowPanel({
             placeholder="Message body"
             style={{ minHeight: 110 }}
           />
-          {attributeRows.map((row, index) => (
-            <div className="queue-attr-row" key={index}>
+          {isFifoQueue && (
+            <>
+              <input
+                className="input"
+                placeholder="Message group ID (required for FIFO)"
+                value={messageGroupId}
+                onChange={(event) => setMessageGroupId(event.target.value)}
+              />
+              <input
+                className="input"
+                placeholder="Message deduplication ID (optional)"
+                value={messageDeduplicationId}
+                onChange={(event) => setMessageDeduplicationId(event.target.value)}
+              />
+            </>
+          )}
+          {attributeRows.map((row) => (
+            <div className="queue-attr-row" key={row.id}>
               <input
                 className="input"
                 placeholder="Attribute name"
                 value={row.key}
-                onChange={(event) => updateAttributeRow(index, { key: event.target.value })}
+                onChange={(event) => updateAttributeRow(row.id, { key: event.target.value })}
               />
               <input
                 className="input"
                 placeholder="Value"
                 value={row.value}
-                onChange={(event) => updateAttributeRow(index, { value: event.target.value })}
+                onChange={(event) => updateAttributeRow(row.id, { value: event.target.value })}
               />
               <button
                 className="icon-btn"
                 type="button"
                 title="Remove attribute"
-                onClick={() => setAttributeRows((rows) => rows.filter((_, i) => i !== index))}
+                onClick={() => setAttributeRows((rows) => rows.filter((r) => r.id !== row.id))}
               >
                 <X size={13} />
               </button>
@@ -284,7 +324,12 @@ export function QueueFlowPanel({
           <button
             className="button"
             type="button"
-            onClick={() => setAttributeRows((rows) => [...rows, { key: "", value: "" }])}
+            onClick={() =>
+              setAttributeRows((rows) => [
+                ...rows,
+                { id: nextAttrId.current++, key: "", value: "" },
+              ])
+            }
           >
             <Plus size={13} />
             Add message attribute
@@ -292,7 +337,12 @@ export function QueueFlowPanel({
           <button
             className="button primary"
             type="button"
-            disabled={!canOperate || sendMut.isPending || !sendBody.trim()}
+            disabled={
+              !canOperate ||
+              sendMut.isPending ||
+              !sendBody.trim() ||
+              (isFifoQueue && !messageGroupId.trim())
+            }
             onClick={() => sendMut.mutate()}
           >
             {sendMut.isPending ? <Loader2 size={13} className="spin" /> : <Send size={13} />}
@@ -381,9 +431,9 @@ export function QueueFlowPanel({
     </section>
   );
 
-  function updateAttributeRow(index: number, patch: Partial<AttributeRow>) {
+  function updateAttributeRow(id: number, patch: Partial<AttributeRow>) {
     setAttributeRows((rows) =>
-      rows.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+      rows.map((row) => (row.id === id ? { ...row, ...patch } : row)),
     );
   }
 }

--- a/packages/frontend/src/components/QueueFlowPanel.tsx
+++ b/packages/frontend/src/components/QueueFlowPanel.tsx
@@ -98,13 +98,13 @@ export function QueueFlowPanel({
   });
 
   const receiveMut = useMutation({
-    mutationFn: () =>
-      receiveQueueMessages(cloud, queueId ?? "", maxMessages, longPoll ? 5 : 0),
-    onSuccess: (received) => {
-      if (received.length === 0) return;
+    mutationFn: (targetQueueId: string) =>
+      receiveQueueMessages(cloud, targetQueueId, maxMessages, longPoll ? 5 : 0),
+    onSuccess: (received, targetQueueId) => {
+      if (targetQueueId !== queueId || received.length === 0) return;
       setMessages((current) => {
-        const seen = new Set(current.map((m) => m.receiptHandle));
-        return [...received.filter((m) => !seen.has(m.receiptHandle)), ...current];
+        const seen = new Set(current.map((m) => m.id));
+        return [...received.filter((m) => !seen.has(m.id)), ...current];
       });
       void qc.invalidateQueries({ queryKey: detailKey });
     },
@@ -391,7 +391,7 @@ export function QueueFlowPanel({
             className="button"
             type="button"
             disabled={!canOperate || receiveMut.isPending}
-            onClick={() => receiveMut.mutate()}
+            onClick={() => receiveMut.mutate(queueId ?? "")}
           >
             {receiveMut.isPending ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />}
             {receiveMut.isPending ? "Polling" : "Poll for messages"}

--- a/packages/frontend/src/components/QueueFlowPanel.tsx
+++ b/packages/frontend/src/components/QueueFlowPanel.tsx
@@ -1,0 +1,400 @@
+import { useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  Eraser,
+  Inbox,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Send,
+  Trash2,
+  Users,
+  X,
+} from "lucide-react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  deleteQueueMessage,
+  getCloudResource,
+  purgeQueue,
+  receiveQueueMessages,
+  sendQueueMessage,
+} from "@/api/cloudProxyClient";
+import type { CloudProvider } from "@/types/cloud";
+import type { CloudResource, QueueMessage } from "@/types/resource";
+
+interface QueueFlowPanelProps {
+  cloud: CloudProvider;
+  resource?: CloudResource;
+  runtimeReachable: boolean;
+}
+
+interface AttributeRow {
+  key: string;
+  value: string;
+}
+
+interface RedrivePolicy {
+  deadLetterTargetArn?: string;
+  maxReceiveCount?: number;
+}
+
+export function QueueFlowPanel({
+  cloud,
+  resource,
+  runtimeReachable,
+}: QueueFlowPanelProps) {
+  const qc = useQueryClient();
+  const queueId = resource?.id;
+
+  const [sendBody, setSendBody] = useState('{\n  \n}');
+  const [attributeRows, setAttributeRows] = useState<AttributeRow[]>([]);
+  const [longPoll, setLongPoll] = useState(false);
+  const [maxMessages, setMaxMessages] = useState(5);
+  const [messages, setMessages] = useState<QueueMessage[]>([]);
+  const [purgeConfirm, setPurgeConfirm] = useState(false);
+  const [lastSentId, setLastSentId] = useState<string | null>(null);
+
+  useEffect(() => {
+    setSendBody('{\n  \n}');
+    setAttributeRows([]);
+    setMessages([]);
+    setPurgeConfirm(false);
+    setLastSentId(null);
+  }, [queueId]);
+
+  const detailKey = ["queue-detail", cloud, queueId];
+  const detailQuery = useQuery({
+    queryKey: detailKey,
+    queryFn: ({ signal }) =>
+      getCloudResource(cloud, "queue", queueId ?? "", signal),
+    enabled: Boolean(queueId) && runtimeReachable,
+    refetchInterval: 4000,
+  });
+
+  const live = detailQuery.data ?? resource;
+  const isQueue = resource?.service === "queue";
+
+  const sendMut = useMutation({
+    mutationFn: () =>
+      sendQueueMessage(cloud, queueId ?? "", sendBody, attributesRecord(attributeRows)),
+    onSuccess: (message) => {
+      setLastSentId(message.id);
+      void qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+
+  const receiveMut = useMutation({
+    mutationFn: () =>
+      receiveQueueMessages(cloud, queueId ?? "", maxMessages, longPoll ? 5 : 0),
+    onSuccess: (received) => {
+      if (received.length === 0) return;
+      setMessages((current) => {
+        const seen = new Set(current.map((m) => m.receiptHandle));
+        return [...received.filter((m) => !seen.has(m.receiptHandle)), ...current];
+      });
+      void qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+
+  const deleteMut = useMutation({
+    mutationFn: (message: QueueMessage) =>
+      deleteQueueMessage(cloud, queueId ?? "", message.receiptHandle),
+    onSuccess: (_, message) => {
+      setMessages((current) => current.filter((m) => m.receiptHandle !== message.receiptHandle));
+      void qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+
+  const purgeMut = useMutation({
+    mutationFn: () => purgeQueue(cloud, queueId ?? ""),
+    onSuccess: () => {
+      setMessages([]);
+      setPurgeConfirm(false);
+      void qc.invalidateQueries({ queryKey: detailKey });
+    },
+  });
+
+  if (!resource || !isQueue) {
+    return (
+      <section className="table-panel">
+        <div className="empty compact">
+          <h3>Select a queue</h3>
+          <p>Select an SQS queue to send and receive messages.</p>
+        </div>
+      </section>
+    );
+  }
+
+  const messagesAvailable = numberMetadata(live?.metadata.messagesAvailable);
+  const messagesInFlight = numberMetadata(live?.metadata.messagesInFlight);
+  const messagesDelayed = numberMetadata(live?.metadata.messagesDelayed);
+  const fifo = Boolean(live?.metadata.fifo);
+  const redrivePolicy = live?.metadata.redrivePolicy as RedrivePolicy | null | undefined;
+  const dlqName = redrivePolicy?.deadLetterTargetArn?.split(":").pop() ?? null;
+
+  const canOperate = Boolean(queueId) && runtimeReachable;
+
+  return (
+    <section className="table-panel queue-flow-panel">
+      <div className="dynamic-stage-header">
+        <div>
+          <p className="eyebrow">Queue Actions</p>
+          <h3>
+            <Inbox size={15} />
+            Send and receive messages
+          </h3>
+          <p className="muted compact-text">
+            {resource.name} {fifo ? "· FIFO queue" : "· Standard queue"}
+          </p>
+        </div>
+        <div className="flow-row-actions" style={{ display: "flex", gap: 8, alignItems: "center" }}>
+          <span className={`runtime-state ${canOperate ? "ready" : "pending"}`}>
+            {canOperate ? "Ready" : "Runtime unavailable"}
+          </span>
+          {purgeConfirm ? (
+            <button
+              className="button danger compact"
+              type="button"
+              disabled={purgeMut.isPending}
+              onClick={() => purgeMut.mutate()}
+            >
+              {purgeMut.isPending ? <Loader2 size={13} className="spin" /> : <Eraser size={13} />}
+              Confirm purge
+            </button>
+          ) : (
+            <button
+              className="button"
+              type="button"
+              disabled={!canOperate}
+              onClick={() => setPurgeConfirm(true)}
+            >
+              <Eraser size={13} />
+              Purge queue
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="queue-flow-diagram">
+        <div className="queue-flow-node">
+          <div className="queue-flow-node-icon">
+            <Send size={16} />
+          </div>
+          <span className="queue-flow-node-label">Producer</span>
+          <span className="queue-flow-node-sublabel">Your application</span>
+        </div>
+
+        <div className={`queue-flow-connector ${sendMut.isPending ? "flow-dot-active" : ""}`}>
+          <span className="flow-dot" />
+        </div>
+
+        <div className="queue-flow-node queue-flow-node--active">
+          <div className="queue-flow-node-icon">
+            <Inbox size={16} />
+          </div>
+          <span className="queue-flow-node-label">{resource.name}</span>
+          <span className="queue-flow-node-sublabel">Amazon SQS</span>
+          <div className="queue-flow-metrics">
+            <div className="queue-flow-metric">
+              <strong>{messagesAvailable}</strong>
+              <span>Available</span>
+            </div>
+            <div className="queue-flow-metric">
+              <strong>{messagesInFlight}</strong>
+              <span>In flight</span>
+            </div>
+            <div className="queue-flow-metric">
+              <strong>{messagesDelayed}</strong>
+              <span>Delayed</span>
+            </div>
+          </div>
+        </div>
+
+        <div
+          className={`queue-flow-connector ${
+            receiveMut.isPending || messagesAvailable > 0 ? "flow-dot-active" : ""
+          }`}
+        >
+          <span className="flow-dot" />
+        </div>
+
+        <div className="queue-flow-node">
+          <div className="queue-flow-node-icon">
+            <Users size={16} />
+          </div>
+          <span className="queue-flow-node-label">Consumer</span>
+          <span className="queue-flow-node-sublabel">Your application</span>
+        </div>
+
+        {redrivePolicy && (
+          <div className="queue-flow-branch">
+            <div className="queue-flow-node queue-flow-node--dlq">
+              <div className="queue-flow-node-icon">
+                <AlertTriangle size={16} />
+              </div>
+              <span className="queue-flow-node-label">{dlqName ?? "Dead-letter queue"}</span>
+              <span className="queue-flow-node-sublabel">
+                After {redrivePolicy.maxReceiveCount ?? "?"} failed receives
+              </span>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="queue-actions-grid">
+        <div className="queue-action-card">
+          <div className="queue-action-card-header">
+            <h4>
+              <Send size={13} />
+              Send a message
+            </h4>
+          </div>
+          <textarea
+            className="textarea code-textarea"
+            value={sendBody}
+            onChange={(event) => setSendBody(event.target.value)}
+            spellCheck={false}
+            placeholder="Message body"
+            style={{ minHeight: 110 }}
+          />
+          {attributeRows.map((row, index) => (
+            <div className="queue-attr-row" key={index}>
+              <input
+                className="input"
+                placeholder="Attribute name"
+                value={row.key}
+                onChange={(event) => updateAttributeRow(index, { key: event.target.value })}
+              />
+              <input
+                className="input"
+                placeholder="Value"
+                value={row.value}
+                onChange={(event) => updateAttributeRow(index, { value: event.target.value })}
+              />
+              <button
+                className="icon-btn"
+                type="button"
+                title="Remove attribute"
+                onClick={() => setAttributeRows((rows) => rows.filter((_, i) => i !== index))}
+              >
+                <X size={13} />
+              </button>
+            </div>
+          ))}
+          <button
+            className="button"
+            type="button"
+            onClick={() => setAttributeRows((rows) => [...rows, { key: "", value: "" }])}
+          >
+            <Plus size={13} />
+            Add message attribute
+          </button>
+          <button
+            className="button primary"
+            type="button"
+            disabled={!canOperate || sendMut.isPending || !sendBody.trim()}
+            onClick={() => sendMut.mutate()}
+          >
+            {sendMut.isPending ? <Loader2 size={13} className="spin" /> : <Send size={13} />}
+            {sendMut.isPending ? "Sending" : "Send message"}
+          </button>
+          {sendMut.isError && (
+            <p className="error-text compact-text">
+              {sendMut.error instanceof Error ? sendMut.error.message : "Send failed"}
+            </p>
+          )}
+          {lastSentId && !sendMut.isPending && !sendMut.isError && (
+            <p className="muted compact-text">Sent — message id {lastSentId}</p>
+          )}
+        </div>
+
+        <div className="queue-action-card">
+          <div className="queue-action-card-header">
+            <h4>
+              <Users size={13} />
+              Receive messages
+            </h4>
+            <div style={{ display: "flex", gap: 6, alignItems: "center" }}>
+              <select
+                className="input"
+                value={maxMessages}
+                onChange={(event) => setMaxMessages(Number(event.target.value))}
+                style={{ width: 64 }}
+              >
+                {[1, 5, 10].map((n) => (
+                  <option key={n} value={n}>
+                    {n}
+                  </option>
+                ))}
+              </select>
+              <label className="muted compact-text" style={{ display: "flex", gap: 4, alignItems: "center" }}>
+                <input
+                  type="checkbox"
+                  checked={longPoll}
+                  onChange={(event) => setLongPoll(event.target.checked)}
+                />
+                Long poll
+              </label>
+            </div>
+          </div>
+          <button
+            className="button"
+            type="button"
+            disabled={!canOperate || receiveMut.isPending}
+            onClick={() => receiveMut.mutate()}
+          >
+            {receiveMut.isPending ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />}
+            {receiveMut.isPending ? "Polling" : "Poll for messages"}
+          </button>
+          {receiveMut.isError && (
+            <p className="error-text compact-text">
+              {receiveMut.error instanceof Error ? receiveMut.error.message : "Receive failed"}
+            </p>
+          )}
+          <div className="queue-message-list">
+            {messages.length === 0 && (
+              <p className="muted compact-text">No messages received yet.</p>
+            )}
+            {messages.map((message) => (
+              <div className="queue-message-card" key={message.receiptHandle}>
+                <div className="queue-message-card-header">
+                  <span className="muted compact-text">
+                    {message.id.slice(0, 12)}
+                    {message.receiveCount !== null ? ` · receive #${message.receiveCount}` : ""}
+                  </span>
+                  <button
+                    className="icon-btn danger"
+                    type="button"
+                    title="Delete message"
+                    disabled={deleteMut.isPending && deleteMut.variables?.receiptHandle === message.receiptHandle}
+                    onClick={() => deleteMut.mutate(message)}
+                  >
+                    <Trash2 size={13} />
+                  </button>
+                </div>
+                <pre className="queue-message-body">{message.body}</pre>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+
+  function updateAttributeRow(index: number, patch: Partial<AttributeRow>) {
+    setAttributeRows((rows) =>
+      rows.map((row, i) => (i === index ? { ...row, ...patch } : row)),
+    );
+  }
+}
+
+function attributesRecord(rows: AttributeRow[]): Record<string, string> | undefined {
+  const entries = rows
+    .map((row) => [row.key.trim(), row.value] as const)
+    .filter(([key]) => key.length > 0);
+  return entries.length ? Object.fromEntries(entries) : undefined;
+}
+
+function numberMetadata(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0;
+}

--- a/packages/frontend/src/features/cloud-console/useCloudConsoleHomeData.ts
+++ b/packages/frontend/src/features/cloud-console/useCloudConsoleHomeData.ts
@@ -20,7 +20,6 @@ import type {CloudProvider} from '@/types/cloud'
 import type {ConsoleServiceCard} from './types'
 
 const SERVICE_PLACEHOLDERS = [
-    {id: 'queue', label: 'Queue', icon: MessageSquare},
     {id: 'function', label: 'Function', icon: Zap},
 ]
 
@@ -37,11 +36,13 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
     const storageResourcesQuery = useCloudConsoleResourcesQuery({...queryContext, service: 'storage'})
     const k8sResourcesQuery = useCloudConsoleResourcesQuery({...queryContext, service: 'k8s'})
     const databaseResourcesQuery = useCloudConsoleResourcesQuery({...queryContext, service: 'database'})
+    const queueResourcesQuery = useCloudConsoleResourcesQuery({...queryContext, service: 'queue'})
     const secretsQuery = useSecretsQuery(cloud === 'aws' && status?.runtime === 'reachable')
     const serviceCards = useMemo<ConsoleServiceCard[]>(() => {
         const storage = servicesQuery.data?.find((service) => service.service === 'storage')
         const k8s = servicesQuery.data?.find((service) => service.service === 'k8s')
         const database = servicesQuery.data?.find((service) => service.service === 'database')
+        const queue = servicesQuery.data?.find((service) => service.service === 'queue')
 
         return [
             {
@@ -79,6 +80,14 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
                 icon: KeyRound,
                 route: '/secretsmanager',
                 meta: serviceMetaLabel(status, secretsQuery.isLoading, 'secrets'),
+            }, {
+                id: 'queue',
+                label: queue?.displayName ?? 'Queue',
+                status: queue?.availability ?? 'coming_soon',
+                count: queueResourcesQuery.data?.length,
+                icon: MessageSquare,
+                route: `/cloud-explorer/${cloud}/queue`,
+                meta: serviceMetaLabel(status, queueResourcesQuery.isLoading, 'queues'),
             }] : []),
             ...SERVICE_PLACEHOLDERS.map((service) => ({
                 ...service,
@@ -94,6 +103,8 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
         cloud,
         k8sResourcesQuery.data,
         k8sResourcesQuery.isLoading,
+        queueResourcesQuery.data,
+        queueResourcesQuery.isLoading,
         secretsQuery.data,
         secretsQuery.isLoading,
         servicesQuery.data,
@@ -105,11 +116,11 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
     const resourcesLoading = storageResourcesQuery.isLoading
         || k8sResourcesQuery.isLoading
         || databaseResourcesQuery.isLoading
-        || (cloud === 'aws' && secretsQuery.isLoading)
+        || (cloud === 'aws' && (secretsQuery.isLoading || queueResourcesQuery.isLoading))
     const resourcesError = storageResourcesQuery.isError
         || k8sResourcesQuery.isError
         || databaseResourcesQuery.isError
-        || (cloud === 'aws' && secretsQuery.isError)
+        || (cloud === 'aws' && (secretsQuery.isError || queueResourcesQuery.isError))
 
     return {
         cloudsQuery,
@@ -123,7 +134,7 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
         resourceCount: (storageResourcesQuery.data?.length ?? 0)
             + (k8sResourcesQuery.data?.length ?? 0)
             + (databaseResourcesQuery.data?.length ?? 0)
-            + (cloud === 'aws' ? (secretsQuery.data?.length ?? 0) : 0),
+            + (cloud === 'aws' ? (secretsQuery.data?.length ?? 0) + (queueResourcesQuery.data?.length ?? 0) : 0),
         resourceDetail: resourceDetailFor(cloud, status, statusQuery.isLoading, resourcesLoading, resourcesError),
         serviceCards,
     }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -3090,3 +3090,260 @@ button.console-service-card {
     animation: spin 1s linear infinite;
 }
 
+/* ── Queue Flow Panel (SQS) ── */
+
+.queue-flow-panel {
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+}
+
+.queue-flow-diagram {
+    display: flex;
+    align-items: center;
+    gap: 0;
+    padding: 24px 12px;
+    background: var(--elevated);
+    border: 1px solid var(--border-faint);
+    border-radius: 12px;
+    overflow-x: auto;
+}
+
+.queue-flow-node {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    min-width: 140px;
+    padding: 14px 16px;
+    border-radius: 10px;
+    border: 1px solid var(--border-faint);
+    background: var(--raised);
+    text-align: center;
+    flex-shrink: 0;
+}
+
+.queue-flow-node.queue-flow-node--active {
+    border-color: var(--accent-tint-border);
+    background: var(--accent-tint-faint);
+}
+
+.queue-flow-node.queue-flow-node--dlq {
+    border-color: rgba(239, 108, 84, 0.35);
+    background: rgba(239, 108, 84, 0.08);
+}
+
+.queue-flow-node-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border-radius: 50%;
+    background: var(--accent-tint);
+    color: var(--accent);
+}
+
+.queue-flow-node--dlq .queue-flow-node-icon {
+    background: rgba(239, 108, 84, 0.16);
+    color: #ef6c54;
+}
+
+.queue-flow-node-label {
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--text);
+}
+
+.queue-flow-node-sublabel {
+    font-size: 11px;
+    color: var(--text-3);
+    word-break: break-word;
+}
+
+.queue-flow-metrics {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    justify-content: center;
+    margin-top: 2px;
+}
+
+.queue-flow-metric {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 3px 8px;
+    border-radius: 6px;
+    background: var(--surface);
+    border: 1px solid var(--border-lighter);
+    min-width: 44px;
+}
+
+.queue-flow-metric strong {
+    font-size: 13px;
+    color: var(--text-bright);
+    line-height: 1.2;
+}
+
+.queue-flow-metric span {
+    font-size: 9.5px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    color: var(--text-3);
+}
+
+.queue-flow-connector {
+    position: relative;
+    flex: 1 1 60px;
+    min-width: 36px;
+    height: 2px;
+    background: repeating-linear-gradient(
+        90deg,
+        var(--border-hover) 0,
+        var(--border-hover) 6px,
+        transparent 6px,
+        transparent 12px
+    );
+    margin: 0 6px;
+}
+
+.queue-flow-connector::after {
+    content: "";
+    position: absolute;
+    right: -1px;
+    top: 50%;
+    width: 7px;
+    height: 7px;
+    border-right: 2px solid var(--border-hover);
+    border-bottom: 2px solid var(--border-hover);
+    transform: translateY(-50%) rotate(-45deg);
+}
+
+.queue-flow-connector .flow-dot {
+    position: absolute;
+    top: 50%;
+    left: 0;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--accent);
+    box-shadow: 0 0 6px var(--accent);
+    transform: translate(-50%, -50%);
+    opacity: 0;
+}
+
+.queue-flow-connector.flow-dot-active .flow-dot {
+    animation: flow-dot-travel 1.1s ease-in-out infinite;
+}
+
+@keyframes flow-dot-travel {
+    0% {
+        left: 0%;
+        opacity: 0;
+    }
+    12% {
+        opacity: 1;
+    }
+    88% {
+        opacity: 1;
+    }
+    100% {
+        left: 100%;
+        opacity: 0;
+    }
+}
+
+.queue-flow-branch {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-left: 8px;
+    padding-left: 12px;
+    border-left: 1px dashed rgba(239, 108, 84, 0.4);
+}
+
+.queue-actions-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 16px;
+    align-items: start;
+}
+
+@media (max-width: 860px) {
+    .queue-actions-grid {
+        grid-template-columns: 1fr;
+    }
+}
+
+.queue-action-card {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    padding: 14px;
+    border-radius: 10px;
+    border: 1px solid var(--border-faint);
+    background: var(--surface);
+}
+
+.queue-action-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.queue-action-card-header h4 {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    font-size: 13px;
+    margin: 0;
+}
+
+.queue-attr-row {
+    display: flex;
+    gap: 6px;
+    align-items: center;
+}
+
+.queue-attr-row .input {
+    flex: 1;
+}
+
+.queue-message-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    max-height: 360px;
+    overflow-y: auto;
+}
+
+.queue-message-card {
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+    padding: 10px 12px;
+    border-radius: 8px;
+    border: 1px solid var(--border-lighter);
+    background: var(--raised);
+}
+
+.queue-message-card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+}
+
+.queue-message-body {
+    margin: 0;
+    font-family: "JetBrains Mono", ui-monospace, monospace;
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 120px;
+    overflow-y: auto;
+    color: var(--text-2);
+}
+

--- a/packages/frontend/src/pages/CloudExplorerPage.tsx
+++ b/packages/frontend/src/pages/CloudExplorerPage.tsx
@@ -102,7 +102,7 @@ function normalizeCloud(value?: string): CloudProvider | null {
 }
 
 function normalizeService(value?: string): CloudServiceType | null {
-    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'compute' || value === 'networking' || value === 'serverless' ? value : null
+    return value === 'storage' || value === 'k8s' || value === 'database' || value === 'compute' || value === 'networking' || value === 'serverless' || value === 'queue' ? value : null
 }
 
 function ServiceInfoDialog({
@@ -256,6 +256,7 @@ function connectionValue(status?: CloudStatus, loading?: boolean): string {
 function serviceLabel(service: CloudServiceType): string {
     if (service === 'k8s') return 'k8s Engine'
     if (service === 'serverless') return 'Serverless'
+    if (service === 'queue') return 'Queue'
     return service.charAt(0).toUpperCase() + service.slice(1)
 }
 

--- a/packages/frontend/src/types/cloud.ts
+++ b/packages/frontend/src/types/cloud.ts
@@ -1,6 +1,6 @@
 export type CloudProvider = 'aws' | 'azure' | 'gcp'
 export type CloudAvailability = 'available' | 'coming_soon'
-export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'compute' | 'networking' | 'serverless'
+export type CloudServiceType = 'storage' | 'k8s' | 'database' | 'compute' | 'networking' | 'serverless' | 'queue'
 
 export interface CloudDescriptor {
     id: CloudProvider

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function';
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'queue';
     region: string | null
     createdAt: string | null
     status?: string | null
@@ -51,4 +51,14 @@ export interface CosmosItem {
 export interface CosmosQueryResult {
     items: Array<Record<string, unknown> | string | number | boolean | null>
     count: number
+}
+
+export interface QueueMessage {
+    id: string
+    receiptHandle: string
+    body: string
+    attributes: Record<string, string>
+    messageAttributes: Record<string, string>
+    sentAt: string | null
+    receiveCount: number | null
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1076.0
         version: 3.1076.0
+      '@aws-sdk/client-sqs':
+        specifier: ^3.1090.0
+        version: 3.1090.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -173,40 +176,80 @@ packages:
     resolution: {integrity: sha512-N6azFky/nhHaBfLxza6fMnLbOCgqO12StpCgMDVzx43W7phexcWT61r2mHWrVK6VA6TU+Bze12ZQUb017+VWpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-sqs@3.1090.0':
+    resolution: {integrity: sha512-XgBD9RoOgF0W1768kRkNNxwZOQZ18pucXWTsa2i4ebfHlbE4fM1Sz30jTLMIbkRGL/JXfMT76ywY3er3N0x5xw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.28':
     resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.975.3':
+    resolution: {integrity: sha512-7ur3kCKuvPLqlsZ2XlvnNBVQ7KkpSu6Y6dOTwSPHLrFpTEfZM8isLBJc4cgv96WB7GifeVM436mpycwxBd2vEA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.54':
     resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.59':
+    resolution: {integrity: sha512-Ny5e4Mfh3QPmiAc0AiUe+cbTXDlxkU3Rc+EpWOfyWeWEy6yp7Fa1KmfNeCc+1a8by9zQ9gtohmiQUkMPScF3ng==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.56':
     resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    resolution: {integrity: sha512-8jAjgStl5Ytq4+HF3X/9f+EmRinaRbGRRtQGktlPfBRVx73H+R1y48vIeXerQtYGFaUqkEp3fT6jP854rVO2yQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.61':
     resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    resolution: {integrity: sha512-e6ZvVsj90aRALf1kHP+J4iqC1496ZpVgqI/+u0LJ5HL7q7ATauGy4gdDvRCP13L1pN/fMiZLah162PGIYkbUVQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.60':
     resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    resolution: {integrity: sha512-g2fsqm87r/nKthLZ0VkkDBElkGg0PvSa8d97HQ6EilMbJTZ6hxa8FxkSZyJfgPfFdZn0TTmkOffQmTSUcAHIng==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.63':
     resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.70':
+    resolution: {integrity: sha512-3xzvkGdykBunxqh8WudmUpSyLWvIhfI6aBQo1b5rb3mDO5mNLadK+0hiI0qBQBMVynJbfLO+Ajy9dztMwy9O8w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.54':
     resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    resolution: {integrity: sha512-DlZF2/MhLlatDdlrIy3CUCpfdbLrKx+3SMjVo+WyHnPpwzkc/M3vwAHw4OVJf7DMvO+4vfRqSCMc/E9I1auN0g==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.60':
     resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    resolution: {integrity: sha512-hmdDHoy2G5Es2e8IgelNMYUuSQI6uCIAKZMJ2u2PdKDhxvbk1uWD/g4+R7R5c/tJfKEB1+KjjWiaoCr/S+ZTiQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    resolution: {integrity: sha512-gHQb/Kt0chjk/JQDa/GJDqmAvEuVn8n7z10wK2h0LFM9TUDRkohgOO4aEF+s2sBLM0br7Cl5W6P7phgjrrJvLQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -225,20 +268,40 @@ packages:
     resolution: {integrity: sha512-KCf/UjbnzV3QIXR1C2MeE9eRUG8EUXUf0V4y65hf2bKWQXzol5f3I8wOhE6OBdEYohn8zHfnC/cyy5+s7/HwLw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.37':
+    resolution: {integrity: sha512-ObKPWZWpog+4zZQ2q+LdBwf/nm+HF2afgBxCtyHeqjRlsnATuKOV3dPYnzCGyjRZ/RHTEre4LRrYRcIxlWhzVQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/nested-clients@3.997.28':
     resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/nested-clients@3.997.33':
+    resolution: {integrity: sha512-dVZOroI/r3/ENvqNGgjMPul+jjlz9GddfVusgTXlVjfZj5isibOxecLkGQbRPp8XOuX+RAfjXLFgPkD1JS5xrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    resolution: {integrity: sha512-QMUytg+FQMGouc8gHS00KoYih3+N6cqmVI/pQGOIo7Nr7OpQaiXjSYOuL+vsPZ1tymY4LAQ8MYcHJmws5LRxng==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/token-providers@3.1080.0':
     resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1088.0':
+    resolution: {integrity: sha512-4ObatWt2qpJg5FBk4LOOKrTQYzaqeewAtdO3r9ZO8lH9YqLtpTzLyIdy0mJ+nVdfYOnqISkKNfmzP22bNDhwyw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.15':
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -247,6 +310,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.33':
     resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.36':
+    resolution: {integrity: sha512-RdGmS1GLrtaTOLE1ElSluMldNrpk9Emq6uYs8SS8iHlu5xTAmM9rRkM91o48+rIRryBtyO9t+uLYCoMG6jVMVA==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -509,12 +576,24 @@ packages:
     resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.29.5':
+    resolution: {integrity: sha512-i0dk2t5B+CwV/dcJdUHILYkOQF5lof8f44dFCfDWToGCxjT9YQ+CgHqTAvJxzc3+zqQwm2QtVoJ5IqiNar/CnQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.10':
+    resolution: {integrity: sha512-MJenAe4OKRZUo1LdYYFDCsSHxaHvInIU/z52GsheO9vl1/VSySVCr0zkyKD6TFiGkSUaWGxvKZ/70OvgUZR5HQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.6':
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.3':
     resolution: {integrity: sha512-CwCc/7SMTj45y97MUnDTbTaxvtAsiNNRm81z3abROIuMbMsC2Iy5EKfkkVdsKrz8WExQAAMx1EJapq+9j4fFTQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.7':
+    resolution: {integrity: sha512-3zpg8yqqyXzoK2TsRDdkqVOj2RDBFfLXwCczOZ5c7TWB4eiaebfSCsbMjDPYB3PJ9ihV62QaeadZ+wLadZtNGA==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/is-array-buffer@2.2.0':
@@ -525,12 +604,24 @@ packages:
     resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/node-http-handler@4.9.7':
+    resolution: {integrity: sha512-wCU8HCLjAtAVqxxe0j2xff9LcEPw3yjBbg5IdQDIYFnxnPxbxcSLc7rgex7kqm9L/WYOnJEgaWQlfDkZleozMA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/signature-v4@5.6.2':
     resolution: {integrity: sha512-QgHflghMoPxCJ9axiCVh8KZfbC9fuP6vkXXyK//E3cq7nLaSSyyLj0GAoqVWezYeDQmXIZhmlRvLE16jsqDK6g==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/signature-v4@5.6.6':
+    resolution: {integrity: sha512-efP6DN3UTFrzIsGO42/xcabv8jU7+9nwEdphFUH7yL0k010ERyAWaO41KFQIDLcFZLZ8xzIQr4wplFxNzslSGQ==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/types@4.15.1':
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -1398,6 +1489,18 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-sqs@3.1090.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-node': 3.972.70
+      '@aws-sdk/middleware-sdk-sqs': 3.972.37
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.28':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -1409,12 +1512,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.975.3':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.36
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.29.5
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.56':
@@ -1425,6 +1547,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.3
       '@smithy/node-http-handler': 4.9.3
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.61':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.61':
@@ -1443,6 +1575,22 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.4':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-login': 3.972.66
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1450,6 +1598,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.66':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.63':
@@ -1466,12 +1623,34 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.70':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.59
+      '@aws-sdk/credential-provider-http': 3.972.61
+      '@aws-sdk/credential-provider-ini': 3.973.4
+      '@aws-sdk/credential-provider-process': 3.972.59
+      '@aws-sdk/credential-provider-sso': 3.973.3
+      '@aws-sdk/credential-provider-web-identity': 3.972.65
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/credential-provider-imds': 4.4.10
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.59':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.60':
@@ -1484,6 +1663,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.3':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/token-providers': 3.1088.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1491,6 +1680,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.65':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -1525,6 +1723,13 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/middleware-sdk-sqs@3.972.37':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/nested-clients@3.997.28':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1536,11 +1741,29 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.33':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/signature-v4-multi-region': 3.996.41
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/fetch-http-handler': 5.6.7
+      '@smithy/node-http-handler': 4.9.7
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     dependencies:
       '@aws-sdk/types': 3.973.15
       '@smithy/signature-v4': 5.6.2
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.41':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.6
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1080.0':
@@ -1552,9 +1775,23 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1088.0':
+    dependencies:
+      '@aws-sdk/core': 3.975.3
+      '@aws-sdk/nested-clients': 3.997.33
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.15':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -1564,6 +1801,11 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.33':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.36':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -1818,6 +2060,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/core@3.29.5':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.10':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.6':
     dependencies:
       '@smithy/core': 3.29.1
@@ -1830,6 +2083,12 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/fetch-http-handler@5.6.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
@@ -1840,13 +2099,29 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.7':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/signature-v4@5.6.2':
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/signature-v4@5.6.6':
+    dependencies:
+      '@smithy/core': 3.29.5
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
## Summary

Adds Amazon SQS as a new Cloud Explorer service (`queue`), including a
dedicated Amazon-Console-style "send and receive messages" flow view.

- **Backend (`packages/api`)**: new `queue` `CloudServiceType`, `AwsQueueAdapter`
  (`@aws-sdk/client-sqs`) implementing list/get/create/delete plus
  `sendMessage`/`receiveMessages`/`deleteMessage`/`purgeQueue`, `queueSchema.ts`,
  and the matching `/api/clouds/aws/services/queue/...` routes
  (`.../messages`, `.../messages/delete`, `.../purge`). Registered in
  `cloudProxy.ts` and `CloudProxyService.ts` following the existing SPI pattern.
- **Frontend (`packages/frontend`)**: `queue` wired into `CloudServiceType`,
  the Cloud Explorer nav/routing, and `DynamicResourceView`. New
  `QueueFlowPanel` component renders a Producer → Queue → Consumer flow
  diagram with live message-count badges, animated connectors, a
  dead-letter-queue branch when a redrive policy is set, a send-message form
  (body + message attributes), and a receive/poll panel with per-message
  delete (ack). Also fixed the `queue` card on the Cloud Console home page
  (`useCloudConsoleHomeData`), which previously pointed at a nonexistent
  `/queue` route with a placeholder icon and no resource count.
- **Review fixes**: `list()` now follows `ListQueuesCommand`'s `NextToken`
  instead of silently dropping queues past the first page; `sendMessage`
  requires and forwards `MessageGroupId`/`MessageDeduplicationId` for FIFO
  queues (previously every FIFO send was rejected by SQS), with matching
  fields added to `QueueFlowPanel`; a malformed `RedrivePolicy` attribute no
  longer throws and breaks `list()`/`get()` for every queue; the purge
  confirmation now has a Cancel option; message-attribute rows are keyed by
  a stable id instead of array index; and the receive mutation is now scoped
  to the queue it targeted (a stale long-poll response could otherwise leak
  messages into a different queue's list) and dedupes by message id instead
  of receipt handle (which changes on SQS redelivery).

Closes #77, closes #65

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [x] API / Cloud Proxy (`packages/api`)
- [x] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

Tested against AWS SQS via a local Floci core (`:4566`), both directly via
`curl` against the API routes and end-to-end through the UI:

- Created a queue, sent a message, polled/received it, deleted (acked) it,
  and purged the queue — confirmed message counts (`Available`/`In flight`/
  `Delayed`) update on the flow diagram.
- Verified the Cloud Console home page's Queue card now shows a live count
  and routes to `/cloud-explorer/aws/queue`.
- Verified the FIFO fix directly: creating a `.fifo` queue and sending
  without a `messageGroupId` now returns `400 messageGroupId is required...`,
  and sending with one succeeds (`201`).
- Verified the receive-mutation fix against a queue pre-loaded with several
  messages: polling renders all received message bodies with their receive
  counts, live counts update (`Available`/`In flight`), and deleting a
  message removes it from the list while the rest correctly return to
  `Available` after their visibility timeout.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [x] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [ ] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
