### PR TITLE
fix(frontend): show app-level validation messages in dynamic create form

### DIFF
--- a/packages/frontend/src/components/DynamicFormRenderer.tsx
+++ b/packages/frontend/src/components/DynamicFormRenderer.tsx
@@ -29,7 +29,7 @@ export function DynamicFormRenderer({schema, isSubmitting, submitLabel = 'Create
     }
 
     return (
-        <form className="dynamic-form" onSubmit={submit}>
+        <form className="dynamic-form" onSubmit={submit} noValidate>
             {schema.fields.map((field) => (
                 <FieldRow
                     key={field.name}
@@ -47,11 +47,15 @@ export function DynamicFormRenderer({schema, isSubmitting, submitLabel = 'Create
                 />
             ))}
             <button className="button primary" type="submit" disabled={isSubmitting}>
-                <Plus size={14}/>
-                {isSubmitting ? pendingLabel : submitLabel}
-            </button>
-            {submitError && <div className="form-error">{submitError}</div>}
-        </form>
+    <Plus size={14}/>
+    {isSubmitting ? pendingLabel : submitLabel}
+</button>
+{submitError && (
+    <div className="form-error" role="alert">
+        {submitError}
+    </div>
+)}
+</form>
     )
 }
 
@@ -66,7 +70,7 @@ function FieldRow({field, value, error, onChange}: {field: FieldSchema; value: s
                 </span>
                 <FieldInput field={field} value={value} invalid={Boolean(error)} onChange={onChange}/>
                 {(error || field.description) && (
-                    <small className={error ? 'field-error' : undefined}>
+                 <small className={error ? 'field-error' : undefined} role={error ? 'alert' : undefined}>
                         {error ?? field.description}
                     </small>
                 )}

--- a/packages/frontend/src/components/DynamicFormRenderer.tsx
+++ b/packages/frontend/src/components/DynamicFormRenderer.tsx
@@ -47,15 +47,11 @@ export function DynamicFormRenderer({schema, isSubmitting, submitLabel = 'Create
                 />
             ))}
             <button className="button primary" type="submit" disabled={isSubmitting}>
-    <Plus size={14}/>
-    {isSubmitting ? pendingLabel : submitLabel}
-</button>
-{submitError && (
-    <div className="form-error" role="alert">
-        {submitError}
-    </div>
-)}
-</form>
+                <Plus size={14}/>
+                {isSubmitting ? pendingLabel : submitLabel}
+            </button>
+            {submitError && <div className="form-error" role="alert">{submitError}</div>}
+        </form>
     )
 }
 
@@ -68,9 +64,9 @@ function FieldRow({field, value, error, onChange}: {field: FieldSchema; value: s
                     {field.label}
                     {field.required && <em className="field-required">*</em>}
                 </span>
-                <FieldInput field={field} value={value} invalid={Boolean(error)} onChange={onChange}/>
+                <FieldInput field={field} value={value} invalid={Boolean(error)} messageId={`${field.name}-message`} onChange={onChange}/>
                 {(error || field.description) && (
-                 <small className={error ? 'field-error' : undefined} role={error ? 'alert' : undefined}>
+                    <small id={`${field.name}-message`} className={error ? 'field-error' : undefined}>
                         {error ?? field.description}
                     </small>
                 )}
@@ -79,10 +75,10 @@ function FieldRow({field, value, error, onChange}: {field: FieldSchema; value: s
     )
 }
 
-function FieldInput({field, value, invalid, onChange}: {field: FieldSchema; value: string; invalid: boolean; onChange: (value: string) => void}) {
+function FieldInput({field, value, invalid, messageId, onChange}: {field: FieldSchema; value: string; invalid: boolean; messageId: string; onChange: (value: string) => void}) {
     if (field.type === 'select') {
         return (
-            <select className={`input ${invalid ? 'invalid' : ''}`} value={value} required={field.required} onChange={(event) => onChange(event.target.value)}>
+            <select className={`input ${invalid ? 'invalid' : ''}`} value={value} required={field.required} aria-invalid={invalid || undefined} aria-describedby={invalid || field.description ? messageId : undefined} onChange={(event) => onChange(event.target.value)}>
                 <option value="">Default</option>
                 {(field.options ?? []).map((option) => (
                     <option key={option.value} value={option.value}>{option.label}</option>
@@ -97,6 +93,8 @@ function FieldInput({field, value, invalid, onChange}: {field: FieldSchema; valu
             className={`input ${invalid ? 'invalid' : ''}`}
             value={value}
             required={field.required}
+            aria-invalid={invalid || undefined}
+            aria-describedby={invalid || field.description ? messageId : undefined}
             minLength={field.validation?.minLength}
             maxLength={field.validation?.maxLength}
             pattern={field.validation?.pattern}


### PR DESCRIPTION
## Summary

Improves create form validation across all serverless providers by updating the shared `DynamicFormRenderer`.

This applies to:
- AWS Lambda
- Azure Functions
- GCP Cloud Functions

The original issue focuses on Azure Functions. In the current Azure schema, only `functionName` is required; runtime, handler, Function App name, location, and inline code remain optional.

## Changes

- Disables native browser validation so application-level validation messages are displayed consistently
- Ensures missing required fields use the existing field-level validation messages
- Prevents submission when validation fails
- Preserves the existing invalid-field highlighting
- Preserves the existing pending state that disables the Create button
- Preserves the existing API error display inside the form

## Provider behavior

Validation is driven by each provider’s schema:

- AWS Lambda validates fields marked as required in the AWS schema
- Azure Functions currently requires only `functionName`
- GCP Cloud Functions validates fields marked as required in the GCP schema

## Validation

- `pnpm --filter @floci/frontend type-check`
- `pnpm --filter @floci/frontend lint`
- `pnpm --filter @floci/frontend build`
- `git diff --check`

Closes #112