### PR TITLE
ci: retry the UI assert in integration to avoid startup race

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -102,9 +102,17 @@ jobs:
 
       - name: Assert the UI is served
         run: |
-          code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:4500/)
-          echo "UI HTTP $code"
-          test "$code" = "200"
+          for i in $(seq 1 20); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' --max-time 10 http://localhost:4500/ || true)
+            echo "[$i] UI HTTP $code"
+            if [ "$code" = "200" ]; then
+              echo "UI reachable."
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "::error::UI did not become reachable in time"
+          exit 1
 
       - name: Dump container logs on failure
         if: failure()


### PR DESCRIPTION
## Summary

The Integration workflow asserts the UI with a single un-retried `curl`, while the Floci runtime gets a 40-attempt poll. The vite dev server's startup timing shifted slightly with the frontend container's npm to pnpm switch (#152), and the first `main` run containing it lost the race: `curl :4500` hit connection reset (exit 56) before vite was listening, with the whole rest of the stack green. The identical commit passed on rerun with no changes (run 30416428298).

This gives the UI assert the same retry shape as the runtime wait: poll up to 20 times, 3s apart, fail with a clear error after ~60s.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature (`feat:`)
- [ ] Breaking change
- [x] Documentation / chore (`docs:` / `chore:` / `ci:`)

## Area

- [ ] Frontend (React UI)
- [ ] API (Bun/Hono backend)
- [ ] Cloud Explorer adapter (`packages/api/src/adapter-*`)
- [x] Build / CI / Docker

## Verification

Failure and recovery observed on `main` run 30416428298: first attempt failed at "Assert the UI is served" with curl exit 56 and every earlier step green; rerun of the same commit passed. The new loop exits on the first 200 (no added latency on healthy runs) and preserves the failure mode with a clearer error annotation.

## Checklist

- [x] PR title follows Conventional Commits
- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, `pnpm build` pass locally (workflow-only change; app code untouched)
- [x] No fake/mock data added
- [x] Focused change, no unrelated refactors
