### PR TITLE
feat(containers): add a containers category with GCP Cloud Run

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cd packages/api && bun run scripts/service-matrix.ts
 | Compute | Compute | Yes (list, inspect, create, delete) | No | No |
 | Compute | EKS / AKS / GKE | Yes (list, inspect) | No | Yes (list, create, inspect, delete) |
 | Compute | Serverless | Yes (list, create, inspect, delete) | Runtime gap | Yes (list, create, inspect, delete) |
+| Compute | Containers / Cloud Run | No | No | Yes (list, create, delete, inspect) |
 | Storage | Storage | Yes (list, create, delete, inspect) | Yes (list, create, delete, inspect) | Yes (list, create, delete, inspect) |
 | Databases | Database | Yes (list, inspect) | Yes (list, create, delete, inspect) | Yes (list, create, inspect, delete) |
 | Networking | Networking | Yes (list) | No | No |
@@ -197,6 +198,30 @@ Current gaps:
 - GCP Cloud Functions invoke is not wired yet; the capability is advertised as
   `coming_soon` instead of being silently missing.
 - Old AWS Lambda page is gone; all future work should stay in the unified model.
+
+</details>
+
+<details>
+<summary><strong>Containers</strong></summary>
+
+GCP Cloud Run, through the unified shell.
+
+- List, inspect, deploy, and delete Cloud Run services.
+- Image, container port, URL, traffic split, and generation are surfaced.
+- Deploying really starts a container: the runtime launches the requested image.
+
+Readiness is reported honestly. A deploy settles at `PENDING` and then becomes
+`SUCCEEDED` or `FAILED`; the runtime's own explanation is kept in
+`metadata.terminalMessage`. The usual cause of `FAILED` is a container that does
+not listen on the port given by `$PORT` (8080 by default) — `nginx:alpine`
+listens on 80 and fails for exactly that reason, so the create form says so.
+
+Current gaps:
+
+- No AWS ECS or Azure Container Apps adapter yet.
+- No revision history, traffic splitting, or scaling controls.
+- Deleting a service while it is still `PENDING` can race the create; deleting a
+  settled service is durable.
 
 </details>
 

--- a/packages/api/src/adapter-gcp/GcpCloudRunAdapter.test.ts
+++ b/packages/api/src/adapter-gcp/GcpCloudRunAdapter.test.ts
@@ -1,0 +1,206 @@
+import {afterEach, describe, expect, test} from 'bun:test'
+import {GcpCloudRunAdapter} from './GcpCloudRunAdapter'
+import {GcpRestRuntimeClient} from '../gcp'
+import {ValidationError} from '../cloud-spi/errors'
+
+const originalFetch = globalThis.fetch
+const ENDPOINT = 'http://localhost:4588'
+const SERVICES_PATH = '/v2/projects/floci-local/locations/us-central1/services'
+
+afterEach(() => {
+    globalThis.fetch = originalFetch
+})
+
+function adapter(): GcpCloudRunAdapter {
+    return new GcpCloudRunAdapter(new GcpRestRuntimeClient(ENDPOINT, 'floci-local', 'us-central1'))
+}
+
+/** Records every request so path, method and body can be asserted. */
+function stubFetch(handler: (url: string, init?: RequestInit) => Response) {
+    const calls: Array<{url: string; init?: RequestInit}> = []
+    globalThis.fetch = (async (url: string, init?: RequestInit) => {
+        calls.push({url: String(url), init})
+        return handler(String(url), init)
+    }) as unknown as typeof fetch
+    return calls
+}
+
+function json(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {status})
+}
+
+function cloudRunService(name: string, overrides: Record<string, unknown> = {}) {
+    return {
+        name: `projects/floci-local/locations/us-central1/services/${name}`,
+        uid: '4cd5586e-3fca-460b-ac38-2267fc4b8b79',
+        generation: '1',
+        createTime: '2026-07-28T09:21:30.065937592Z',
+        updateTime: '2026-07-28T09:21:30.065937592Z',
+        template: {containers: [{image: 'nginx:alpine'}]},
+        traffic: [{type: 'TRAFFIC_TARGET_ALLOCATION_TYPE_LATEST', percent: 100}],
+        urls: [`http://${name}-1efb2c36c23f.us-central1.run.localhost.floci.io:4588`],
+        observedGeneration: '1',
+        terminalCondition: {
+            type: 'Ready',
+            state: 'CONDITION_SUCCEEDED',
+            message: 'Ready',
+            lastTransitionTime: '2026-07-28T09:21:30.065937592Z',
+        },
+        ...overrides,
+    }
+}
+
+describe('GcpCloudRunAdapter', () => {
+    test('identifies itself as the GCP containers adapter', () => {
+        const a = adapter()
+
+        expect(a.cloud).toBe('gcp')
+        expect(a.service).toBe('containers')
+        expect(a.schema().displayName).toBe('Cloud Run')
+    })
+
+    test('lists services and maps the v2 resource shape', async () => {
+        const calls = stubFetch(() => json({services: [cloudRunService('web')]}))
+        const [resource] = await adapter().list()
+
+        expect(calls[0]?.url).toBe(`${ENDPOINT}${SERVICES_PATH}`)
+        expect(resource).toMatchObject({
+            id: 'web',
+            name: 'web',
+            cloud: 'gcp',
+            service: 'containers',
+            type: 'cloud-run-service',
+            region: 'us-central1',
+            createdAt: '2026-07-28T09:21:30.065937592Z',
+            status: 'SUCCEEDED',
+        })
+        expect(resource?.metadata).toMatchObject({
+            image: 'nginx:alpine',
+            uri: 'http://web-1efb2c36c23f.us-central1.run.localhost.floci.io:4588',
+            generation: '1',
+        })
+    })
+
+    test('reports an empty list when the runtime returns no services key', async () => {
+        // The runtime answers `{}` rather than `{"services": []}` when empty.
+        stubFetch(() => json({}))
+        await expect(adapter().list()).resolves.toEqual([])
+    })
+
+    test('surfaces a failed readiness condition instead of hiding it', async () => {
+        // A container that does not listen on $PORT never becomes ready. The state
+        // and the runtime's explanation both have to reach the UI.
+        stubFetch(() =>
+            json({
+                services: [
+                    cloudRunService('broken', {
+                        terminalCondition: {
+                            type: 'Ready',
+                            state: 'CONDITION_FAILED',
+                            message: 'Cloud Run runtime did not become ready before timeout: Connection refused',
+                        },
+                    }),
+                ],
+            }),
+        )
+        const [resource] = await adapter().list()
+
+        expect(resource?.status).toBe('FAILED')
+        expect(resource?.metadata.terminalMessage).toContain('did not become ready')
+    })
+
+    test('follows nextPageToken until the runtime stops paging', async () => {
+        let call = 0
+        const calls = stubFetch(() => {
+            call += 1
+            if (call === 1) return json({services: [cloudRunService('one')], nextPageToken: 'page-2'})
+            return json({services: [cloudRunService('two')]})
+        })
+
+        const resources = await adapter().list()
+
+        expect(resources.map((r) => r.id)).toEqual(['one', 'two'])
+        expect(calls[1]?.url).toContain('pageToken=page-2')
+    })
+
+    test('filters the list by search term', async () => {
+        stubFetch(() => json({services: [cloudRunService('web'), cloudRunService('api')]}))
+        const a = adapter()
+
+        await expect(a.list({search: 'we'})).resolves.toHaveLength(1)
+        await expect(a.list({search: 'nope'})).resolves.toHaveLength(0)
+    })
+
+    test('inspects a service by short name', async () => {
+        const calls = stubFetch(() => json(cloudRunService('web')))
+        const resource = await adapter().get('web')
+
+        expect(calls[0]?.url).toBe(`${ENDPOINT}${SERVICES_PATH}/web`)
+        expect(resource?.id).toBe('web')
+    })
+
+    test('returns null when a service does not exist', async () => {
+        stubFetch(() => json({error: {code: 404, message: 'Cloud Run service not found', status: 'NOT_FOUND'}}, 404))
+        await expect(adapter().get('missing')).resolves.toBeNull()
+    })
+
+    test('deploys a service with the image under the template', async () => {
+        const calls = stubFetch((url, init) =>
+            init?.method === 'POST'
+                ? json({name: 'projects/floci-local/locations/us-central1/operations/op-1'})
+                : json(cloudRunService('web')),
+        )
+        const resource = await adapter().create({values: {name: 'web', image: 'nginx:alpine'}})
+
+        const post = calls[0]
+        expect(post?.url).toBe(`${ENDPOINT}${SERVICES_PATH}?serviceId=web`)
+        expect(post?.init?.method).toBe('POST')
+        expect(JSON.parse(String(post?.init?.body))).toEqual({
+            template: {containers: [{image: 'nginx:alpine'}]},
+        })
+        // create returns an Operation, so the service is read back rather than
+        // parsed out of the envelope.
+        expect(calls[1]?.url).toBe(`${ENDPOINT}${SERVICES_PATH}/web`)
+        expect(resource.id).toBe('web')
+    })
+
+    test('passes a container port through when one is given', async () => {
+        const calls = stubFetch((url, init) =>
+            init?.method === 'POST' ? json({name: 'op'}) : json(cloudRunService('web')),
+        )
+        await adapter().create({values: {name: 'web', image: 'nginx:alpine', port: '3000'}})
+
+        expect(JSON.parse(String(calls[0]?.init?.body))).toEqual({
+            template: {containers: [{image: 'nginx:alpine', ports: [{containerPort: 3000}]}]},
+        })
+    })
+
+    test('requires the fields the schema marks required', async () => {
+        const a = adapter()
+
+        await expect(a.create({values: {}})).rejects.toThrow(new ValidationError('name is required'))
+        await expect(a.create({values: {name: 'web'}})).rejects.toThrow(new ValidationError('image is required'))
+    })
+
+    test('rejects a name the runtime would refuse', async () => {
+        const a = adapter()
+
+        for (const name of ['Web', '1web', 'web_service', 'web-']) {
+            await expect(a.create({values: {name, image: 'nginx'}})).rejects.toThrow(ValidationError)
+        }
+    })
+
+    test('rejects a port that is not a number', async () => {
+        await expect(
+            adapter().create({values: {name: 'web', image: 'nginx', port: 'http'}}),
+        ).rejects.toThrow(ValidationError)
+    })
+
+    test('deletes a service by short name', async () => {
+        const calls = stubFetch(() => json({name: 'op-delete'}))
+        await adapter().delete('web')
+
+        expect(calls[0]?.url).toBe(`${ENDPOINT}${SERVICES_PATH}/web`)
+        expect(calls[0]?.init?.method).toBe('DELETE')
+    })
+})

--- a/packages/api/src/adapter-gcp/GcpCloudRunAdapter.ts
+++ b/packages/api/src/adapter-gcp/GcpCloudRunAdapter.ts
@@ -1,0 +1,211 @@
+import {RuntimeError, ValidationError} from '../cloud-spi/errors'
+import {
+    CLOUD_RUN_NAME_MAX_LENGTH,
+    CLOUD_RUN_NAME_PATTERN,
+    gcpContainersSchema,
+} from '../cloud-spi/containersSchema'
+import {gcp, type GcpRuntimeClient} from '../gcp'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+
+/**
+ * Talks to the Floci-GCP emulator's Cloud Run service. The emulator mirrors the
+ * public Cloud Run Admin v2 REST API — verified against `floci/floci-gcp` 0.5.0:
+ *
+ *   list   GET    /v2/projects/{p}/locations/{l}/services                  -> {services: [...]}
+ *   get    GET    /v2/projects/{p}/locations/{l}/services/{id}             -> Service
+ *   create POST   /v2/projects/{p}/locations/{l}/services?serviceId={id}   -> Operation
+ *   delete DELETE /v2/projects/{p}/locations/{l}/services/{id}             -> Operation
+ *
+ * Notes from probing the emulator:
+ *  - An empty project returns `{}`, not `{"services": []}`.
+ *  - create really does start a container: a service with `nginx:alpine` produced
+ *    a `floci-cloudrun-*` container running that image.
+ *  - create is asynchronous. It returns an Operation whose `metadata` holds the
+ *    Service, and the service is immediately listable as `CONDITION_PENDING`, so
+ *    this adapter reads the service back rather than unpacking the envelope.
+ *  - Readiness is real: a container that does not listen on $PORT settles at
+ *    `CONDITION_FAILED` with "did not become ready before timeout". That state is
+ *    surfaced, not hidden — it is the single most common deploy mistake.
+ */
+interface CloudRunContainer {
+    image?: string
+    ports?: Array<{containerPort?: number; name?: string}>
+    resources?: {limits?: Record<string, string>}
+}
+
+interface CloudRunService {
+    name?: string
+    uid?: string
+    generation?: string
+    createTime?: string
+    updateTime?: string
+    template?: {containers?: CloudRunContainer[]; revision?: string; serviceAccount?: string}
+    traffic?: Array<{type?: string; percent?: number; revision?: string}>
+    urls?: string[]
+    observedGeneration?: string
+    terminalCondition?: {type?: string; state?: string; message?: string; lastTransitionTime?: string}
+    labels?: Record<string, string>
+}
+
+interface CloudRunServiceList {
+    services?: CloudRunService[]
+    nextPageToken?: string
+}
+
+export class GcpCloudRunAdapter implements CloudServiceAdapter {
+    readonly cloud = 'gcp' as const
+    readonly service = 'containers' as const
+
+    constructor(private readonly client: GcpRuntimeClient = gcp) {}
+
+    schema(): ServiceSchema {
+        return gcpContainersSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const services: CloudRunService[] = []
+        let pageToken: string | undefined
+
+        do {
+            const path = pageToken
+                ? `${this.servicesPath()}?pageToken=${encodeURIComponent(pageToken)}`
+                : this.servicesPath()
+            const body = await this.client.json<CloudRunServiceList>(path)
+            services.push(...(body?.services ?? []))
+            pageToken = body?.nextPageToken
+        } while (pageToken)
+
+        return filterBySearch(services.map(toResource), query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        const service = await this.client.json<CloudRunService>(
+            `${this.servicesPath()}/${encodeURIComponent(id)}`,
+            {method: 'GET'},
+            {emptyOnNotFound: true},
+        )
+        return service ? toResource(service) : null
+    }
+
+    async create(input: CreateResourceInput): Promise<CloudResource> {
+        const name = requiredString(input.values.name, 'name')
+        if (name.length > CLOUD_RUN_NAME_MAX_LENGTH || !new RegExp(CLOUD_RUN_NAME_PATTERN).test(name)) {
+            throw new ValidationError(
+                'name must start with a letter and contain only lowercase letters, digits and hyphens',
+            )
+        }
+        const image = requiredString(input.values.image, 'image')
+        const port = optionalPort(input.values.port)
+
+        const container: CloudRunContainer = {image, ...(port ? {ports: [{containerPort: port}]} : {})}
+
+        await this.client.json(this.servicesPath(`?serviceId=${encodeURIComponent(name)}`), {
+            method: 'POST',
+            headers: {'content-type': 'application/json'},
+            body: JSON.stringify({template: {containers: [container]}}),
+        })
+
+        // The Operation envelope carries the Service under `metadata`, but reading
+        // it back is what the runtime actually holds — including the pending
+        // readiness state a fresh deploy starts in.
+        const created = await this.get(name)
+        if (!created) throw new RuntimeError(`Cloud Run service ${name} was created but could not be read back`)
+        return created
+    }
+
+    async delete(id: string): Promise<void> {
+        await this.client.fetch(
+            `${this.servicesPath()}/${encodeURIComponent(id)}`,
+            {method: 'DELETE'},
+            {emptyOnNotFound: true},
+        )
+    }
+
+    private servicesPath(suffix = ''): string {
+        const project = encodeURIComponent(this.client.project)
+        const location = encodeURIComponent(this.client.location)
+        return `/v2/projects/${project}/locations/${location}/services${suffix}`
+    }
+}
+
+function toResource(service: CloudRunService): CloudResource {
+    const name = shortName(service.name ?? '')
+    const container = service.template?.containers?.[0] ?? {}
+    const condition = service.terminalCondition ?? {}
+
+    return {
+        id: name,
+        name,
+        cloud: 'gcp',
+        service: 'containers',
+        type: 'cloud-run-service',
+        region: locationOf(service.name ?? ''),
+        createdAt: service.createTime ?? service.updateTime ?? null,
+        // CONDITION_SUCCEEDED / CONDITION_PENDING / CONDITION_FAILED — the prefix
+        // is noise in a table cell, the value itself is the runtime's.
+        status: readinessState(condition.state),
+        metadata: {
+            provider: 'gcp',
+            containerService: 'cloud-run',
+            resourceName: service.name,
+            uid: service.uid,
+            image: container.image,
+            containerPort: container.ports?.[0]?.containerPort,
+            resourceLimits: container.resources?.limits,
+            urls: service.urls,
+            uri: service.urls?.[0],
+            traffic: service.traffic,
+            generation: service.generation,
+            observedGeneration: service.observedGeneration,
+            /** Why the service is not ready, straight from the runtime. */
+            terminalMessage: condition.message,
+            serviceAccount: service.template?.serviceAccount,
+            updateTime: service.updateTime,
+            lastModified: service.updateTime,
+            labels: service.labels,
+        },
+    }
+}
+
+/** `CONDITION_FAILED` -> `FAILED`; anything unexpected passes through unchanged. */
+function readinessState(state: string | undefined): string | null {
+    if (!state) return null
+    return state.startsWith('CONDITION_') ? state.slice('CONDITION_'.length) : state
+}
+
+function shortName(resourceName: string): string {
+    const match = resourceName.match(/services\/([^/]+)$/)
+    return match ? match[1] : resourceName
+}
+
+function locationOf(resourceName: string): string | null {
+    const match = resourceName.match(/locations\/([^/]+)/)
+    return match ? match[1] : null
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((resource) => resource.name.toLowerCase().includes(normalized))
+}
+
+function requiredString(value: unknown, field: string): string {
+    const raw = typeof value === 'string' ? value.trim() : ''
+    if (!raw) throw new ValidationError(`${field} is required`)
+    return raw
+}
+
+function optionalPort(value: unknown): number | undefined {
+    if (value === undefined || value === null || value === '') return undefined
+    const port = Number(value)
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+        throw new ValidationError('port must be an integer between 1 and 65535')
+    }
+    return port
+}

--- a/packages/api/src/cloud-spi/containersSchema.ts
+++ b/packages/api/src/cloud-spi/containersSchema.ts
@@ -1,0 +1,69 @@
+import type {CloudProvider, FieldSchema, ServiceSchema, TableColumnSchema} from './types'
+
+const containerColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Service'},
+    {name: 'status', label: 'State', format: 'badge'},
+    {name: 'image', label: 'Image', path: 'metadata.image', format: 'code', emptyText: '—'},
+    {name: 'uri', label: 'URL', path: 'metadata.uri', emptyText: '—'},
+    {name: 'createdAt', label: 'Created', format: 'datetime'},
+]
+
+const containerFilters: FieldSchema[] = [{name: 'search', label: 'Search', type: 'text', required: false}]
+
+/** Cloud Run service names: lowercase letters, digits and hyphens, max 49 chars. */
+export const CLOUD_RUN_NAME_PATTERN = '^[a-z]([-a-z0-9]*[a-z0-9])?$'
+export const CLOUD_RUN_NAME_MAX_LENGTH = 49
+
+export function gcpContainersSchema(): ServiceSchema {
+    return {
+        cloud: 'gcp',
+        service: 'containers',
+        displayName: 'Cloud Run',
+        fields: [
+            {
+                name: 'name',
+                label: 'Service Name',
+                type: 'text',
+                required: true,
+                validation: {
+                    pattern: CLOUD_RUN_NAME_PATTERN,
+                    minLength: 1,
+                    maxLength: CLOUD_RUN_NAME_MAX_LENGTH,
+                    message: 'Start with a letter; lowercase letters, digits and hyphens only.',
+                },
+            },
+            {
+                name: 'image',
+                label: 'Container Image',
+                type: 'text',
+                required: true,
+                span: true,
+                // The most common cause of a service that never becomes ready.
+                description:
+                    'The container must listen on the port given by the PORT environment variable (8080 by default). An image that listens elsewhere will report a failed condition.',
+            },
+            {
+                name: 'port',
+                label: 'Container Port',
+                type: 'text',
+                required: false,
+                description: 'Overrides the port passed to the container. Defaults to 8080.',
+            },
+        ],
+        actions: ['list', 'create', 'delete', 'inspect'],
+        capabilities: {
+            resourceActions: [
+                {name: 'list', label: 'List services', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'create', label: 'Deploy service', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'delete', label: 'Delete service', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'inspect', label: 'Inspect service', enabled: true, status: 'available', runtimeRequired: true},
+            ],
+        },
+        filters: containerFilters,
+        columns: containerColumns,
+    }
+}
+
+export function containersSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    return cloud === 'gcp' ? gcpContainersSchema() : null
+}

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -68,6 +68,13 @@ export const SERVICE_CATALOG = {
         order: 20,
     },
     serverless: {displayName: 'Serverless', iconKey: 'serverless', group: 'Compute', order: 30},
+    containers: {
+        displayName: 'Containers',
+        displayNameByCloud: {gcp: 'Cloud Run'},
+        iconKey: 'containers',
+        group: 'Compute',
+        order: 40,
+    },
     storage: {displayName: 'Storage', iconKey: 'storage', group: 'Storage', order: 10},
     database: {displayName: 'Database', iconKey: 'database', group: 'Databases', order: 10},
     networking: {displayName: 'Networking', iconKey: 'networking', group: 'Networking', order: 10},

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -152,7 +152,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret' | 'cloud-run-service'
     region: string | null
     createdAt: string | null
     status?: string | null

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -10,6 +10,7 @@ import {GcpStorageAdapter} from './adapter-gcp/GcpStorageAdapter'
 import {GcpCloudFunctionsAdapter} from './adapter-gcp/GcpCloudFunctionsAdapter'
 import {GcpCloudSqlAdapter} from './adapter-gcp/GcpCloudSqlAdapter'
 import {GcpGkeAdapter} from './adapter-gcp/GcpGkeAdapter'
+import {GcpCloudRunAdapter} from './adapter-gcp/GcpCloudRunAdapter'
 import {CloudProxyService} from './service/CloudProxyService'
 import {AzureServerlessAdapter} from './adapter-azure/AzureServerlessAdapter'
 import {AzureKeyVaultAdapter} from './adapter-azure/AzureKeyVaultAdapter'
@@ -45,6 +46,7 @@ export function createCloudAdapterRegistry(accountId?: string | null): CloudAdap
         new GcpCloudFunctionsAdapter(),
         new GcpCloudSqlAdapter(),
         new GcpGkeAdapter(),
+        new GcpCloudRunAdapter(),
         new AzureServerlessAdapter(),
         new AzureKeyVaultAdapter(),
     ])

--- a/packages/frontend/src/components/serviceIcons.ts
+++ b/packages/frontend/src/components/serviceIcons.ts
@@ -1,6 +1,7 @@
 import {
     Boxes,
     Circle,
+    Container,
     Database,
     HardDrive,
     KeyRound,
@@ -30,7 +31,7 @@ const SERVICE_ICONS: Record<string, LucideIcon> = {
     nosql: Database,
     k8s: Boxes,
     compute: Server,
-    containers: Boxes,
+    containers: Container,
     networking: Network,
     serverless: Zap,
     secrets: KeyRound,

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret';
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret' | 'cloud-run-service';
     region: string | null
     createdAt: string | null
     status?: string | null


### PR DESCRIPTION
Adds a `containers` service under Compute, backed by a new `GcpCloudRunAdapter`
against the Cloud Run Admin v2 API.

One catalog row, one adapter, one registry line, no frontend change, and **no new
dependency** — it reuses the shared Floci-GCP REST client.

## Readiness is surfaced, not hidden

A deploy settles at `PENDING` and then `SUCCEEDED` or `FAILED`, and the runtime's
own explanation is kept in `metadata.terminalMessage`.

The usual cause of `FAILED` is a container that does not listen on the port given
by `$PORT` (8080 by default). `nginx:alpine` listens on 80 and fails for exactly
that reason — so the image field carries that warning rather than leaving the user
with an unexplained failed service. `status` strips the `CONDITION_` prefix
(`CONDITION_FAILED` → `FAILED`); the value is otherwise the runtime's.

## Notes from probing the runtime

- An empty project returns `{}`, not `{"services": []}` — covered by a test.
- `create` is asynchronous and returns an Operation whose `metadata` holds the
  Service. The adapter reads the service back rather than unpacking the envelope,
  so the returned resource carries the real pending state instead of a synthesised
  one.
- **`create` genuinely starts a container.** Deploying `nginx:alpine` produced a
  `floci-cloudrun-*` container running that image, confirmed with `docker ps`
  rather than trusting the response — the same check that caught a `/clusters`
  path on this runtime being Managed Kafka rather than GKE.
- Deleting a service while it is still `PENDING` can race the create; deleting a
  settled service is durable across repeated polls.
- `list` follows `nextPageToken`. The runtime returns everything in one response,
  so only the unit test covers that loop.

## Verification

`lint`, `type-check`, `test` and `build` pass from the repo root.

Tests are hermetic — the Cloud Run, capability-guard and catalog suites (98 tests)
pass with `globalThis.fetch` replaced by a throw.

Verified end to end through the generic resources route: the nav entry appears for
GCP only, deploy, list, inspect, delete, and all three validation rejections
(invalid name, non-numeric port, missing image) returning 400.

## Merge note

Branched off `main` and independent of the other open service PRs. Adds
`'cloud-run-service'` to `CloudResource.type`; #156, #157, #158 and #159 each widen
that same union with their own member, so the last to merge resolves a one-line
conflict there.