### PR TITLE
feat(parameters): add an AWS SSM Parameter Store adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ cd packages/api && bun run scripts/service-matrix.ts
 | Databases | Database | Yes (list, inspect) | Yes (list, create, delete, inspect) | Yes (list, create, inspect, delete) |
 | Networking | Networking | Yes (list) | No | No |
 | Security | Secrets Manager / Key Vault | Yes (legacy page) | Yes (list, create, delete, inspect) | No |
+| Security | Parameter Store | Yes (list, create, delete, inspect) | No | No |
 
 Console Home is available for all three clouds.
 

--- a/bun.lock
+++ b/bun.lock
@@ -14,6 +14,7 @@
         "@aws-sdk/client-rds": "^3.1076.0",
         "@aws-sdk/client-s3": "^3.1076.0",
         "@aws-sdk/client-secrets-manager": "^3.1076.0",
+        "@aws-sdk/client-ssm": "^3.1096.0",
         "dotenv": "^17.4.2",
         "hono": "^4.12.27",
       },
@@ -25,7 +26,7 @@
     },
     "packages/frontend": {
       "name": "@floci/frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
@@ -72,6 +73,8 @@
     "@aws-sdk/client-s3": ["@aws-sdk/client-s3@3.1080.0", "", { "dependencies": { "@aws-sdk/checksums": "^3.1000.13", "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/middleware-sdk-s3": "^3.972.59", "@aws-sdk/signature-v4-multi-region": "^3.996.38", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-erKuxbwhYLKs0ZviBeTDvXxC0E4AtugHXLbt5kFk8u9/rQMglh/QJNK5f9KuLjlMrbFSJgkBmjNSY5O03YoK4A=="],
 
     "@aws-sdk/client-secrets-manager": ["@aws-sdk/client-secrets-manager@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-lgrJFeDMdFz7ly0Jn7sTs2wNODJrvq8s1oiiCJFfCiRmMgS2IKk7b73zCC9y0ofKHtp+P+AbqnqUsMabXijmMw=="],
+
+    "@aws-sdk/client-ssm": ["@aws-sdk/client-ssm@3.1096.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/credential-provider-node": "^3.972.73", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-0XcirYRFHk1aWNqUy1QmQKqluZcAvWNAjVUo4izzMlb1bLg1vS8Cmsh2gfONhadBoGXyeSPbkDgWxZWVNXaXrA=="],
 
     "@aws-sdk/core": ["@aws-sdk/core@3.974.28", "", { "dependencies": { "@aws-sdk/types": "^3.973.15", "@aws-sdk/xml-builder": "^3.972.33", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.0", "@smithy/signature-v4": "^5.6.1", "@smithy/types": "^4.15.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw=="],
 
@@ -533,6 +536,20 @@
 
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
+    "@aws-sdk/client-ssm/@aws-sdk/core": ["@aws-sdk/core@3.977.1", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@aws-sdk/xml-builder": "^3.972.37", "@aws/lambda-invoke-store": "^0.3.0", "@smithy/core": "^3.29.8", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "bowser": "^2.11.0", "tslib": "^2.6.2" } }, "sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node": ["@aws-sdk/credential-provider-node@3.972.73", "", { "dependencies": { "@aws-sdk/credential-provider-env": "^3.972.62", "@aws-sdk/credential-provider-http": "^3.972.64", "@aws-sdk/credential-provider-ini": "^3.973.7", "@aws-sdk/credential-provider-process": "^3.972.62", "@aws-sdk/credential-provider-sso": "^3.973.6", "@aws-sdk/credential-provider-web-identity": "^3.972.68", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/types": ["@aws-sdk/types@3.974.2", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA=="],
+
+    "@aws-sdk/client-ssm/@smithy/core": ["@smithy/core@3.31.0", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw=="],
+
+    "@aws-sdk/client-ssm/@smithy/fetch-http-handler": ["@smithy/fetch-http-handler@5.6.12", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q=="],
+
+    "@aws-sdk/client-ssm/@smithy/node-http-handler": ["@smithy/node-http-handler@4.9.12", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q=="],
+
+    "@aws-sdk/client-ssm/@smithy/types": ["@smithy/types@4.16.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg=="],
+
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
@@ -543,6 +560,24 @@
 
     "bun-types/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
 
+    "@aws-sdk/client-ssm/@aws-sdk/core/@aws-sdk/xml-builder": ["@aws-sdk/xml-builder@3.972.37", "", { "dependencies": { "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/core/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-env": ["@aws-sdk/credential-provider-env@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-http": ["@aws-sdk/credential-provider-http@3.972.64", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini": ["@aws-sdk/credential-provider-ini@3.973.7", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/credential-provider-env": "^3.972.62", "@aws-sdk/credential-provider-http": "^3.972.64", "@aws-sdk/credential-provider-login": "^3.972.69", "@aws-sdk/credential-provider-process": "^3.972.62", "@aws-sdk/credential-provider-sso": "^3.973.6", "@aws-sdk/credential-provider-web-identity": "^3.972.68", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/credential-provider-imds": "^4.4.13", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-process": ["@aws-sdk/credential-provider-process@3.972.62", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso": ["@aws-sdk/credential-provider-sso@3.973.6", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/token-providers": "3.1096.0", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity": ["@aws-sdk/credential-provider-web-identity@3.972.68", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@smithy/credential-provider-imds": ["@smithy/credential-provider-imds@4.4.15", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA=="],
+
     "@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
 
     "@babel/helper-compilation-targets/browserslist/caniuse-lite": ["caniuse-lite@1.0.30001791", "", {}, "sha512-yk0l/YSrOnFZk3UROpDLQD9+kC1l4meK/wed583AXrzoarMGJcbRi2Q4RaUYbKxYAsZ8sWmaSa/DsLmdBeI1vQ=="],
@@ -552,5 +587,27 @@
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/credential-provider-login": ["@aws-sdk/credential-provider-login@3.972.69", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/token-providers": ["@aws-sdk/token-providers@3.1096.0", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/nested-clients": "^3.997.36", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients": ["@aws-sdk/nested-clients@3.997.36", "", { "dependencies": { "@aws-sdk/core": "^3.977.1", "@aws-sdk/signature-v4-multi-region": "^3.996.42", "@aws-sdk/types": "^3.974.2", "@smithy/core": "^3.29.8", "@smithy/fetch-http-handler": "^5.6.10", "@smithy/node-http-handler": "^4.9.10", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region": ["@aws-sdk/signature-v4-multi-region@3.996.42", "", { "dependencies": { "@aws-sdk/types": "^3.974.2", "@smithy/signature-v4": "^5.6.9", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-ini/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-sso/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
+
+    "@aws-sdk/client-ssm/@aws-sdk/credential-provider-node/@aws-sdk/credential-provider-web-identity/@aws-sdk/nested-clients/@aws-sdk/signature-v4-multi-region/@smithy/signature-v4": ["@smithy/signature-v4@5.6.11", "", { "dependencies": { "@smithy/core": "^3.31.0", "@smithy/types": "^4.16.1", "tslib": "^2.6.2" } }, "sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw=="],
   }
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -16,6 +16,7 @@
     "@aws-sdk/client-rds": "^3.1076.0",
     "@aws-sdk/client-s3": "^3.1076.0",
     "@aws-sdk/client-secrets-manager": "^3.1076.0",
+    "@aws-sdk/client-ssm": "^3.1096.0",
     "dotenv": "^17.4.2",
     "hono": "^4.12.27"
   },

--- a/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
@@ -291,7 +291,7 @@ describe('AwsParameterStoreAdapter', () => {
         expect(removed.input.TagKeys).toEqual(['stale'])
     })
 
-    test('skips the tag call it has nothing to send', async () => {
+    test('skips the tag call when it has nothing to send', async () => {
         const {client, sent} = stubSsm(() => ({}))
         await new AwsParameterStoreAdapter(client).updateTags('/floci/app/region', {env: 'prod'})
 

--- a/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
@@ -1,0 +1,272 @@
+import {describe, expect, test} from 'bun:test'
+import {
+    AddTagsToResourceCommand,
+    DeleteParameterCommand,
+    DescribeParametersCommand,
+    ListTagsForResourceCommand,
+    PutParameterCommand,
+    RemoveTagsFromResourceCommand,
+    type SSMClient,
+} from '@aws-sdk/client-ssm'
+import {AwsParameterStoreAdapter} from './AwsParameterStoreAdapter'
+import {ValidationError} from '../cloud-spi/errors'
+
+type SendResult = Record<string, unknown>
+
+/** Minimal SSMClient stub that records the commands it was sent. */
+function stubSsm(handler: (command: object) => SendResult | Promise<SendResult>) {
+    const sent: object[] = []
+    const client = {
+        async send(command: object) {
+            sent.push(command)
+            return handler(command)
+        },
+    } as unknown as SSMClient
+    return {client, sent}
+}
+
+const plain = {
+    Name: '/floci/app/region',
+    Type: 'String',
+    Version: 1,
+    LastModifiedDate: new Date('2026-07-28T10:00:00.000Z'),
+    Description: 'deployment region',
+    DataType: 'text',
+    Tier: 'Standard',
+}
+
+const secure = {
+    Name: '/floci/app/token',
+    Type: 'SecureString',
+    Version: 3,
+    LastModifiedDate: new Date('2026-07-28T11:00:00.000Z'),
+    DataType: 'text',
+}
+
+function runtimeStub(overrides: {describe?: SendResult; tags?: SendResult} = {}) {
+    return stubSsm((command) => {
+        if (command instanceof DescribeParametersCommand) {
+            return overrides.describe ?? {Parameters: [plain, secure]}
+        }
+        if (command instanceof ListTagsForResourceCommand) {
+            return overrides.tags ?? {TagList: []}
+        }
+        if (command instanceof PutParameterCommand) return {Version: 1}
+        return {}
+    })
+}
+
+describe('AwsParameterStoreAdapter', () => {
+    test('identifies itself as the AWS Parameter Store adapter', () => {
+        const adapter = new AwsParameterStoreAdapter(runtimeStub().client)
+
+        expect(adapter.cloud).toBe('aws')
+        expect(adapter.service).toBe('parameters')
+        expect(adapter.schema().displayName).toBe('SSM Parameter Store')
+    })
+
+    test('lists parameters with their metadata', async () => {
+        const {client, sent} = runtimeStub()
+        const resources = await new AwsParameterStoreAdapter(client).list()
+
+        expect(sent[0]).toBeInstanceOf(DescribeParametersCommand)
+        expect(resources).toHaveLength(2)
+        expect(resources[0]).toMatchObject({
+            id: '/floci/app/region',
+            name: '/floci/app/region',
+            cloud: 'aws',
+            service: 'parameters',
+            type: 'parameter',
+            createdAt: '2026-07-28T10:00:00.000Z',
+        })
+        expect(resources[0]?.metadata).toMatchObject({
+            parameterType: 'String',
+            version: 1,
+            description: 'deployment region',
+            dataType: 'text',
+            tier: 'Standard',
+        })
+    })
+
+    test('never exposes a parameter value, not even for a plain String', async () => {
+        // metadata reaches the inspector, the query cache and telemetry, so a
+        // value must not travel with the resource. This is the same rule both
+        // secrets adapters pin, and it matters more here: the local runtime
+        // returns SecureString plaintext even without WithDecryption, so relying
+        // on the runtime to withhold it would leak.
+        const {client, sent} = runtimeStub()
+        const adapter = new AwsParameterStoreAdapter(client)
+
+        const resources = await adapter.list()
+        const inspected = await adapter.get('/floci/app/token')
+
+        for (const resource of [...resources, inspected]) {
+            expect(JSON.stringify(resource)).not.toContain('Value')
+            expect(resource?.metadata.value).toBeUndefined()
+        }
+        // The value is never even requested.
+        expect(sent.every((command) => command.constructor.name !== 'GetParameterCommand')).toBe(true)
+    })
+
+    test('marks that the value is withheld so the UI can explain the empty field', async () => {
+        const {client} = runtimeStub()
+        const [resource] = await new AwsParameterStoreAdapter(client).list()
+
+        expect(resource?.metadata.valueWithheld).toBe(true)
+    })
+
+    test('follows NextToken until the runtime stops paging', async () => {
+        // The local runtime ignores MaxResults and returns everything in one
+        // response, so only a stub can prove the loop works. Real SSM pages at 10.
+        let call = 0
+        const {client, sent} = stubSsm((command) => {
+            if (command instanceof ListTagsForResourceCommand) return {TagList: []}
+            call += 1
+            if (call === 1) return {Parameters: [plain], NextToken: 'page-2'}
+            if (call === 2) return {Parameters: [secure], NextToken: 'page-3'}
+            return {Parameters: [{...plain, Name: '/floci/app/third'}]}
+        })
+
+        const resources = await new AwsParameterStoreAdapter(client).list()
+
+        expect(resources.map((r) => r.id)).toEqual(['/floci/app/region', '/floci/app/token', '/floci/app/third'])
+        const describes = sent.filter((c) => c instanceof DescribeParametersCommand) as DescribeParametersCommand[]
+        expect(describes).toHaveLength(3)
+        expect(describes[1]?.input.NextToken).toBe('page-2')
+        expect(describes[2]?.input.NextToken).toBe('page-3')
+    })
+
+    test('filters the list by name or description', async () => {
+        const adapter = new AwsParameterStoreAdapter(runtimeStub().client)
+
+        await expect(adapter.list({search: 'token'})).resolves.toHaveLength(1)
+        await expect(adapter.list({search: 'deployment'})).resolves.toHaveLength(1)
+        await expect(adapter.list({search: 'nope'})).resolves.toHaveLength(0)
+    })
+
+    test('inspects a parameter through a server-side name filter', async () => {
+        const {client, sent} = runtimeStub({describe: {Parameters: [plain]}})
+        const resource = await new AwsParameterStoreAdapter(client).get('/floci/app/region')
+
+        const command = sent[0] as DescribeParametersCommand
+        expect(command).toBeInstanceOf(DescribeParametersCommand)
+        expect(command.input.ParameterFilters).toEqual([
+            {Key: 'Name', Option: 'Equals', Values: ['/floci/app/region']},
+        ])
+        expect(resource?.id).toBe('/floci/app/region')
+    })
+
+    test('returns null when the name filter matches nothing', async () => {
+        const {client} = runtimeStub({describe: {Parameters: []}})
+        await expect(new AwsParameterStoreAdapter(client).get('/nope')).resolves.toBeNull()
+    })
+
+    test('returns null on ParameterNotFound even though the runtime answers 400', async () => {
+        // SSM reports a missing parameter as ParameterNotFound with HTTP 400, not
+        // 404, so matching on the status alone would rethrow instead of returning
+        // null and the inspector would show a runtime error for a missing row.
+        const {client} = stubSsm(() => {
+            throw Object.assign(new Error('Parameter /nope not found.'), {
+                name: 'ParameterNotFound',
+                $metadata: {httpStatusCode: 400},
+            })
+        })
+        await expect(new AwsParameterStoreAdapter(client).get('/nope')).resolves.toBeNull()
+    })
+
+    test('rethrows a failure that is not a missing parameter', async () => {
+        const {client} = stubSsm(() => {
+            throw Object.assign(new Error('AccessDenied'), {
+                name: 'AccessDeniedException',
+                $metadata: {httpStatusCode: 403},
+            })
+        })
+        await expect(new AwsParameterStoreAdapter(client).get('/floci/app/region')).rejects.toThrow('AccessDenied')
+    })
+
+    test('creates a parameter without Overwrite so an existing name is a conflict', async () => {
+        // Overwrite:true would silently replace a parameter the user did not mean
+        // to touch, which is data loss dressed up as a create.
+        const {client, sent} = runtimeStub({describe: {Parameters: [plain]}})
+        await new AwsParameterStoreAdapter(client).create({
+            values: {name: '/floci/app/region', value: 'eu-west-1', type: 'String', description: 'deployment region'},
+        })
+
+        const command = sent[0] as PutParameterCommand
+        expect(command).toBeInstanceOf(PutParameterCommand)
+        expect(command.input.Name).toBe('/floci/app/region')
+        expect(command.input.Value).toBe('eu-west-1')
+        expect(command.input.Type).toBe('String')
+        expect(command.input.Overwrite).toBeUndefined()
+    })
+
+    test('returns the created parameter without echoing the value back', async () => {
+        const {client} = runtimeStub({describe: {Parameters: [plain]}})
+        const resource = await new AwsParameterStoreAdapter(client).create({
+            values: {name: '/floci/app/region', value: 'eu-west-1', type: 'String'},
+        })
+
+        expect(resource.id).toBe('/floci/app/region')
+        expect(JSON.stringify(resource)).not.toContain('eu-west-1')
+    })
+
+    test('requires the fields the schema marks required', async () => {
+        const adapter = new AwsParameterStoreAdapter(runtimeStub().client)
+
+        const cases: Array<[Record<string, unknown>, string]> = [
+            [{}, 'name is required'],
+            [{name: '/floci/app/region'}, 'value is required'],
+        ]
+
+        for (const [values, message] of cases) {
+            await expect(adapter.create({values})).rejects.toThrow(new ValidationError(message))
+        }
+    })
+
+    test('rejects a parameter type the schema does not offer', async () => {
+        const adapter = new AwsParameterStoreAdapter(runtimeStub().client)
+
+        await expect(
+            adapter.create({values: {name: '/a', value: 'b', type: 'Encrypted'}}),
+        ).rejects.toThrow(ValidationError)
+    })
+
+    test('deletes a parameter by name', async () => {
+        const {client, sent} = stubSsm(() => ({}))
+        await new AwsParameterStoreAdapter(client).delete('/floci/app/region')
+
+        const command = sent[0] as DeleteParameterCommand
+        expect(command).toBeInstanceOf(DeleteParameterCommand)
+        expect(command.input.Name).toBe('/floci/app/region')
+    })
+
+    test('surfaces parameter tags under metadata', async () => {
+        const {client} = runtimeStub({
+            describe: {Parameters: [plain]},
+            tags: {TagList: [{Key: 'env', Value: 'prod'}]},
+        })
+        const [resource] = await new AwsParameterStoreAdapter(client).list()
+
+        expect(resource?.metadata.tags).toEqual([{key: 'env', value: 'prod'}])
+    })
+
+    test('adds and removes tags against the Parameter resource type', async () => {
+        const {client, sent} = stubSsm(() => ({}))
+        await new AwsParameterStoreAdapter(client).updateTags('/floci/app/region', {env: 'prod', stale: null})
+
+        const added = sent.find((c) => c instanceof AddTagsToResourceCommand) as AddTagsToResourceCommand
+        const removed = sent.find((c) => c instanceof RemoveTagsFromResourceCommand) as RemoveTagsFromResourceCommand
+
+        expect(added.input.ResourceType).toBe('Parameter')
+        expect(added.input.ResourceId).toBe('/floci/app/region')
+        expect(added.input.Tags).toEqual([{Key: 'env', Value: 'prod'}])
+        expect(removed.input.TagKeys).toEqual(['stale'])
+    })
+
+    test('skips the tag call it has nothing to send', async () => {
+        const {client, sent} = stubSsm(() => ({}))
+        await new AwsParameterStoreAdapter(client).updateTags('/floci/app/region', {env: 'prod'})
+
+        expect(sent.some((c) => c instanceof RemoveTagsFromResourceCommand)).toBe(false)
+    })
+})

--- a/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsParameterStoreAdapter.test.ts
@@ -250,6 +250,34 @@ describe('AwsParameterStoreAdapter', () => {
         expect(resource?.metadata.tags).toEqual([{key: 'env', value: 'prod'}])
     })
 
+    test('still lists parameters when the tag lookup fails', async () => {
+        // list() builds every row through Promise.all, so an unisolated tag
+        // failure — throttling, transient IAM, a delete race — would reject the
+        // whole view and show nothing rather than metadata without tags.
+        const {client} = stubSsm((command) => {
+            if (command instanceof DescribeParametersCommand) return {Parameters: [plain]}
+            throw Object.assign(new Error('Rate exceeded'), {
+                name: 'ThrottlingException',
+                $metadata: {httpStatusCode: 400},
+            })
+        })
+
+        const [resource] = await new AwsParameterStoreAdapter(client).list()
+
+        expect(resource?.id).toBe('/floci/app/region')
+        expect(resource?.metadata.tags).toEqual([])
+        // Degraded, not silent: the UI can say tags could not be read.
+        expect(resource?.metadata.tagsUnavailable).toBe(true)
+    })
+
+    test('does not claim tags are unavailable when they are simply empty', async () => {
+        const {client} = runtimeStub({describe: {Parameters: [plain]}, tags: {TagList: []}})
+        const [resource] = await new AwsParameterStoreAdapter(client).list()
+
+        expect(resource?.metadata.tags).toEqual([])
+        expect(resource?.metadata.tagsUnavailable).toBeUndefined()
+    })
+
     test('adds and removes tags against the Parameter resource type', async () => {
         const {client, sent} = stubSsm(() => ({}))
         await new AwsParameterStoreAdapter(client).updateTags('/floci/app/region', {env: 'prod', stale: null})

--- a/packages/api/src/adapter-aws/AwsParameterStoreAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsParameterStoreAdapter.ts
@@ -1,0 +1,220 @@
+import {
+    AddTagsToResourceCommand,
+    DeleteParameterCommand,
+    DescribeParametersCommand,
+    type DescribeParametersCommandInput,
+    ListTagsForResourceCommand,
+    type ParameterMetadata,
+    PutParameterCommand,
+    RemoveTagsFromResourceCommand,
+    type SSMClient,
+} from '@aws-sdk/client-ssm'
+import {RuntimeError, ValidationError} from '../cloud-spi/errors'
+import {awsParametersSchema, PARAMETER_NAME_MAX_LENGTH, PARAMETER_TYPES} from '../cloud-spi/parametersSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+
+type ParameterTag = {key: string; value: string}
+
+/**
+ * SSM reports a missing parameter as `ParameterNotFound` with HTTP **400**, not
+ * 404, so `get` matches on the error name. Matching the status instead would
+ * rethrow and show a runtime error where the console expects an empty result.
+ */
+const NOT_FOUND_NAME = 'ParameterNotFound'
+
+export class AwsParameterStoreAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'parameters' as const
+
+    constructor(private readonly ssm: SSMClient) {}
+
+    schema(): ServiceSchema {
+        return awsParametersSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const parameters = await this.describeAll()
+        const resources = await Promise.all(parameters.map((parameter) => this.toResource(parameter)))
+        return filterBySearch(resources, query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        try {
+            const [parameter] = await this.describe({
+                ParameterFilters: [{Key: 'Name', Option: 'Equals', Values: [id]}],
+            })
+            return parameter ? await this.toResource(parameter) : null
+        } catch (error) {
+            if (isNotFound(error)) return null
+            throw error
+        }
+    }
+
+    /**
+     * Creates without `Overwrite`, so an existing name fails as a conflict rather
+     * than silently replacing a parameter the caller did not mean to touch.
+     */
+    async create(input: CreateResourceInput): Promise<CloudResource> {
+        const name = requiredString(input.values.name, 'name')
+        if (name.length > PARAMETER_NAME_MAX_LENGTH) {
+            throw new ValidationError(`name must be ${PARAMETER_NAME_MAX_LENGTH} characters or fewer`)
+        }
+        const value = requiredString(input.values.value, 'value')
+        const type = oneOf(input.values.type, PARAMETER_TYPES, 'type')
+        const description = optionalString(input.values.description, 'description')
+
+        await this.ssm.send(
+            new PutParameterCommand({
+                Name: name,
+                Value: value,
+                Type: type,
+                ...(description ? {Description: description} : {}),
+            }),
+        )
+
+        // Read the metadata back rather than echoing the input, so the returned
+        // resource reflects the runtime — and carries no value.
+        const created = await this.get(name)
+        if (!created) throw new RuntimeError(`Parameter ${name} was created but could not be read back`)
+        return created
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.ssm.send(new DeleteParameterCommand({Name: id}))
+    }
+
+    async updateTags(id: string, tags: Record<string, string | null>): Promise<void> {
+        const added = Object.entries(tags).filter((entry): entry is [string, string] => entry[1] !== null)
+        const removed = Object.keys(tags).filter((key) => tags[key] === null)
+
+        if (added.length > 0) {
+            await this.ssm.send(
+                new AddTagsToResourceCommand({
+                    ResourceType: 'Parameter',
+                    ResourceId: id,
+                    Tags: added.map(([key, value]) => ({Key: key, Value: value})),
+                }),
+            )
+        }
+        if (removed.length > 0) {
+            await this.ssm.send(
+                new RemoveTagsFromResourceCommand({ResourceType: 'Parameter', ResourceId: id, TagKeys: removed}),
+            )
+        }
+    }
+
+    /**
+     * The local runtime ignores MaxResults and returns everything in one response,
+     * so this loop is only exercised by tests. Real SSM pages at 10.
+     */
+    private async describeAll(): Promise<ParameterMetadata[]> {
+        const parameters: ParameterMetadata[] = []
+        let token: string | undefined
+
+        do {
+            const page = await this.ssm.send(
+                new DescribeParametersCommand(token ? {NextToken: token} : {}),
+            )
+            parameters.push(...(page.Parameters ?? []))
+            token = page.NextToken
+        } while (token)
+
+        return parameters
+    }
+
+    private async describe(input: DescribeParametersCommandInput): Promise<ParameterMetadata[]> {
+        const res = await this.ssm.send(new DescribeParametersCommand(input))
+        return res.Parameters ?? []
+    }
+
+    private async toResource(parameter: ParameterMetadata): Promise<CloudResource> {
+        const name = parameter.Name ?? ''
+        return toResource(parameter, await this.getTags(name))
+    }
+
+    private async getTags(name: string): Promise<ParameterTag[]> {
+        const res = await this.ssm.send(
+            new ListTagsForResourceCommand({ResourceType: 'Parameter', ResourceId: name}),
+        )
+        return (res.TagList ?? []).map((tag) => ({key: tag.Key ?? '', value: tag.Value ?? ''}))
+    }
+}
+
+/**
+ * Builds the resource **without the parameter value**, deliberately.
+ *
+ * `metadata` reaches the inspector, the React Query cache and telemetry, so a
+ * value must never travel with the resource — the same rule both secrets
+ * adapters pin. It matters more here than it looks: the local runtime returns
+ * SecureString plaintext even when `WithDecryption` is false, so relying on the
+ * runtime to withhold it would leak the secret. The adapter therefore never
+ * issues GetParameter at all.
+ */
+function toResource(parameter: ParameterMetadata, tags: ParameterTag[]): CloudResource {
+    const name = parameter.Name ?? ''
+
+    return {
+        id: name,
+        name,
+        cloud: 'aws',
+        service: 'parameters',
+        type: 'parameter',
+        // Parameter Store is regional but DescribeParameters does not echo the
+        // region, and inventing one would be fake data.
+        region: null,
+        createdAt: parameter.LastModifiedDate ? parameter.LastModifiedDate.toISOString() : null,
+        status: null,
+        metadata: {
+            parameterType: parameter.Type,
+            version: parameter.Version,
+            description: parameter.Description,
+            dataType: parameter.DataType,
+            tier: parameter.Tier,
+            allowedPattern: parameter.AllowedPattern,
+            lastModifiedUser: parameter.LastModifiedUser,
+            /** Tells the inspector the blank value is a policy, not a gap. */
+            valueWithheld: true,
+            tags,
+        },
+    }
+}
+
+/** Matches on the name and the description, since a name is often a long path. */
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+
+    return resources.filter((resource) => {
+        const description = String(resource.metadata.description ?? '').toLowerCase()
+        return resource.name.toLowerCase().includes(normalized) || description.includes(normalized)
+    })
+}
+
+function isNotFound(error: unknown): boolean {
+    return typeof error === 'object' && error !== null && (error as {name?: string}).name === NOT_FOUND_NAME
+}
+
+function requiredString(value: unknown, field: string): string {
+    const raw = optionalString(value, field)
+    if (raw === undefined) throw new ValidationError(`${field} is required`)
+    return raw
+}
+
+function optionalString(value: unknown, field: string): string | undefined {
+    if (value === undefined || value === null || value === '') return undefined
+    if (typeof value !== 'string') throw new ValidationError(`${field} must be a string`)
+    return value
+}
+
+function oneOf<T extends readonly string[]>(value: unknown, allowed: T, field: string): T[number] {
+    const raw = optionalString(value, field)
+    if (raw === undefined) return allowed[0] as T[number]
+    if (!allowed.includes(raw)) throw new ValidationError(`${field} must be one of ${allowed.join(', ')}`)
+    return raw as T[number]
+}

--- a/packages/api/src/adapter-aws/AwsParameterStoreAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsParameterStoreAdapter.ts
@@ -21,6 +21,9 @@ import type {
 
 type ParameterTag = {key: string; value: string}
 
+/** Tags plus whether the lookup itself failed, so the two stay distinguishable. */
+type TagLookup = {tags: ParameterTag[]; unavailable?: true}
+
 /**
  * SSM reports a missing parameter as `ParameterNotFound` with HTTP **400**, not
  * 404, so `get` matches on the error name. Matching the status instead would
@@ -138,11 +141,23 @@ export class AwsParameterStoreAdapter implements CloudServiceAdapter {
         return toResource(parameter, await this.getTags(name))
     }
 
-    private async getTags(name: string): Promise<ParameterTag[]> {
-        const res = await this.ssm.send(
-            new ListTagsForResourceCommand({ResourceType: 'Parameter', ResourceId: name}),
-        )
-        return (res.TagList ?? []).map((tag) => ({key: tag.Key ?? '', value: tag.Value ?? ''}))
+    /**
+     * Tags are enrichment, so a failure here degrades the row instead of failing
+     * the request. `list` builds every row through `Promise.all`, so an unisolated
+     * throttle or a delete race would reject the whole view and show nothing.
+     *
+     * The failure is reported as `tagsUnavailable` rather than swallowed, so an
+     * empty tag list and an unreadable one stay distinguishable.
+     */
+    private async getTags(name: string): Promise<TagLookup> {
+        try {
+            const res = await this.ssm.send(
+                new ListTagsForResourceCommand({ResourceType: 'Parameter', ResourceId: name}),
+            )
+            return {tags: (res.TagList ?? []).map((tag) => ({key: tag.Key ?? '', value: tag.Value ?? ''}))}
+        } catch {
+            return {tags: [], unavailable: true}
+        }
     }
 }
 
@@ -156,7 +171,7 @@ export class AwsParameterStoreAdapter implements CloudServiceAdapter {
  * runtime to withhold it would leak the secret. The adapter therefore never
  * issues GetParameter at all.
  */
-function toResource(parameter: ParameterMetadata, tags: ParameterTag[]): CloudResource {
+function toResource(parameter: ParameterMetadata, tagLookup: TagLookup): CloudResource {
     const name = parameter.Name ?? ''
 
     return {
@@ -180,7 +195,8 @@ function toResource(parameter: ParameterMetadata, tags: ParameterTag[]): CloudRe
             lastModifiedUser: parameter.LastModifiedUser,
             /** Tells the inspector the blank value is a policy, not a gap. */
             valueWithheld: true,
-            tags,
+            tags: tagLookup.tags,
+            ...(tagLookup.unavailable ? {tagsUnavailable: true} : {}),
         },
     }
 }

--- a/packages/api/src/aws.ts
+++ b/packages/api/src/aws.ts
@@ -4,6 +4,7 @@ import { EKSClient } from "@aws-sdk/client-eks";
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { RDSClient } from "@aws-sdk/client-rds";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { SSMClient } from "@aws-sdk/client-ssm";
 
 const endpoint = process.env.FLOCI_ENDPOINT;
 const region = process.env.AWS_REGION || "us-east-1";
@@ -39,6 +40,7 @@ export type AwsClients = {
   ec2: EC2Client;
   rds: RDSClient;
   secretsManager: SecretsManagerClient;
+  ssm: SSMClient;
 };
 
 export type AwsClientName = keyof AwsClients;
@@ -58,6 +60,7 @@ function buildClients(accountId: string): AwsClients {
     ec2: new EC2Client(base),
     rds: new RDSClient(base),
     secretsManager: new SecretsManagerClient(base),
+    ssm: new SSMClient(base),
   };
 }
 

--- a/packages/api/src/cloud-spi/parametersSchema.ts
+++ b/packages/api/src/cloud-spi/parametersSchema.ts
@@ -1,0 +1,86 @@
+import type {CloudProvider, FieldSchema, ServiceSchema, TableColumnSchema} from './types'
+
+/**
+ * No value column, by design. A parameter value never travels with the resource
+ * (see AwsParameterStoreAdapter), so offering the column would render an empty
+ * cell for every row.
+ */
+const parameterColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Name', format: 'code'},
+    {name: 'parameterType', label: 'Type', path: 'metadata.parameterType', format: 'badge'},
+    {name: 'description', label: 'Description', path: 'metadata.description', emptyText: '—'},
+    {name: 'version', label: 'Version', path: 'metadata.version'},
+    {name: 'createdAt', label: 'Last Modified', format: 'datetime'},
+]
+
+const parameterFilters: FieldSchema[] = [{name: 'search', label: 'Search', type: 'text', required: false}]
+
+export const PARAMETER_TYPES = ['String', 'StringList', 'SecureString'] as const
+
+/** SSM caps a Standard-tier parameter name at 1011 characters. */
+export const PARAMETER_NAME_MAX_LENGTH = 1011
+
+export function awsParametersSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'parameters',
+        displayName: 'SSM Parameter Store',
+        fields: [
+            {
+                name: 'name',
+                label: 'Name',
+                type: 'text',
+                required: true,
+                description: 'Hierarchical names are conventional, e.g. /app/prod/region.',
+                validation: {
+                    minLength: 1,
+                    maxLength: PARAMETER_NAME_MAX_LENGTH,
+                    message: 'Use a name of up to 1011 characters, optionally with / separators.',
+                },
+            },
+            {
+                name: 'type',
+                label: 'Type',
+                type: 'select',
+                required: false,
+                description: 'SecureString is stored encrypted. Its value is never returned to the console.',
+                options: PARAMETER_TYPES.map((value) => ({label: value, value})),
+            },
+            {
+                name: 'value',
+                label: 'Value',
+                type: 'text',
+                required: true,
+                span: true,
+                description: 'Accepted here on create, but never read back.',
+            },
+            {name: 'description', label: 'Description', type: 'text', required: false, span: true},
+        ],
+        actions: ['list', 'create', 'delete', 'inspect'],
+        capabilities: {
+            resourceActions: [
+                {name: 'list', label: 'List parameters', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'create', label: 'Create parameter', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'delete', label: 'Delete parameter', enabled: true, status: 'available', runtimeRequired: true},
+                {
+                    name: 'inspect',
+                    label: 'Inspect parameter',
+                    enabled: true,
+                    // Metadata only. The value is deliberately withheld, so this is
+                    // not a full inspect and the UI should say so rather than
+                    // render a blank field and look broken.
+                    status: 'partial',
+                    reason: 'Parameter values are never returned to the console, so the inspector shows metadata only.',
+                    runtimeRequired: true,
+                },
+                {name: 'updateTags', label: 'Edit tags', enabled: true, status: 'available', runtimeRequired: true},
+            ],
+        },
+        filters: parameterFilters,
+        columns: parameterColumns,
+    }
+}
+
+export function parametersSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    return cloud === 'aws' ? awsParametersSchema() : null
+}

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -71,6 +71,12 @@ export const SERVICE_CATALOG = {
     storage: {displayName: 'Storage', iconKey: 'storage', group: 'Storage', order: 10},
     database: {displayName: 'Database', iconKey: 'database', group: 'Databases', order: 10},
     networking: {displayName: 'Networking', iconKey: 'networking', group: 'Networking', order: 10},
+    parameters: {
+        displayName: 'Parameter Store',
+        iconKey: 'parameters',
+        group: 'Security',
+        order: 30,
+    },
     secrets: {
         displayName: 'Secrets Manager',
         displayNameByCloud: {azure: 'Key Vault'},

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -152,7 +152,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret' | 'parameter'
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -14,6 +14,7 @@ import {CloudProxyService} from './service/CloudProxyService'
 import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AzureKeyVaultAdapter} from './adapter-azure/AzureKeyVaultAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
+import {AwsParameterStoreAdapter} from './adapter-aws/AwsParameterStoreAdapter'
 import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
@@ -39,6 +40,7 @@ export function createCloudAdapterRegistry(accountId?: string | null): CloudAdap
         new AwsComputeAdapter(ec2Service),
         new AwsNetworkingAdapter(ec2Service),
         new AwsServerlessAdapter(clients.lambda),
+        new AwsParameterStoreAdapter(clients.ssm),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new GcpStorageAdapter(),

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret';
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret' | 'parameter';
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       '@aws-sdk/client-secrets-manager':
         specifier: ^3.1076.0
         version: 3.1076.0
+      '@aws-sdk/client-ssm':
+        specifier: ^3.1096.0
+        version: 3.1096.0
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -173,40 +176,80 @@ packages:
     resolution: {integrity: sha512-N6azFky/nhHaBfLxza6fMnLbOCgqO12StpCgMDVzx43W7phexcWT61r2mHWrVK6VA6TU+Bze12ZQUb017+VWpw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/client-ssm@3.1096.0':
+    resolution: {integrity: sha512-0XcirYRFHk1aWNqUy1QmQKqluZcAvWNAjVUo4izzMlb1bLg1vS8Cmsh2gfONhadBoGXyeSPbkDgWxZWVNXaXrA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/core@3.974.28':
     resolution: {integrity: sha512-4/1DtLwgLqzIg2uFzkFaFjMQHhhhwHIZN4PfziIVqXYX7koO78omuchQlLHyzQBw80l255dtmTA/J4W5yhb7zw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/core@3.977.1':
+    resolution: {integrity: sha512-KVtQRtc00ES/y+Sc3vYXeP6pCIcNlBJCZOwvqSy8ZpVGmbM5+IG+AfhuTKQ2oXmIVqZJewaGMMpzPkywC6xg0w==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-env@3.972.54':
     resolution: {integrity: sha512-F4WQCG8GULIt+XrMHsqUM9dZc0eTwZM3HUWByOjIKOwBqJSzUxX8CFAtbgMvWfCua52FS1oi5FXarH3+khFq8A==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-env@3.972.62':
+    resolution: {integrity: sha512-BkDrk2cNjed31IKin/Oksb2ziF+gfuyRskFVuT4EU9Mep7M8Y/d8DJG4+anHme4Vuse7CwaEscwEfGyR6mzBhQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-http@3.972.56':
     resolution: {integrity: sha512-PiwHgEK2srdfi/lFveyQ+3w/qikyh6MKvuZAdlMC+dwQi4K5iVBr32oh7cugnYw+jA8iGtnQMhCGvLm/mqplmw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-http@3.972.64':
+    resolution: {integrity: sha512-Wj1FGK2IxY5EccQCvH+niTYhIvDoDujJf2CpRRgS3NpYNEgiFNVItNbJYQjINRlu7fG7jSsXkKV0UWKriEplrw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-ini@3.972.61':
     resolution: {integrity: sha512-9CZWMjhBlgfKlqJk40R7kvMOLEIoOr3HJ1J/ELjAH9H5LzR4bCxLujPVM/1PKAEjzSZKZCxWOalm7JUGZbhQqw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    resolution: {integrity: sha512-2CefB8cCxDu52P24B8Ay93/cTT199bcSvNHQ8e2f4BjSCF83yErBnTIZEBo0VeIgCfmw+PJKFUXnlQWxm2dkug==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-login@3.972.60':
     resolution: {integrity: sha512-Ak6OOrCbXvACyxLFIP1mcS+JTLS9ZpW1ZqyBtqu6axvdpsbG1gVNhUlAfQq8TK/gar/h2w35LrzlQU0PcUzJpw==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-login@3.972.69':
+    resolution: {integrity: sha512-gM3j0Ie9+FoLNTYODY+QWbg3vCRBc7mR9cRdntxTMkFYIrwfRmuucfavP6HNBlYSuaYww54TNJGej4GFgoPZAg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-node@3.972.63':
     resolution: {integrity: sha512-YmgWtTPZDStyT74ApSHpApD3r7W9znsc+WEZjW0vceom+NAxRx9/F3TyukOKix8kJkPaa49aIREQJdpGeLDiEw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-node@3.972.73':
+    resolution: {integrity: sha512-VTzdbf8Ukjdb9yUubZzRI678CWZvKovhE8Nv3qihwhC187sRMGls+r9N8Wuht5q1xjKx2nmpS48ar8ppupjkCA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-process@3.972.54':
     resolution: {integrity: sha512-UNmUjtTnp3wH3YTZcctN7yK17S2AdaJpiNIdIf0l70hHOdGuDfdMxk62P5rt64GwGm6qkFOYG0js/cU6cdZDdg==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-process@3.972.62':
+    resolution: {integrity: sha512-zXYU9UWNL66gtMgNLhmxlrvEokuI7r6G2q7FRGu41Bya4iS30JLelUipJX9SV4zhyCPWJhI9Li54R1d9H8Tq6A==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/credential-provider-sso@3.972.60':
     resolution: {integrity: sha512-zH8SvJkTRw1Kb7GARjGPjzkQPfL3jDi/OxK32I5SQq7bgwgFHJZaoDEwkEvFlfNfpByM6n4Rs20Y1mLyOdb6ag==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    resolution: {integrity: sha512-DobZggy3K49xdCpjeyMou0FQhkoYbluVGNydL6D+lcxF8GoAsttFX0xnH5GmiQ89We5dB6TRpW+CD/VowBH6HQ==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     resolution: {integrity: sha512-q2rJSQ/AMjemUS18OtQqczqSo2R6VjOCLmLVmLVcdrP5/AKoj632lGCrMUWQ6EgnaLMEHbq0UO4mWh/u6gjPhA==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    resolution: {integrity: sha512-bq+yTt+uWJx60VVp/OIAX5xqUAu/K2Uc3eknWnWl+KtfcU2CQe0uNw6lySrn2t5GKHq7jsV0Z63HiBGVtzr/lg==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -229,16 +272,32 @@ packages:
     resolution: {integrity: sha512-1oG/mM3jmE2M3kad2zWJS6IKIY8hjRV4l5kAgg+xTQdLMTtehhcSucL/y4WqQpcHmQwi6+gRK8E46GYl1NBW9Q==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/nested-clients@3.997.36':
+    resolution: {integrity: sha512-b71Suv7L+DnhM0MsQHU4WO42I32kxLZi96PbVhZbxMYIoKnEZz3v+LSrG8fupAoA4cBSshCk1Dl/PeRz49qUSg==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     resolution: {integrity: sha512-C379Sk+MiFZCfWZphKlMyLHKxV22OjoGM5KJjj5IJNJcOCWL4IGIpnEGzv1FQiRwhYXfq55SJMfxlqPE08JJ9g==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    resolution: {integrity: sha512-DBV4naZP6HYBlAvPpoQzOP12Wvfou/5rN8yJPXjBTBylU5qwCbh/tXr2MddHoIjgoRkEl/eS+IljiUqvmwey1Q==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/token-providers@3.1080.0':
     resolution: {integrity: sha512-8PufAQvncWXvdZUvODbuyXa8l3aszefEzwSMBUcgheNbZOmJMcNn388Ebt/piVrUHyxKN1MlxnR2OonzTyZaGw==}
     engines: {node: '>=20.0.0'}
 
+  '@aws-sdk/token-providers@3.1096.0':
+    resolution: {integrity: sha512-hdUS2hDppy3vkWeFl5y86RLNU6OWH2mQB09yOSsRefwhhGTSFPkaZvfLDD/9vFcvMzlr8QFQFw3fw2FtrurVQA==}
+    engines: {node: '>=20.0.0'}
+
   '@aws-sdk/types@3.973.15':
     resolution: {integrity: sha512-IULn8uBV/SMtmOIANsm4WHXIOtVPBWfOWs3WGL0j/sI+KhaYehvOw0ET+9urnn8MBpiijuU/0JOpuwKOE451PQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/types@3.974.2':
+    resolution: {integrity: sha512-3W6IUtSxFbH6X7Wb7DzGCV5QiFQsd0g8bOfntpmDxQlzBoKWUMBu/JPQR0DwkE+Hpnxd6db1tXbOwdeHddG6cA==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -247,6 +306,10 @@ packages:
 
   '@aws-sdk/xml-builder@3.972.33':
     resolution: {integrity: sha512-ezbwz9WpuLctm6o7P2t2naDhVVPI5jFGrVefVybhcKGjU57VIyT46pQVO0RI2RYkUdhdj2Z9uSIlAzGZE9NW9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@aws-sdk/xml-builder@3.972.37':
+    resolution: {integrity: sha512-zKq4HQum8JwDyEuyfuI4bbiAcU0KxP6qy+9PR/IsR92IyE/DaBAikzAS50tjxip4bqIIANpCcG+Yyj6CVhXupg==}
     engines: {node: '>=20.0.0'}
 
   '@aws/lambda-invoke-store@0.3.0':
@@ -509,8 +572,20 @@ packages:
     resolution: {integrity: sha512-qoiY4nrk5OCu1+eIR1VB8l5DmON/oKiqrd5zZFAhXJXjJlLWQusKEW/SkBDAtGDcPaz86m9kfcE1lngU0GlM6A==}
     engines: {node: '>=18.0.0'}
 
+  '@smithy/core@3.31.0':
+    resolution: {integrity: sha512-sylYk2l9d7CmRv8ts8p0SDQUr3VO+HMeS1nrjL6+UtbO8ktJHTOeQ1McX+aAyvGGccp5aZX9eNtdcXrSwzoZaw==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/credential-provider-imds@4.4.15':
+    resolution: {integrity: sha512-xYVGrisQqTJWhOnScUhbx8s9H63TMtoxzuUoxG6mP8J+B/YbX3vZxVsgV0xDf43abJnJP0fjP7BkQh7OESwuRA==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/credential-provider-imds@4.4.6':
     resolution: {integrity: sha512-B2WQ/PV/H6Jeg3lrIq6bKUfa6Hy01mtK7CGs6lhjzHA6k4aagldH6T6eEjnzKl4HI0cJnAsxfJ19pgb5PV+CVQ==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/fetch-http-handler@5.6.12':
+    resolution: {integrity: sha512-OpQgP6IGH4j0NJ2zjfYZLjQL85ai+Wi/q51EmZJovXsEwKSvu89qiXUq77Q6EmwZ/hSl7fKpn2Z9mhiDN6OM+Q==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/fetch-http-handler@5.6.3':
@@ -521,8 +596,16 @@ packages:
     resolution: {integrity: sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==}
     engines: {node: '>=14.0.0'}
 
+  '@smithy/node-http-handler@4.9.12':
+    resolution: {integrity: sha512-dWW5KRt4mnEvjNzbGqGeCuAvgum85Y9ZoyuMQqcTEfapndyVJ1k9BEHK7kdXJZ32enyRmmwcFjMwlB/KgLKI3Q==}
+    engines: {node: '>=18.0.0'}
+
   '@smithy/node-http-handler@4.9.3':
     resolution: {integrity: sha512-qZTa4gQFUo8RM02rk6q5UVTDLNrQ1oS20LsepBzqq1QBVc/EHJ03OOUADcqMZiXHArW+Y7+OGY0BpdTwZRq/Yg==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/signature-v4@5.6.11':
+    resolution: {integrity: sha512-7HsspeiNCZvZHEJ22vV5L/QYuJdTyJvPJvMrYD3AgkM3IJB0pkln4jkjPvtpTWRMkHXbO8WKwNjoVdVlBFwHmw==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/signature-v4@5.6.2':
@@ -531,6 +614,10 @@ packages:
 
   '@smithy/types@4.15.1':
     resolution: {integrity: sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q==}
+    engines: {node: '>=18.0.0'}
+
+  '@smithy/types@4.16.1':
+    resolution: {integrity: sha512-0JFs3V2y2M9tKW5na/qxe69Zv+uxLMO7QBbhxF/FHu/Gp2NFZAAL9tWl9PU02xxo07pb3G9FTyjNc6D5uZrJIg==}
     engines: {node: '>=18.0.0'}
 
   '@smithy/util-buffer-from@2.2.0':
@@ -1398,6 +1485,17 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/client-ssm@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-node': 3.972.73
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/core@3.974.28':
     dependencies:
       '@aws-sdk/types': 3.973.15
@@ -1409,12 +1507,31 @@ snapshots:
       bowser: 2.14.1
       tslib: 2.8.1
 
+  '@aws-sdk/core@3.977.1':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@aws-sdk/xml-builder': 3.972.37
+      '@aws/lambda-invoke-store': 0.3.0
+      '@smithy/core': 3.31.0
+      '@smithy/signature-v4': 5.6.11
+      '@smithy/types': 4.16.1
+      bowser: 2.14.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-env@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-env@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-http@3.972.56':
@@ -1425,6 +1542,16 @@ snapshots:
       '@smithy/fetch-http-handler': 5.6.3
       '@smithy/node-http-handler': 4.9.3
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-http@3.972.64':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-ini@3.972.61':
@@ -1443,6 +1570,22 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-ini@3.973.7':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-login': 3.972.69
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.15
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-login@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1450,6 +1593,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-login@3.972.69':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-node@3.972.63':
@@ -1466,12 +1618,34 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-node@3.972.73':
+    dependencies:
+      '@aws-sdk/credential-provider-env': 3.972.62
+      '@aws-sdk/credential-provider-http': 3.972.64
+      '@aws-sdk/credential-provider-ini': 3.973.7
+      '@aws-sdk/credential-provider-process': 3.972.62
+      '@aws-sdk/credential-provider-sso': 3.973.6
+      '@aws-sdk/credential-provider-web-identity': 3.972.68
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/credential-provider-imds': 4.4.15
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-process@3.972.54':
     dependencies:
       '@aws-sdk/core': 3.974.28
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-process@3.972.62':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/credential-provider-sso@3.972.60':
@@ -1484,6 +1658,16 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/credential-provider-sso@3.973.6':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/token-providers': 3.1096.0
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/credential-provider-web-identity@3.972.60':
     dependencies:
       '@aws-sdk/core': 3.974.28
@@ -1491,6 +1675,15 @@ snapshots:
       '@aws-sdk/types': 3.973.15
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/credential-provider-web-identity@3.972.68':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/middleware-flexible-checksums@3.974.38':
@@ -1536,11 +1729,29 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/nested-clients@3.997.36':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/signature-v4-multi-region': 3.996.42
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/fetch-http-handler': 5.6.12
+      '@smithy/node-http-handler': 4.9.12
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/signature-v4-multi-region@3.996.38':
     dependencies:
       '@aws-sdk/types': 3.973.15
       '@smithy/signature-v4': 5.6.2
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/signature-v4-multi-region@3.996.42':
+    dependencies:
+      '@aws-sdk/types': 3.974.2
+      '@smithy/signature-v4': 5.6.11
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/token-providers@3.1080.0':
@@ -1552,9 +1763,23 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@aws-sdk/token-providers@3.1096.0':
+    dependencies:
+      '@aws-sdk/core': 3.977.1
+      '@aws-sdk/nested-clients': 3.997.36
+      '@aws-sdk/types': 3.974.2
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@aws-sdk/types@3.973.15':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/types@3.974.2':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws-sdk/util-locate-window@3.965.8':
@@ -1564,6 +1789,11 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.33':
     dependencies:
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@aws-sdk/xml-builder@3.972.37':
+    dependencies:
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@aws/lambda-invoke-store@0.3.0': {}
@@ -1818,10 +2048,27 @@ snapshots:
       '@smithy/types': 4.15.1
       tslib: 2.8.1
 
+  '@smithy/core@3.31.0':
+    dependencies:
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
+  '@smithy/credential-provider-imds@4.4.15':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/credential-provider-imds@4.4.6':
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/fetch-http-handler@5.6.12':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/fetch-http-handler@5.6.3':
@@ -1834,10 +2081,22 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
+  '@smithy/node-http-handler@4.9.12':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
+      tslib: 2.8.1
+
   '@smithy/node-http-handler@4.9.3':
     dependencies:
       '@smithy/core': 3.29.1
       '@smithy/types': 4.15.1
+      tslib: 2.8.1
+
+  '@smithy/signature-v4@5.6.11':
+    dependencies:
+      '@smithy/core': 3.31.0
+      '@smithy/types': 4.16.1
       tslib: 2.8.1
 
   '@smithy/signature-v4@5.6.2':
@@ -1847,6 +2106,10 @@ snapshots:
       tslib: 2.8.1
 
   '@smithy/types@4.15.1':
+    dependencies:
+      tslib: 2.8.1
+
+  '@smithy/types@4.16.1':
     dependencies:
       tslib: 2.8.1
 


### PR DESCRIPTION
Adds a `parameters` service under the Security group, backed by a new
`AwsParameterStoreAdapter`. One catalog row, one adapter, one registry line, no
frontend change.

## Values are never returned

A value is accepted on create, but no list or inspect response carries one and
the adapter **never calls `GetParameter` at all**, so a value cannot reach the
inspector, the React Query cache or telemetry. This is the rule both secrets
adapters pin, and it matters more here than it looks: the local runtime returns
`SecureString` plaintext **even when `WithDecryption` is false**, so relying on
the runtime to withhold it would leak the secret.

Resources carry `metadata.valueWithheld` so the UI can say the field is withheld
by policy rather than missing, and `inspect` is advertised as `partial` with that
reason rather than claiming a full inspect it does not provide.

## Runtime contract notes

- A missing parameter is `ParameterNotFound` with HTTP **400, not 404**, so `get`
  matches on the error name. The `hasHttpStatus(error, 404)` idiom used elsewhere
  in `adapter-aws/` would rethrow here and show a runtime error where the console
  expects an empty result. (`awsErrors.ts` already maps the name correctly for the
  route layer — this is only about `get` returning `null`.)
- `create` omits `Overwrite`, so an existing name is a 409 conflict rather than a
  silent replacement of a parameter the caller did not target.
- `DescribeParameters` is paged on `NextToken`. The local runtime **ignores
  `MaxResults`** and returns everything in one response, so only the unit test
  covers the loop; real SSM pages at 10.
- Search matches the description as well as the name, since names are often long
  paths and the name alone is a poor search target.
- Hierarchical names work end to end: `HttpClient.ts:257` encodes path params, so
  an id like `/app/prod/region` survives the generic resources route. Verified
  with an encoded id rather than assumed.

## Verification

`lint`, `type-check`, `test` and `build` pass from the repo root. Both lockfiles
install `--frozen-lockfile` clean.

Tests are hermetic — the parameters, capability-guard and catalog suites (102
tests) pass with `globalThis.fetch` replaced by a throw.

Verified against the local Floci runtime through the generic resources route:
create for `String` and `SecureString`, list, inspect by encoded hierarchical id,
tag add/remove, delete, search, 404 for a missing name, and 409 on a duplicate
create. Both list and inspect responses were grepped and contain neither value.

## Merge note

Branched off `main` and independent of the other open service PRs. Adds
`'parameter'` to `CloudResource.type`; #156, #157 and #158 each widen that same
union with their own member, so the last of them to merge may need a trivial
conflict resolution on that one line.