### PR TITLE
fix(docker): frontend dev container missing rolldown native binding

### DIFF
--- a/packages/frontend/Dockerfile.dev
+++ b/packages/frontend/Dockerfile.dev
@@ -1,5 +1,8 @@
 FROM node:20-alpine
 WORKDIR /app
+# pnpm resolves platform-specific optional deps (e.g. Vite's rolldown native
+# binding) reliably; npm intermittently drops them (npm/cli#4828).
+RUN corepack enable && corepack prepare pnpm@9.2.0 --activate
 COPY package.json ./
-RUN npm install
-CMD ["npm", "run", "dev"]
+RUN pnpm install
+CMD ["pnpm", "run", "dev"]


### PR DESCRIPTION
## Problem

`docker compose up -d` never brings `floci-ui` up. The container starts, then exits:

```
Error: Cannot find native binding. npm has a bug related to optional dependencies
(https://github.com/npm/cli/issues/4828)...
  cause: Error: Cannot find module '@rolldown/binding-linux-arm64-musl'
```

## Root cause

`npm install` in `packages/frontend/Dockerfile.dev` silently dropped Vite 8's platform-specific rolldown native binding. Confirmed by inspecting the built image — `node_modules/@rolldown/` contained only `pluginutils`, no `binding-*`:

```
$ docker run --rm floci-ui-floci-ui:latest sh -c 'ls node_modules/@rolldown/'
pluginutils
```

The binding package is published for this platform and installs fine standalone, so this is npm's optional-dependency bug (npm/cli#4828). Because the broken tree is baked into a cached layer, plain `docker compose build` kept reusing it.

## Fix

Install with pnpm — the repo's declared package manager — which resolves platform optional deps reliably. Pinned to `9.2.0` to match the root `package.json`; corepack's current default (11.x) requires `node:sqlite` and crashes on Node 20.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [x] Build / CI / Docker

## Verification

```
$ docker compose build --no-cache floci-ui
$ docker run --rm floci-ui-floci-ui:latest sh -c 'ls node_modules/.pnpm | grep -i rolldown'
@rolldown+binding-linux-arm64-gnu@1.1.5
@rolldown+binding-linux-arm64-musl@1.1.5
@rolldown+pluginutils@1.0.1
rolldown@1.1.5

$ docker compose up -d floci-ui && docker compose logs floci-ui
  VITE v8.1.5  ready in 211 ms
  ➜  Local:   http://localhost:4500/

$ curl -s -o /dev/null -w "%{http_code}" http://localhost:4500/
200
```

Tested on arm64 (Docker Desktop, macOS).

## Notes / out of scope

- The dev image installs from `package.json` with no lockfile, so builds still aren't reproducible (this build resolved rolldown 1.1.5; latest is 1.2.0). Wiring in `pnpm-lock.yaml` would require moving the build context to the repo root — left for a follow-up.
- Correction to an earlier version of this description: the API images use `bun install`, not npm. The remaining npm install is the `frontend-build` stage of `docker/Dockerfile` (line 5), which is susceptible to the same bug but wasn't part of this failure.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, and `pnpm build` pass locally. `pnpm test` has one
  pre-existing failure unrelated to this PR — `returns GCP runtime status without a
  registered adapter` calls `:4588` for real, so it only passes when no floci-gcp
  container is listening (it passes in CI, and fails locally with the multicloud stack
  up). Reproduced on `main` at the same commit this branch forks from. Fixed separately
  in #153.
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`) — n/a, no application code changed; verified by building and running the image
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
