### PR TITLE
feat(kms): add an AWS KMS adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cd packages/api && bun run scripts/service-matrix.ts
 | Databases | Database | Yes (list, inspect) | Yes (list, create, delete, inspect) | Yes (list, create, inspect, delete) |
 | Networking | Networking | Yes (list) | No | No |
 | Security | Secrets Manager / Key Vault | Yes (legacy page) | Yes (list, create, delete, inspect) | No |
+| Security | KMS / Key Management | Yes (list, create, delete, inspect) | No | No |
 
 Console Home is available for all three clouds.
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "dependencies": {
         "@aws-sdk/client-ec2": "^3.1076.0",
         "@aws-sdk/client-eks": "^3.1076.0",
+        "@aws-sdk/client-kms": "^3.1096.0",
         "@aws-sdk/client-lambda": "^3.1076.0",
         "@aws-sdk/client-rds": "^3.1076.0",
         "@aws-sdk/client-s3": "^3.1076.0",
@@ -25,7 +26,7 @@
     },
     "packages/frontend": {
       "name": "@floci/frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
@@ -64,6 +65,8 @@
     "@aws-sdk/client-ec2": ["@aws-sdk/client-ec2@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/middleware-sdk-ec2": "^3.972.42", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-sDob1bPeCAU80M85xJdKZkTaEvHTD6HwwxfnKsy6hKGReTDw9IGJJ7tzjsdvSzp2+MRT5Vf6GHgRchGblPC4yQ=="],
 
     "@aws-sdk/client-eks": ["@aws-sdk/client-eks@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-tN9O6f9vc9ns/uaPsN6vzEOrD7ftkWOMgzXoxY1J438WM2M8qcGbRJkhD2c+PvaZvZY3MVF7843mdIVrOA3zzQ=="],
+
+    "@aws-sdk/client-kms": ["@aws-sdk/client-kms@3.1096.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/credential-provider-node": "^3.972.73", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-oOq9AEOkmEhL9Vlgw5vTYsmeRfZJWnwuAUYCaYHG10UrNApl1gkZEux13eqWYpxsoUM+sNyL9BOthahbUgbSLQ=="],
 
     "@aws-sdk/client-lambda": ["@aws-sdk/client-lambda@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-rTitNyvjgBrJzjDkzLRcLi1QcxSomomLRjhYXJWID97uaw1uxtmer8wOVi8l6UFxzlRVa83laZ3srAeWRs509A=="],
 
@@ -533,6 +536,20 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
+    "@aws-sdk/client-kms/@aws-sdk/core": ["@aws-sdk/core@3.977.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.8", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.73", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.62", "@aws-sdk/credential-provider-http": "^3.972.64", "@aws-sdk/credential-provider-ini": "^3.973.7", "@aws-sdk/credential-provider-process": "^3.972.62", "@aws-sdk/credential-provider-sso": "^3.973.6", "@aws-sdk/credential-provider-web-identity": "^3.972.68", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/client-kms/@smithy/core": ["@smithy/core@3.31.0", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw=="],
+
+    "@aws-sdk/client-kms/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q=="],
+
+    "@aws-sdk/client-kms/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.12", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q=="],
+
+    "@aws-sdk/client-kms/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -543,6 +560,24 @@
 
     "bun-types/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
+    "@aws-sdk/client-kms/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.7", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/credential-provider-env": "^3.972.62", "@aws-sdk/credential-provider-http": "^3.972.64", "@aws-sdk/credential-provider-login": "^3.972.69", "@aws-sdk/credential-provider-process": "^3.972.62", "@aws-sdk/credential-provider-sso": "^3.973.6", "@aws-sdk/credential-provider-web-identity": "^3.972.68", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.6", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/token-providers": "3.1096.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.68", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.15", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA=="],
+
     "@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
 
     "@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
@@ -552,5 +587,27 @@
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1096.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-kms/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@aws-sdk/client-ec2": "^3.1076.0",
     "@aws-sdk/client-eks": "^3.1076.0",
+    "@aws-sdk/client-kms": "^3.1096.0",
     "@aws-sdk/client-lambda": "^3.1076.0",
     "@aws-sdk/client-rds": "^3.1076.0",
     "@aws-sdk/client-s3": "^3.1076.0",

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
@@ -1,0 +1,213 @@
+import {describe, expect, test} from 'bun:test'
+import {
+    CreateKeyCommand,
+    DescribeKeyCommand,
+    type KMSClient,
+    ListKeysCommand,
+    ListResourceTagsCommand,
+    ScheduleKeyDeletionCommand,
+    TagResourceCommand,
+    UntagResourceCommand,
+} from '@aws-sdk/client-kms'
+import {AwsKmsAdapter} from './AwsKmsAdapter'
+import {ValidationError} from '../cloud-spi/errors'
+
+type SendResult = Record<string, unknown>
+
+/** Minimal KMSClient stub that records the commands it was sent. */
+function stubKms(handler: (command: object) => SendResult | Promise<SendResult>) {
+    const sent: object[] = []
+    const client = {
+        async send(command: object) {
+            sent.push(command)
+            return handler(command)
+        },
+    } as unknown as KMSClient
+    return {client, sent}
+}
+
+const KEY_ID = '68543643-23b6-4037-a59b-4d43d5d308f1'
+const KEY_ARN = `arn:aws:kms:us-east-1:000000000000:key/${KEY_ID}`
+
+const keyMetadata = {
+    AWSAccountId: '000000000000',
+    KeyId: KEY_ID,
+    Arn: KEY_ARN,
+    CreationDate: new Date('2026-07-28T10:00:00.000Z'),
+    Enabled: true,
+    Description: 'payments signing key',
+    KeyUsage: 'ENCRYPT_DECRYPT',
+    KeyState: 'Enabled',
+    Origin: 'AWS_KMS',
+    KeyManager: 'CUSTOMER',
+    KeySpec: 'SYMMETRIC_DEFAULT',
+    EncryptionAlgorithms: ['SYMMETRIC_DEFAULT'],
+}
+
+/** Routes each command to the response the real runtime gives for it. */
+function runtimeStub(overrides: Record<string, SendResult> = {}) {
+    return stubKms((command) => {
+        if (command instanceof ListKeysCommand) {
+            return overrides.list ?? {Keys: [{KeyId: KEY_ID, KeyArn: KEY_ARN}]}
+        }
+        if (command instanceof DescribeKeyCommand) {
+            return overrides.describe ?? {KeyMetadata: keyMetadata}
+        }
+        if (command instanceof ListResourceTagsCommand) {
+            return overrides.tags ?? {Tags: []}
+        }
+        return {}
+    })
+}
+
+describe('AwsKmsAdapter', () => {
+    test('identifies itself as the AWS KMS adapter', () => {
+        const adapter = new AwsKmsAdapter(runtimeStub().client)
+
+        expect(adapter.cloud).toBe('aws')
+        expect(adapter.service).toBe('kms')
+        expect(adapter.schema().displayName).toBe('AWS KMS')
+    })
+
+    test('lists keys by fanning out DescribeKey over the thin ListKeys result', async () => {
+        // ListKeys returns only id and ARN, so every displayed column depends on
+        // the per-key DescribeKey call.
+        const {client, sent} = runtimeStub()
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(sent[0]).toBeInstanceOf(ListKeysCommand)
+        expect(sent[1]).toBeInstanceOf(DescribeKeyCommand)
+        expect(resource).toMatchObject({
+            id: KEY_ID,
+            name: KEY_ID,
+            cloud: 'aws',
+            service: 'kms',
+            type: 'key',
+            region: 'us-east-1',
+            status: 'Enabled',
+            createdAt: '2026-07-28T10:00:00.000Z',
+        })
+        expect(resource?.metadata).toMatchObject({
+            arn: KEY_ARN,
+            description: 'payments signing key',
+            keyUsage: 'ENCRYPT_DECRYPT',
+            keySpec: 'SYMMETRIC_DEFAULT',
+            keyManager: 'CUSTOMER',
+            origin: 'AWS_KMS',
+            enabled: true,
+        })
+    })
+
+    test('keeps keys that are pending deletion in the list', async () => {
+        // ScheduleKeyDeletion is a soft delete and real AWS keeps listing the key,
+        // so hiding it here would misreport the account.
+        const {client} = runtimeStub({
+            describe: {KeyMetadata: {...keyMetadata, KeyState: 'PendingDeletion', Enabled: false}},
+        })
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(resource?.status).toBe('PendingDeletion')
+    })
+
+    test('surfaces key tags under metadata', async () => {
+        const {client} = runtimeStub({tags: {Tags: [{TagKey: 'env', TagValue: 'prod'}]}})
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(resource?.metadata.tags).toEqual([{key: 'env', value: 'prod'}])
+    })
+
+    test('filters the list by key id or description', async () => {
+        // The name is an opaque uuid, so a search that ignored the description
+        // would be unusable.
+        const adapter = new AwsKmsAdapter(runtimeStub().client)
+
+        await expect(adapter.list({search: '68543643'})).resolves.toHaveLength(1)
+        await expect(adapter.list({search: 'payments'})).resolves.toHaveLength(1)
+        await expect(adapter.list({search: 'nope'})).resolves.toHaveLength(0)
+    })
+
+    test('returns null when a key does not exist', async () => {
+        const {client} = stubKms(() => {
+            throw Object.assign(new Error('NotFoundException'), {$metadata: {httpStatusCode: 404}})
+        })
+        await expect(new AwsKmsAdapter(client).get('missing')).resolves.toBeNull()
+    })
+
+    test('rethrows a non-404 failure from get', async () => {
+        const {client} = stubKms(() => {
+            throw Object.assign(new Error('AccessDenied'), {$metadata: {httpStatusCode: 403}})
+        })
+        await expect(new AwsKmsAdapter(client).get(KEY_ID)).rejects.toThrow('AccessDenied')
+    })
+
+    test('inspects a key through DescribeKey', async () => {
+        const {client, sent} = runtimeStub()
+        const resource = await new AwsKmsAdapter(client).get(KEY_ID)
+
+        expect(sent[0]).toBeInstanceOf(DescribeKeyCommand)
+        expect((sent[0] as DescribeKeyCommand).input.KeyId).toBe(KEY_ID)
+        expect(resource?.id).toBe(KEY_ID)
+    })
+
+    test('creates a key with the requested description and usage', async () => {
+        const {client, sent} = stubKms(() => ({KeyMetadata: keyMetadata}))
+        const resource = await new AwsKmsAdapter(client).create({
+            values: {description: 'payments signing key', keyUsage: 'ENCRYPT_DECRYPT'},
+        })
+
+        const command = sent[0] as CreateKeyCommand
+        expect(command).toBeInstanceOf(CreateKeyCommand)
+        expect(command.input.Description).toBe('payments signing key')
+        expect(command.input.KeyUsage).toBe('ENCRYPT_DECRYPT')
+        expect(resource.id).toBe(KEY_ID)
+    })
+
+    test('defaults key usage and spec when they are omitted', async () => {
+        const {client, sent} = stubKms(() => ({KeyMetadata: keyMetadata}))
+        await new AwsKmsAdapter(client).create({values: {}})
+
+        const command = sent[0] as CreateKeyCommand
+        expect(command.input.KeyUsage).toBe('ENCRYPT_DECRYPT')
+        expect(command.input.KeySpec).toBe('SYMMETRIC_DEFAULT')
+    })
+
+    test('rejects a key usage the schema does not offer', async () => {
+        const adapter = new AwsKmsAdapter(stubKms(() => ({})).client)
+
+        await expect(adapter.create({values: {keyUsage: 'MINE_BITCOIN'}})).rejects.toThrow(ValidationError)
+    })
+
+    test('rejects a description longer than the KMS limit', async () => {
+        const adapter = new AwsKmsAdapter(stubKms(() => ({})).client)
+
+        await expect(adapter.create({values: {description: 'x'.repeat(8193)}})).rejects.toThrow(ValidationError)
+    })
+
+    test('deletes a key by scheduling deletion with the shortest window', async () => {
+        const {client, sent} = stubKms(() => ({KeyId: KEY_ARN, DeletionDate: new Date()}))
+        await new AwsKmsAdapter(client).delete(KEY_ID)
+
+        const command = sent[0] as ScheduleKeyDeletionCommand
+        expect(command).toBeInstanceOf(ScheduleKeyDeletionCommand)
+        expect(command.input.KeyId).toBe(KEY_ID)
+        expect(command.input.PendingWindowInDays).toBe(7)
+    })
+
+    test('adds and removes tags in one update', async () => {
+        const {client, sent} = stubKms(() => ({}))
+        await new AwsKmsAdapter(client).updateTags(KEY_ID, {env: 'prod', stale: null})
+
+        const tagged = sent.find((c) => c instanceof TagResourceCommand) as TagResourceCommand
+        const untagged = sent.find((c) => c instanceof UntagResourceCommand) as UntagResourceCommand
+
+        expect(tagged.input.Tags).toEqual([{TagKey: 'env', TagValue: 'prod'}])
+        expect(untagged.input.TagKeys).toEqual(['stale'])
+    })
+
+    test('skips the tag calls it has nothing to send', async () => {
+        const {client, sent} = stubKms(() => ({}))
+        await new AwsKmsAdapter(client).updateTags(KEY_ID, {env: 'prod'})
+
+        expect(sent.some((c) => c instanceof UntagResourceCommand)).toBe(false)
+    })
+})

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
@@ -171,6 +171,85 @@ describe('AwsKmsAdapter', () => {
         expect(command.input.KeySpec).toBe('SYMMETRIC_DEFAULT')
     })
 
+    describe('key usage and spec compatibility', () => {
+        // The local runtime accepts SIGN_VERIFY with SYMMETRIC_DEFAULT and
+        // ENCRYPT_DECRYPT with ECC_NIST_P256 and returns 200, but real KMS rejects
+        // both. Only these tests can hold the line, so they encode the provider's
+        // rules rather than the emulator's.
+        test('defaults the spec to one that is valid for the chosen usage', async () => {
+            const cases: Array<[string, string]> = [
+                ['ENCRYPT_DECRYPT', 'SYMMETRIC_DEFAULT'],
+                ['SIGN_VERIFY', 'RSA_2048'],
+                ['GENERATE_VERIFY_MAC', 'HMAC_256'],
+            ]
+
+            for (const [keyUsage, expectedSpec] of cases) {
+                const {client, sent} = stubKms(() => ({KeyMetadata: keyMetadata}))
+                await new AwsKmsAdapter(client).create({values: {keyUsage}})
+
+                expect(String((sent[0] as CreateKeyCommand).input.KeySpec)).toBe(expectedSpec)
+            }
+        })
+
+        test('rejects a spec that the chosen usage cannot use', async () => {
+            const cases: Array<[string, string]> = [
+                ['SIGN_VERIFY', 'SYMMETRIC_DEFAULT'],
+                ['ENCRYPT_DECRYPT', 'ECC_NIST_P256'],
+                ['ENCRYPT_DECRYPT', 'HMAC_256'],
+                ['GENERATE_VERIFY_MAC', 'RSA_2048'],
+            ]
+
+            for (const [keyUsage, keySpec] of cases) {
+                // Returns valid metadata, so a create that reaches the runtime
+                // succeeds — the only way this rejects is the compatibility check.
+                const {client, sent} = stubKms(() => ({KeyMetadata: keyMetadata}))
+                const adapter = new AwsKmsAdapter(client)
+
+                await expect(adapter.create({values: {keyUsage, keySpec}})).rejects.toThrow(ValidationError)
+                expect(sent, `${keyUsage}/${keySpec} must be rejected before reaching KMS`).toHaveLength(0)
+            }
+        })
+
+        test('accepts every pair the provider considers valid', async () => {
+            const cases: Array<[string, string]> = [
+                ['ENCRYPT_DECRYPT', 'SYMMETRIC_DEFAULT'],
+                ['ENCRYPT_DECRYPT', 'RSA_2048'],
+                ['ENCRYPT_DECRYPT', 'RSA_4096'],
+                ['SIGN_VERIFY', 'RSA_2048'],
+                ['SIGN_VERIFY', 'RSA_4096'],
+                ['SIGN_VERIFY', 'ECC_NIST_P256'],
+                ['GENERATE_VERIFY_MAC', 'HMAC_256'],
+            ]
+
+            for (const [keyUsage, keySpec] of cases) {
+                const {client, sent} = stubKms(() => ({KeyMetadata: keyMetadata}))
+                await new AwsKmsAdapter(client).create({values: {keyUsage, keySpec}})
+
+                expect(String((sent[0] as CreateKeyCommand).input.KeySpec)).toBe(keySpec)
+            }
+        })
+    })
+
+    test('follows the tag pages so a heavily tagged key is not truncated', async () => {
+        let tagCall = 0
+        const {client} = stubKms((command) => {
+            if (command instanceof ListKeysCommand) return {Keys: [{KeyId: KEY_ID, KeyArn: KEY_ARN}]}
+            if (command instanceof DescribeKeyCommand) return {KeyMetadata: keyMetadata}
+            tagCall += 1
+            if (tagCall === 1) {
+                return {Tags: [{TagKey: 'a', TagValue: '1'}], Truncated: true, NextMarker: 'tag-page-2'}
+            }
+            return {Tags: [{TagKey: 'b', TagValue: '2'}], Truncated: false}
+        })
+
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(resource?.metadata.tags).toEqual([
+            {key: 'a', value: '1'},
+            {key: 'b', value: '2'},
+        ])
+    })
+
     test('rejects a key usage the schema does not offer', async () => {
         const adapter = new AwsKmsAdapter(stubKms(() => ({})).client)
 

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
@@ -162,6 +162,22 @@ describe('AwsKmsAdapter', () => {
         await expect(new AwsKmsAdapter(client).get('missing')).resolves.toBeNull()
     })
 
+    /**
+     * Real KMS is one of the AWS services that does not use 404 for not-found:
+     * it answers `NotFoundException` with HTTP 400. The local runtime sends 404,
+     * so a status-only check passes locally and turns a missing key into a 502
+     * against real AWS.
+     */
+    test('returns null for the real KMS not-found shape, which carries HTTP 400', async () => {
+        const {client} = stubKms(() => {
+            throw Object.assign(new Error('Key ARN does not exist'), {
+                name: 'NotFoundException',
+                $metadata: {httpStatusCode: 400},
+            })
+        })
+        await expect(new AwsKmsAdapter(client).get('missing')).resolves.toBeNull()
+    })
+
     test('rethrows a non-404 failure from get', async () => {
         const {client} = stubKms(() => {
             throw Object.assign(new Error('AccessDenied'), {$metadata: {httpStatusCode: 403}})

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.test.ts
@@ -116,6 +116,35 @@ describe('AwsKmsAdapter', () => {
         expect(resource?.metadata.tags).toEqual([{key: 'env', value: 'prod'}])
     })
 
+    test('still lists keys when the tag lookup fails', async () => {
+        // list() builds every row through Promise.all, so an unisolated tag
+        // failure would reject the whole view and show nothing, when the key
+        // metadata was available all along.
+        const {client} = stubKms((command) => {
+            if (command instanceof ListKeysCommand) return {Keys: [{KeyId: KEY_ID, KeyArn: KEY_ARN}]}
+            if (command instanceof DescribeKeyCommand) return {KeyMetadata: keyMetadata}
+            throw Object.assign(new Error('Rate exceeded'), {
+                name: 'ThrottlingException',
+                $metadata: {httpStatusCode: 400},
+            })
+        })
+
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(resource?.id).toBe(KEY_ID)
+        expect(resource?.metadata.tags).toEqual([])
+        // Degraded, not silent.
+        expect(resource?.metadata.tagsUnavailable).toBe(true)
+    })
+
+    test('does not claim tags are unavailable when a key simply has none', async () => {
+        const {client} = runtimeStub()
+        const [resource] = await new AwsKmsAdapter(client).list()
+
+        expect(resource?.metadata.tags).toEqual([])
+        expect(resource?.metadata.tagsUnavailable).toBeUndefined()
+    })
+
     test('filters the list by key id or description', async () => {
         // The name is an opaque uuid, so a search that ignored the description
         // would be unusable.

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.ts
@@ -15,6 +15,7 @@ import {
     KMS_DESCRIPTION_MAX_LENGTH,
     KMS_KEY_SPECS,
     KMS_KEY_USAGES,
+    KMS_SPECS_BY_USAGE,
 } from '../cloud-spi/kmsSchema'
 import type {
     CloudResource,
@@ -60,7 +61,7 @@ export class AwsKmsAdapter implements CloudServiceAdapter {
         }
 
         const keyUsage = oneOf(input.values.keyUsage, KMS_KEY_USAGES, 'keyUsage')
-        const keySpec = oneOf(input.values.keySpec, KMS_KEY_SPECS, 'keySpec')
+        const keySpec = keySpecFor(keyUsage, input.values.keySpec)
 
         const res = await this.kms.send(
             new CreateKeyCommand({
@@ -134,9 +135,20 @@ export class AwsKmsAdapter implements CloudServiceAdapter {
         }
     }
 
+    /** Paged like ListKeys, so a heavily tagged key would otherwise be truncated. */
     private async getTags(id: string): Promise<KeyTag[]> {
-        const res = await this.kms.send(new ListResourceTagsCommand({KeyId: id}))
-        return (res.Tags ?? []).map((tag) => ({key: tag.TagKey ?? '', value: tag.TagValue ?? ''}))
+        const tags: KeyTag[] = []
+        let marker: string | undefined
+
+        do {
+            const res = await this.kms.send(new ListResourceTagsCommand({KeyId: id, ...(marker ? {Marker: marker} : {})}))
+            for (const tag of res.Tags ?? []) {
+                tags.push({key: tag.TagKey ?? '', value: tag.TagValue ?? ''})
+            }
+            marker = res.Truncated ? res.NextMarker : undefined
+        } while (marker)
+
+        return tags
     }
 }
 
@@ -194,12 +206,37 @@ function optionalString(value: unknown, field: string): string | undefined {
 }
 
 /**
+ * Resolve the key spec for a usage, defaulting to the first spec that usage
+ * supports rather than to a fixed symmetric default.
+ *
+ * A fixed default would pair SIGN_VERIFY with SYMMETRIC_DEFAULT, which real KMS
+ * rejects — and the local runtime accepts, so the failure would only appear
+ * against a real provider.
+ */
+function keySpecFor(keyUsage: (typeof KMS_KEY_USAGES)[number], raw: unknown): (typeof KMS_KEY_SPECS)[number] {
+    const allowed = KMS_SPECS_BY_USAGE[keyUsage]
+    const requested = oneOf(raw, KMS_KEY_SPECS, 'keySpec', allowed[0])
+
+    if (!(allowed as readonly string[]).includes(requested)) {
+        throw new ValidationError(
+            `keySpec ${requested} is not valid for keyUsage ${keyUsage}; use one of ${allowed.join(', ')}`,
+        )
+    }
+    return requested
+}
+
+/**
  * Keeps create honest about the schema: a value the form never offers would be
  * rejected by KMS anyway, and failing here gives a typed error instead of a 400.
  */
-function oneOf<T extends readonly string[]>(value: unknown, allowed: T, field: string): T[number] {
+function oneOf<T extends readonly string[]>(
+    value: unknown,
+    allowed: T,
+    field: string,
+    fallback: T[number] = allowed[0] as T[number],
+): T[number] {
     const raw = optionalString(value, field)
-    if (raw === undefined) return allowed[0] as T[number]
+    if (raw === undefined) return fallback
     if (!allowed.includes(raw)) {
         throw new ValidationError(`${field} must be one of ${allowed.join(', ')}`)
     }

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.ts
@@ -27,6 +27,9 @@ import type {
 
 type KeyTag = {key: string; value: string}
 
+/** Tags plus whether the lookup itself failed, so the two stay distinguishable. */
+type TagLookup = {tags: KeyTag[]; unavailable?: true}
+
 /**
  * The shortest deletion window KMS accepts. Deletion is irreversible once it
  * completes, so the console never offers a longer wait than it has to — but it
@@ -73,7 +76,7 @@ export class AwsKmsAdapter implements CloudServiceAdapter {
         if (!res.KeyMetadata) throw new ValidationError('KMS did not return metadata for the created key')
 
         // A brand new key has no tags, so this skips the ListResourceTags call.
-        return toResource(res.KeyMetadata, [])
+        return toResource(res.KeyMetadata, {tags: []})
     }
 
     /**
@@ -135,24 +138,40 @@ export class AwsKmsAdapter implements CloudServiceAdapter {
         }
     }
 
-    /** Paged like ListKeys, so a heavily tagged key would otherwise be truncated. */
-    private async getTags(id: string): Promise<KeyTag[]> {
+    /**
+     * Paged like ListKeys, so a heavily tagged key would otherwise be truncated.
+     *
+     * Tags are enrichment, so a failure degrades the row rather than the request:
+     * `list` builds every row through `Promise.all`, so an unisolated throttle
+     * would reject the whole view. Isolating it here also stops a tag 404 — a key
+     * deleted mid-list — from reaching `describe`'s catch and silently dropping
+     * the key. The failure is reported rather than swallowed, so an untagged key
+     * and an unreadable one stay distinguishable.
+     */
+    private async getTags(id: string): Promise<TagLookup> {
         const tags: KeyTag[] = []
         let marker: string | undefined
 
-        do {
-            const res = await this.kms.send(new ListResourceTagsCommand({KeyId: id, ...(marker ? {Marker: marker} : {})}))
-            for (const tag of res.Tags ?? []) {
-                tags.push({key: tag.TagKey ?? '', value: tag.TagValue ?? ''})
-            }
-            marker = res.Truncated ? res.NextMarker : undefined
-        } while (marker)
+        try {
+            do {
+                const res = await this.kms.send(
+                    new ListResourceTagsCommand({KeyId: id, ...(marker ? {Marker: marker} : {})}),
+                )
+                for (const tag of res.Tags ?? []) {
+                    tags.push({key: tag.TagKey ?? '', value: tag.TagValue ?? ''})
+                }
+                marker = res.Truncated ? res.NextMarker : undefined
+            } while (marker)
+        } catch {
+            // Keep whatever pages already arrived rather than discarding them.
+            return {tags, unavailable: true}
+        }
 
-        return tags
+        return {tags}
     }
 }
 
-function toResource(metadata: KeyMetadata, tags: KeyTag[]): CloudResource {
+function toResource(metadata: KeyMetadata, tagLookup: TagLookup): CloudResource {
     const id = metadata.KeyId ?? ''
 
     return {
@@ -178,7 +197,8 @@ function toResource(metadata: KeyMetadata, tags: KeyTag[]): CloudResource {
             encryptionAlgorithms: metadata.EncryptionAlgorithms,
             signingAlgorithms: metadata.SigningAlgorithms,
             multiRegion: metadata.MultiRegion,
-            tags,
+            tags: tagLookup.tags,
+            ...(tagLookup.unavailable ? {tagsUnavailable: true} : {}),
         },
     }
 }

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.ts
@@ -1,0 +1,213 @@
+import {
+    CreateKeyCommand,
+    DescribeKeyCommand,
+    type KeyMetadata,
+    type KMSClient,
+    ListKeysCommand,
+    ListResourceTagsCommand,
+    ScheduleKeyDeletionCommand,
+    TagResourceCommand,
+    UntagResourceCommand,
+} from '@aws-sdk/client-kms'
+import {ValidationError} from '../cloud-spi/errors'
+import {
+    awsKmsSchema,
+    KMS_DESCRIPTION_MAX_LENGTH,
+    KMS_KEY_SPECS,
+    KMS_KEY_USAGES,
+} from '../cloud-spi/kmsSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+
+type KeyTag = {key: string; value: string}
+
+/**
+ * The shortest deletion window KMS accepts. Deletion is irreversible once it
+ * completes, so the console never offers a longer wait than it has to — but it
+ * also cannot delete immediately, which is why `delete` schedules.
+ */
+const PENDING_DELETION_WINDOW_DAYS = 7
+
+export class AwsKmsAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'kms' as const
+
+    constructor(private readonly kms: KMSClient) {}
+
+    schema(): ServiceSchema {
+        return awsKmsSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const ids = await this.listKeyIds()
+        const resources = await Promise.all(ids.map((id) => this.describe(id)))
+        return filterBySearch(resources.filter((resource): resource is CloudResource => resource !== null), query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        return this.describe(id)
+    }
+
+    async create(input: CreateResourceInput): Promise<CloudResource> {
+        const description = optionalString(input.values.description, 'description')
+        if (description && description.length > KMS_DESCRIPTION_MAX_LENGTH) {
+            throw new ValidationError(`description must be ${KMS_DESCRIPTION_MAX_LENGTH} characters or fewer`)
+        }
+
+        const keyUsage = oneOf(input.values.keyUsage, KMS_KEY_USAGES, 'keyUsage')
+        const keySpec = oneOf(input.values.keySpec, KMS_KEY_SPECS, 'keySpec')
+
+        const res = await this.kms.send(
+            new CreateKeyCommand({
+                ...(description ? {Description: description} : {}),
+                KeyUsage: keyUsage,
+                KeySpec: keySpec,
+            }),
+        )
+        if (!res.KeyMetadata) throw new ValidationError('KMS did not return metadata for the created key')
+
+        // A brand new key has no tags, so this skips the ListResourceTags call.
+        return toResource(res.KeyMetadata, [])
+    }
+
+    /**
+     * KMS has no immediate delete: the key enters PendingDeletion and is destroyed
+     * when the window elapses. It keeps appearing in `list()` until then, which is
+     * the runtime's behaviour and not something to hide.
+     */
+    async delete(id: string): Promise<void> {
+        await this.kms.send(
+            new ScheduleKeyDeletionCommand({KeyId: id, PendingWindowInDays: PENDING_DELETION_WINDOW_DAYS}),
+        )
+    }
+
+    async updateTags(id: string, tags: Record<string, string | null>): Promise<void> {
+        const added = Object.entries(tags).filter((entry): entry is [string, string] => entry[1] !== null)
+        const removed = Object.keys(tags).filter((key) => tags[key] === null)
+
+        if (added.length > 0) {
+            await this.kms.send(
+                new TagResourceCommand({
+                    KeyId: id,
+                    Tags: added.map(([key, value]) => ({TagKey: key, TagValue: value})),
+                }),
+            )
+        }
+        if (removed.length > 0) {
+            await this.kms.send(new UntagResourceCommand({KeyId: id, TagKeys: removed}))
+        }
+    }
+
+    /** ListKeys pages at 100 keys, so an account past that would silently truncate. */
+    private async listKeyIds(): Promise<string[]> {
+        const ids: string[] = []
+        let marker: string | undefined
+
+        do {
+            const res = await this.kms.send(new ListKeysCommand(marker ? {Marker: marker} : {}))
+            for (const key of res.Keys ?? []) {
+                if (key.KeyId) ids.push(key.KeyId)
+            }
+            marker = res.Truncated ? res.NextMarker : undefined
+        } while (marker)
+
+        return ids
+    }
+
+    /**
+     * ListKeys returns only an id and an ARN, so every column the table shows
+     * comes from this per-key DescribeKey call.
+     */
+    private async describe(id: string): Promise<CloudResource | null> {
+        try {
+            const res = await this.kms.send(new DescribeKeyCommand({KeyId: id}))
+            if (!res.KeyMetadata) return null
+            return toResource(res.KeyMetadata, await this.getTags(id))
+        } catch (error) {
+            if (hasHttpStatus(error, 404)) return null
+            throw error
+        }
+    }
+
+    private async getTags(id: string): Promise<KeyTag[]> {
+        const res = await this.kms.send(new ListResourceTagsCommand({KeyId: id}))
+        return (res.Tags ?? []).map((tag) => ({key: tag.TagKey ?? '', value: tag.TagValue ?? ''}))
+    }
+}
+
+function toResource(metadata: KeyMetadata, tags: KeyTag[]): CloudResource {
+    const id = metadata.KeyId ?? ''
+
+    return {
+        id,
+        // KMS keys have no name field; the uuid is the identity.
+        name: id,
+        cloud: 'aws',
+        service: 'kms',
+        type: 'key',
+        region: regionFromArn(metadata.Arn),
+        createdAt: metadata.CreationDate ? metadata.CreationDate.toISOString() : null,
+        status: metadata.KeyState ?? null,
+        metadata: {
+            arn: metadata.Arn,
+            accountId: metadata.AWSAccountId,
+            description: metadata.Description,
+            keyUsage: metadata.KeyUsage,
+            keySpec: metadata.KeySpec,
+            keyManager: metadata.KeyManager,
+            origin: metadata.Origin,
+            enabled: metadata.Enabled,
+            deletionDate: metadata.DeletionDate ? metadata.DeletionDate.toISOString() : null,
+            encryptionAlgorithms: metadata.EncryptionAlgorithms,
+            signingAlgorithms: metadata.SigningAlgorithms,
+            multiRegion: metadata.MultiRegion,
+            tags,
+        },
+    }
+}
+
+/** `arn:aws:kms:us-east-1:000000000000:key/<uuid>` — the region is the 4th field. */
+function regionFromArn(arn: string | undefined): string | null {
+    return arn?.split(':')[3] || null
+}
+
+/** Matches on the id and the description, because the id alone is an opaque uuid. */
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+
+    return resources.filter((resource) => {
+        const description = String(resource.metadata.description ?? '').toLowerCase()
+        return resource.name.toLowerCase().includes(normalized) || description.includes(normalized)
+    })
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+    if (value === undefined || value === null || value === '') return undefined
+    if (typeof value !== 'string') throw new ValidationError(`${field} must be a string`)
+    return value
+}
+
+/**
+ * Keeps create honest about the schema: a value the form never offers would be
+ * rejected by KMS anyway, and failing here gives a typed error instead of a 400.
+ */
+function oneOf<T extends readonly string[]>(value: unknown, allowed: T, field: string): T[number] {
+    const raw = optionalString(value, field)
+    if (raw === undefined) return allowed[0] as T[number]
+    if (!allowed.includes(raw)) {
+        throw new ValidationError(`${field} must be one of ${allowed.join(', ')}`)
+    }
+    return raw as T[number]
+}
+
+function hasHttpStatus(error: unknown, status: number): boolean {
+    if (typeof error !== 'object' || error === null) return false
+    const metadata = (error as {$metadata?: {httpStatusCode?: number}}).$metadata
+    return metadata?.httpStatusCode === status
+}

--- a/packages/api/src/adapter-aws/AwsKmsAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsKmsAdapter.ts
@@ -133,7 +133,7 @@ export class AwsKmsAdapter implements CloudServiceAdapter {
             if (!res.KeyMetadata) return null
             return toResource(res.KeyMetadata, await this.getTags(id))
         } catch (error) {
-            if (hasHttpStatus(error, 404)) return null
+            if (isNotFound(error)) return null
             throw error
         }
     }
@@ -263,8 +263,17 @@ function oneOf<T extends readonly string[]>(
     return raw as T[number]
 }
 
-function hasHttpStatus(error: unknown, status: number): boolean {
+/**
+ * KMS is one of the AWS services that does not use 404 for not-found: real KMS
+ * answers `NotFoundException` with HTTP **400**. The local runtime happens to
+ * send 404, so a status-only check passes every test here and would start
+ * throwing 502s the moment the runtime tightened to the real contract — the same
+ * shape of bug as matching a wire code the SDK never produces. Match the name
+ * first and keep the status as a fallback for the emulator.
+ */
+function isNotFound(error: unknown): boolean {
     if (typeof error !== 'object' || error === null) return false
+    if ((error as {name?: string}).name === 'NotFoundException') return true
     const metadata = (error as {$metadata?: {httpStatusCode?: number}}).$metadata
-    return metadata?.httpStatusCode === status
+    return metadata?.httpStatusCode === 404
 }

--- a/packages/api/src/aws.ts
+++ b/packages/api/src/aws.ts
@@ -4,6 +4,7 @@ import { EKSClient } from "@aws-sdk/client-eks";
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { RDSClient } from "@aws-sdk/client-rds";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { KMSClient } from "@aws-sdk/client-kms";
 
 const endpoint = process.env.FLOCI_ENDPOINT;
 const region = process.env.AWS_REGION || "us-east-1";
@@ -39,6 +40,7 @@ export type AwsClients = {
   ec2: EC2Client;
   rds: RDSClient;
   secretsManager: SecretsManagerClient;
+  kms: KMSClient;
 };
 
 export type AwsClientName = keyof AwsClients;
@@ -58,6 +60,7 @@ function buildClients(accountId: string): AwsClients {
     ec2: new EC2Client(base),
     rds: new RDSClient(base),
     secretsManager: new SecretsManagerClient(base),
+    kms: new KMSClient(base),
   };
 }
 

--- a/packages/api/src/cloud-spi/kmsSchema.ts
+++ b/packages/api/src/cloud-spi/kmsSchema.ts
@@ -1,0 +1,86 @@
+import type {CloudProvider, FieldSchema, ServiceSchema, TableColumnSchema} from './types'
+
+/**
+ * A KMS key has no name — only an opaque uuid and an optional description — so
+ * the description carries the identity in the table and in search.
+ */
+const kmsColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Key ID', format: 'code'},
+    {name: 'description', label: 'Description', path: 'metadata.description', emptyText: '—'},
+    {name: 'status', label: 'State', format: 'badge'},
+    {name: 'keyUsage', label: 'Usage', path: 'metadata.keyUsage'},
+    {name: 'createdAt', label: 'Created', format: 'datetime'},
+]
+
+const kmsFilters: FieldSchema[] = [{name: 'search', label: 'Search', type: 'text', required: false}]
+
+/** Offered on create. Kept in sync with the adapter's validation. */
+export const KMS_KEY_USAGES = ['ENCRYPT_DECRYPT', 'SIGN_VERIFY', 'GENERATE_VERIFY_MAC'] as const
+export const KMS_KEY_SPECS = [
+    'SYMMETRIC_DEFAULT',
+    'RSA_2048',
+    'RSA_4096',
+    'ECC_NIST_P256',
+    'HMAC_256',
+] as const
+
+/** KMS caps a key description at 8192 characters. */
+export const KMS_DESCRIPTION_MAX_LENGTH = 8192
+
+export function awsKmsSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'kms',
+        displayName: 'AWS KMS',
+        fields: [
+            {
+                name: 'description',
+                label: 'Description',
+                type: 'text',
+                required: false,
+                description: 'How this key is used. A key has no name, so this is how you will recognise it.',
+                span: true,
+                validation: {
+                    maxLength: KMS_DESCRIPTION_MAX_LENGTH,
+                    message: `Keep the description under ${KMS_DESCRIPTION_MAX_LENGTH} characters.`,
+                },
+            },
+            {
+                name: 'keyUsage',
+                label: 'Key Usage',
+                type: 'select',
+                required: false,
+                options: KMS_KEY_USAGES.map((value) => ({label: value, value})),
+            },
+            {
+                name: 'keySpec',
+                label: 'Key Spec',
+                type: 'select',
+                required: false,
+                options: KMS_KEY_SPECS.map((value) => ({label: value, value})),
+            },
+        ],
+        actions: ['list', 'create', 'delete', 'inspect'],
+        capabilities: {
+            resourceActions: [
+                {name: 'list', label: 'List keys', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'create', label: 'Create key', enabled: true, status: 'available', runtimeRequired: true},
+                {
+                    name: 'delete',
+                    label: 'Schedule key deletion',
+                    enabled: true,
+                    status: 'available',
+                    runtimeRequired: true,
+                },
+                {name: 'inspect', label: 'Inspect key', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'updateTags', label: 'Edit tags', enabled: true, status: 'available', runtimeRequired: true},
+            ],
+        },
+        filters: kmsFilters,
+        columns: kmsColumns,
+    }
+}
+
+export function kmsSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    return cloud === 'aws' ? awsKmsSchema() : null
+}

--- a/packages/api/src/cloud-spi/kmsSchema.ts
+++ b/packages/api/src/cloud-spi/kmsSchema.ts
@@ -24,6 +24,21 @@ export const KMS_KEY_SPECS = [
     'HMAC_256',
 ] as const
 
+/**
+ * Which specs each usage can actually be created with, and the spec to use when
+ * the caller picks a usage but no spec.
+ *
+ * KMS rejects a mismatched pair — a SIGN_VERIFY key cannot be SYMMETRIC_DEFAULT,
+ * and only HMAC specs can generate MACs. The local runtime is more permissive and
+ * returns 200 for pairs real KMS refuses, so this table, not the runtime, is the
+ * authority. The first entry of each list is the default.
+ */
+export const KMS_SPECS_BY_USAGE = {
+    ENCRYPT_DECRYPT: ['SYMMETRIC_DEFAULT', 'RSA_2048', 'RSA_4096'],
+    SIGN_VERIFY: ['RSA_2048', 'RSA_4096', 'ECC_NIST_P256'],
+    GENERATE_VERIFY_MAC: ['HMAC_256'],
+} as const satisfies Record<(typeof KMS_KEY_USAGES)[number], readonly (typeof KMS_KEY_SPECS)[number][]>
+
 /** KMS caps a key description at 8192 characters. */
 export const KMS_DESCRIPTION_MAX_LENGTH = 8192
 
@@ -57,6 +72,8 @@ export function awsKmsSchema(): ServiceSchema {
                 label: 'Key Spec',
                 type: 'select',
                 required: false,
+                description:
+                    'Must match the key usage: symmetric or RSA to encrypt, RSA or ECC to sign, HMAC to generate MACs. Left unset, a valid spec is chosen for the usage.',
                 options: KMS_KEY_SPECS.map((value) => ({label: value, value})),
             },
         ],

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -71,6 +71,13 @@ export const SERVICE_CATALOG = {
     storage: {displayName: 'Storage', iconKey: 'storage', group: 'Storage', order: 10},
     database: {displayName: 'Database', iconKey: 'database', group: 'Databases', order: 10},
     networking: {displayName: 'Networking', iconKey: 'networking', group: 'Networking', order: 10},
+    kms: {
+        displayName: 'Key Management',
+        displayNameByCloud: {aws: 'KMS'},
+        iconKey: 'kms',
+        group: 'Security',
+        order: 20,
+    },
     secrets: {
         displayName: 'Secrets Manager',
         displayNameByCloud: {azure: 'Key Vault'},

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -152,7 +152,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret' | 'key'
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -14,6 +14,7 @@ import {CloudProxyService} from './service/CloudProxyService'
 import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AzureKeyVaultAdapter} from './adapter-azure/AzureKeyVaultAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
+import {AwsKmsAdapter} from './adapter-aws/AwsKmsAdapter'
 import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
@@ -39,6 +40,7 @@ export function createCloudAdapterRegistry(accountId?: string | null): CloudAdap
         new AwsComputeAdapter(ec2Service),
         new AwsNetworkingAdapter(ec2Service),
         new AwsServerlessAdapter(clients.lambda),
+        new AwsKmsAdapter(clients.kms),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret';
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret' | 'key';
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@aws-sdk/client-eks':
         specifier: ^3.1076.0
         version: 3.1076.0
+      '@aws-sdk/client-kms':
+        specifier: ^3.1096.0
+        version: 3.1096.0
       '@aws-sdk/client-lambda':
         specifier: ^3.1076.0
         version: 3.1076.0
@@ -157,6 +160,10 @@ packages:
     resolution: {integrity: sha512-Hqr3hdwUgqWAQbdx6UDy81UBF+jdu3ws6RrykQ4YmBhe/XOKv57lt2lhkjgBuF9fiSw4UUl2XQteks9oxgm4XA==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-kms@3.1096.0':
+    resolution: {integrity: sha512-oOq9AEOkmEhL9Vlgw5vTYsmeRfZJWnwuAUYCaYHG10UrNApl1gkZEux13eqWYpxsoUM+sNyL9BOthahbUgbSLQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/client-lambda@3.1076.0':
     resolution: {integrity: sha512-uueu0Do1dy3cm42AdjL3zivHoc5b55vOL3g6BjxUv2xMifSLKZi5Ilh5FhXVDdS/Uwxak/JH+vVQDDnEuQ52gA==}
     engines: {node: '>=20.0.0'}
@@ -177,36 +184,72 @@ packages:
     resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/core@3.977.1':
+    resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-env@3.972.54':
     resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-env@3.972.62':
+    resolution: {integrity: sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-http@3.972.56':
     resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-http@3.972.64':
+    resolution: {integrity: sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-ini@3.972.61':
     resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    resolution: {integrity: sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-login@3.972.60':
     resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-login@3.972.69':
+    resolution: {integrity: sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-node@3.972.63':
     resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-node@3.972.73':
+    resolution: {integrity: sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-process@3.972.54':
     resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-process@3.972.62':
+    resolution: {integrity: sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-sso@3.972.60':
     resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    resolution: {integrity: sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    resolution: {integrity: sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -229,16 +272,32 @@ packages:
     resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.36':
+    resolution: {integrity: sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1080.0':
     resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1096.0':
+    resolution: {integrity: sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.15':
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -247,6 +306,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.33':
     resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -509,8 +572,20 @@ packages:
     resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.0':
+    resolution: {integrity: sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.15':
+    resolution: {integrity: sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.6':
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.12':
+    resolution: {integrity: sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.3':
@@ -521,8 +596,16 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/node-http-handler@4.9.12':
+    resolution: {integrity: sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.3':
     resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.11':
+    resolution: {integrity: sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.2':
@@ -531,6 +614,10 @@ packages:
 
   '@smithy/types@4.15.1':
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -1341,6 +1428,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-kms@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/client-lambda@3.1076.0':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -1409,12 +1507,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.0
+      '@smithy/signature-v4': 5.6.11
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.56':
@@ -1425,6 +1542,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.3
       '@smithy/node-http-handler': 4.9.3
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.61':
@@ -1443,6 +1570,22 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-login': 3.972.69
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.15
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1450,6 +1593,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.63':
@@ -1466,12 +1618,34 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.73':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-ini': 3.973.7
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.15
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.60':
@@ -1484,6 +1658,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/token-providers': 3.1096.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1491,6 +1675,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -1536,11 +1729,29 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.36':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     dependencies:
       '@aws-sdk/types': 3.973.15
       '@smithy/signature-v4': 5.6.2
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.11
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1080.0':
@@ -1552,9 +1763,23 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.15':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -1564,6 +1789,11 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.33':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -1818,10 +2048,27 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.15':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.6':
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.3':
@@ -1834,10 +2081,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.12':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.9.3':
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.11':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.2':
@@ -1847,6 +2106,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Adds a `kms` service under the Security group, backed by a new `AwsKmsAdapter`.

Follows the shape established in #153: one catalog row, one adapter, one registry
line, colocated tests. No frontend change.

## Runtime contract notes

- `ListKeys` returns only an id and an ARN, so every displayed column comes from a
  per-key `DescribeKey` fan-out.
- `delete()` maps to `ScheduleKeyDeletion` with the shortest window KMS accepts
  (7 days). Deletion is not immediate and the key keeps appearing in `list()` as
  `PendingDeletion` — that is the provider's behaviour, so it is pinned by a test
  rather than hidden. The capability is labelled "Schedule key deletion" so the UI
  does not promise an immediate delete.
- Search matches the description as well as the id. A KMS key has no name and the
  id is an opaque uuid, so id-only search would be unusable.
- `create()` rejects a `keyUsage` or `keySpec` the schema does not offer, so an
  unsupported value is a typed 400 rather than a provider error.
- `ListKeys` pages at 100 keys; the adapter follows `NextMarker` so a larger
  account does not silently truncate.

## Verification

`lint`, `type-check`, `test` and `build` pass from the repo root.

Tests are hermetic — the KMS, capability-guard and catalog suites pass with
`globalThis.fetch` replaced by a throw.

Verified end to end against the local Floci runtime through the generic resources
route: create (with description, `SIGN_VERIFY`/`RSA_2048`), list, inspect, tag
add/remove, and scheduled deletion; plus both validation paths returning 400
`invalid_request`.

## Merge note

Branched off `main` and independent of #154–#157. The only overlap is the one-line
`CloudResource.type` widening (adds `'key'`), which #156 and #157 also touch — so
whichever of the three merges last is a trivial no-op hunk there.