### PR TITLE
fix(docker): mount the Docker socket so Lambda and Cloud SQL can run

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,6 +46,11 @@ services:
     ports:
       - "4566:4566"
     volumes:
+      # Floci runs Lambda functions in throwaway containers, so it needs the host
+      # Docker daemon. Without this, invoke fails with "Failed to start Lambda
+      # container". This grants the emulator control of host Docker — acceptable
+      # for a local dev stack, and the same mount the README's docker run uses.
+      - /var/run/docker.sock:/var/run/docker.sock
       - ./data:/app/data
       - ./init/ready.d:/etc/floci/init/ready.d:ro
       - ./init/files:/etc/floci/init/files:ro
@@ -71,6 +76,9 @@ services:
     profiles: ["multicloud"]
     ports:
       - "4588:4588"
+    volumes:
+      # Cloud SQL instances are real Postgres containers; see the note on `floci`.
+      - /var/run/docker.sock:/var/run/docker.sock
     networks:
       - floci_default
 

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -13,6 +13,9 @@ import { getAccountId } from "@/lib/accountStore";
 
 type CloudPathParams = Record<string, string>;
 
+/** Cold starts pull a container image; measured at ~60s on a first invoke. */
+const INVOKE_TIMEOUT_MS = 120_000;
+
 export async function listClouds(
   signal?: AbortSignal,
 ): Promise<CloudDescriptor[]> {
@@ -152,7 +155,15 @@ export async function invokeCloudResource(
 ): Promise<ServerlessInvokeResult> {
   const res = await apiClient.call<ServerlessInvokeResult, { payload: string }>(
     apiEndpointKeys.clouds.resources.invoke,
-    requestOptions(cloud, service, { signal, body: { payload } }),
+    requestOptions(cloud, service, {
+      signal,
+      body: { payload },
+      // A cold invoke can exceed a minute while the runtime pulls and starts the
+      // function container, so the 10s default would abort a request that is
+      // working. The user-visible alternative is a timeout error for a function
+      // that in fact ran.
+      timeout: INVOKE_TIMEOUT_MS,
+    }),
     { cloud, service, id },
   );
   return res.data;
@@ -350,6 +361,8 @@ function requestOptions<TBody = unknown>(
     body?: TBody;
     rawBody?: BodyInit;
     headers?: HeadersInit;
+    /** Overrides the client default; needed for calls that can legitimately run long. */
+    timeout?: number;
   } = {},
 ) {
   return {


### PR DESCRIPTION
## Problem

Floci runs Lambda functions and Cloud SQL instances as real containers, so the emulators need the host Docker daemon. The compose stack never mounted the socket — even though the README's `docker run` example does — so anything that spawns a container failed.

**Lambda invoke:**

```
$ curl -s -X POST localhost:4501/api/clouds/aws/services/serverless/resources/demo/invoke -d '{}'
{"statusCode":200,
 "payload":"{\"errorMessage\":\"Failed to start Lambda container: java.net.SocketException: No such file or directory\",\"errorType\":\"Lambda.InitError\"}",
 "functionError":"Unhandled"}
```

**Cloud SQL create** — a bare HTTP 500, with the cause only visible in the runtime log:

```
$ docker logs floci-ui-floci-gcp-1
  at com.github.dockerjava.transport.UnixSocket.get(UnixSocket.java:27)
  at com.github.dockerjava.httpclient5.ApacheDockerHttpClientImpl...
```

## Fix

Mount `/var/run/docker.sock` into `floci` and `floci-gcp`.

## Verification

Lambda now actually executes the function:

```
$ curl -s -X POST localhost:4501/api/clouds/aws/services/serverless/resources/demo/invoke \
    -d '{"payload":"{\"hello\":\"floci\"}"}'
{"statusCode":200,
 "payload":"{\"statusCode\":200,\"body\":\"{\\\"message\\\":\\\"Hello from Floci Cloud Explorer\\\",\\\"event\\\":{\\\"hello\\\":\\\"floci\\\"}}\"}",
 "executionDuration":58248}
```

Cloud SQL starts a real Postgres container:

```
$ docker ps | grep cloudsql
floci-cloudsql-floci-local-probe-sql   postgres:15.18-alpine   Up

$ curl -s localhost:4588/sql/v1beta4/projects/floci-local/instances | jq '.items[0] | {name, state, connectionName}'
{ "name": "probe-sql", "state": "RUNNABLE", "connectionName": "floci-local:us-central1:probe-sql" }
```

## Security note

This grants the emulators control of the host Docker daemon. That is inherent to running functions and databases locally, it is the same mount the README already documents for the same image, and the stack is a local dev tool — but it is a real privilege grant rather than a formality, so both mounts carry a comment saying why they are there. Happy to gate them behind a compose profile instead if you'd rather it be opt-in.

## Also here

A cold invoke takes ~60s while the runtime pulls the function image. The frontend's 10s default timeout aborts well before that, so the user sees a timeout for a function that in fact ran and succeeded. Invoke now uses its own 120s timeout; `requestOptions` gained a `timeout` passthrough to allow it.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [x] Build / CI / Docker

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense — n/a, compose and a client timeout; verified by running the stack
- [x] No fake/mock data added
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)