### PR TITLE
✨ feat(s3): add inline preview for images, video, audio, text and pdf

### DIFF
--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -186,6 +186,36 @@ describe('cloud schema routes', () => {
         expect(body.objects[0].name).toBe('object.txt')
     })
 
+    test('downloads a storage object as an attachment by default', async () => {
+        const app = appWithRoutes([mockAdapter('aws', {
+            getObject: async () => ({
+                body: new TextEncoder().encode('hello'),
+                contentType: 'text/plain',
+                contentLength: 5,
+            }),
+        })])
+        const res = await app.request('/api/clouds/aws/services/storage/resources/demo/object?key=notes.txt')
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-disposition')).toBe('attachment; filename="notes.txt"')
+    })
+
+    test('serves a storage object inline when previewing (inline=1)', async () => {
+        // Previews (e.g. an in-browser PDF viewer) need the response to render
+        // inline instead of triggering a download.
+        const app = appWithRoutes([mockAdapter('aws', {
+            getObject: async () => ({
+                body: new TextEncoder().encode('%PDF-1.4'),
+                contentType: 'application/pdf',
+                contentLength: 8,
+            }),
+        })])
+        const res = await app.request('/api/clouds/aws/services/storage/resources/demo/object?key=report.pdf&inline=1')
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-disposition')).toBe('inline; filename="report.pdf"')
+    })
+
     test('lists Cosmos containers through the cloud database adapter', async () => {
         const app = appWithRoutes([mockAdapter('azure', {
             service: 'database',

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -216,6 +216,24 @@ describe('cloud schema routes', () => {
         expect(res.headers.get('content-disposition')).toBe('inline; filename="report.pdf"')
     })
 
+    test('never honors inline=1 for an unsafe stored content type, regardless of extension', async () => {
+        // Security regression test: putObject() stores whatever Content-Type the
+        // uploader sent, so an object named "report.pdf" could actually be stored
+        // as text/html. inline=1 must not let that render (and execute) as HTML
+        // in the unsandboxed preview surface — it must still download.
+        const app = appWithRoutes([mockAdapter('aws', {
+            getObject: async () => ({
+                body: new TextEncoder().encode('<script>alert(document.domain)</script>'),
+                contentType: 'text/html',
+                contentLength: 40,
+            }),
+        })])
+        const res = await app.request('/api/clouds/aws/services/storage/resources/demo/object?key=report.pdf&inline=1')
+
+        expect(res.status).toBe(200)
+        expect(res.headers.get('content-disposition')).toBe('attachment; filename="report.pdf"')
+    })
+
     test('lists Cosmos containers through the cloud database adapter', async () => {
         const app = appWithRoutes([mockAdapter('azure', {
             service: 'database',

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -184,13 +184,19 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
 
         const key = c.req.query('key') ?? ''
         if (!key) return c.json({error: 'Object key is required'}, 400)
+        // Object previews (e.g. an in-browser PDF viewer) need the response to
+        // render inline instead of triggering a download. Regular downloads
+        // (the toolbar Download button, "Save As") keep the existing
+        // attachment behavior unchanged.
+        const inline = c.req.query('inline') === '1'
         return withRuntime(c, async () => {
             const object = await svc(c).getObject(cloud, serviceType, c.req.param('id'), key)
+            const disposition = inline ? 'inline' : 'attachment'
             return new Response(object.body, {
                 headers: {
                     'content-type': object.contentType,
                     ...(object.contentLength === null ? {} : {'content-length': String(object.contentLength)}),
-                    'content-disposition': `attachment; filename="${key.split('/').pop() ?? key}"`,
+                    'content-disposition': `${disposition}; filename="${key.split('/').pop() ?? key}"`,
                 },
             })
         })

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -188,9 +188,14 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         // render inline instead of triggering a download. Regular downloads
         // (the toolbar Download button, "Save As") keep the existing
         // attachment behavior unchanged.
-        const inline = c.req.query('inline') === '1'
+        const inlineRequested = c.req.query('inline') === '1'
         return withRuntime(c, async () => {
             const object = await svc(c).getObject(cloud, serviceType, c.req.param('id'), key)
+            // putObject() stores whatever Content-Type the uploader sent — it is not
+            // trustworthy. Never honor `inline` for a type outside this allow-list,
+            // or an object uploaded as "report.pdf" with Content-Type: text/html
+            // would render (and execute) as HTML in the preview surface.
+            const inline = inlineRequested && isSafeForInlinePreview(object.contentType)
             const disposition = inline ? 'inline' : 'attachment'
             return new Response(object.body, {
                 headers: {
@@ -276,6 +281,41 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
 
 function isCloudProvider(value: string): value is CloudProvider {
     return value === 'aws' || value === 'azure' || value === 'gcp'
+}
+
+/**
+ * Non-media Content-Types the object browser is allowed to render inline.
+ * Deliberately an explicit allow-list rather than a "text/*" prefix check:
+ * text/html (and friends like application/xhtml+xml) render as an
+ * interactive document and execute embedded <script> when navigated to
+ * directly — exactly what the PDF preview iframe does — so they must never
+ * be reachable via `inline=1` no matter what extension the object was
+ * uploaded with.
+ */
+const INLINE_SAFE_NON_MEDIA_TYPES = new Set([
+    'application/pdf',
+    'application/json',
+    'text/plain',
+    'text/css',
+    'text/csv',
+    'text/markdown',
+    'text/yaml',
+    'text/x-yaml',
+])
+
+/**
+ * putObject() stores whatever Content-Type the uploader sent — it is
+ * attacker-controlled and not trustworthy. Only content types on this
+ * allow-list may ever be served with `Content-Disposition: inline`;
+ * everything else falls back to `attachment` regardless of the `inline`
+ * query flag or the object's file extension, so an object uploaded as
+ * "report.pdf" with Content-Type: text/html can't render (and execute) as
+ * HTML in the preview surface.
+ */
+function isSafeForInlinePreview(contentType: string): boolean {
+    const type = contentType.split(';')[0]!.trim().toLowerCase()
+    if (type.startsWith('image/') || type.startsWith('video/') || type.startsWith('audio/')) return true
+    return INLINE_SAFE_NON_MEDIA_TYPES.has(type)
 }
 
 async function withRuntime(c: Context, handler: () => Promise<Response>): Promise<Response> {

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -206,6 +206,19 @@ export function storageObjectDownloadUrl(
   )}&account=${encodeURIComponent(getAccountId())}`;
 }
 
+/**
+ * Same object, but rendered inline (e.g. in an <iframe> PDF viewer) instead
+ * of triggering a download. The regular Download button/link always uses
+ * {@link storageObjectDownloadUrl} — this is only for the preview surface.
+ */
+export function storageObjectPreviewUrl(
+  cloud: CloudProvider,
+  resourceId: string,
+  key: string,
+): string {
+  return `${storageObjectDownloadUrl(cloud, resourceId, key)}&inline=1`;
+}
+
 export async function deleteStorageObject(
   cloud: CloudProvider,
   resourceId: string,

--- a/packages/frontend/src/components/ImagePreviewModal.tsx
+++ b/packages/frontend/src/components/ImagePreviewModal.tsx
@@ -52,7 +52,10 @@ export function ImagePreviewModal({kind, name, src, previewSrc, onClose}: Object
                     {kind === 'video' && <video src={src} controls autoPlay={false}/>}
                     {kind === 'audio' && <audio src={src} controls autoPlay={false} style={{width: '100%'}}/>}
                     {kind === 'text' && <TextPreview src={src}/>}
-                    {kind === 'pdf' && <iframe className="object-pdf-preview" src={previewSrc} title={name}/>}
+                    {/* No `sandbox` permissions granted: this must stay a passive document
+                        view, since the backend only guarantees the response can't be
+                        text/html — it can't guarantee the bytes are a well-formed PDF. */}
+                    {kind === 'pdf' && <iframe className="object-pdf-preview" src={previewSrc} title={name} sandbox=""/>}
                 </div>
             </div>
         </div>

--- a/packages/frontend/src/components/ImagePreviewModal.tsx
+++ b/packages/frontend/src/components/ImagePreviewModal.tsx
@@ -1,0 +1,121 @@
+import {useEffect, useState} from 'react'
+import {AlertTriangle, Download, Loader2, X} from 'lucide-react'
+import type {ObjectPreviewKind} from '@/lib/format'
+
+interface ObjectPreviewModalProps {
+    kind: ObjectPreviewKind
+    name: string
+    /** Plain (attachment) object URL — used for Download and for img/video/audio/text,
+     *  since those elements don't act on Content-Disposition the way a top-level or
+     *  iframe navigation does. */
+    src: string
+    /** Inline-disposition URL, only needed by kinds rendered in an <iframe> (pdf). */
+    previewSrc: string
+    onClose: () => void
+}
+
+/** Text previews are fetched inline, so cap how much we pull and render. */
+const TEXT_PREVIEW_LIMIT = 200_000
+
+/**
+ * Lightbox/preview drawer for storage objects. Reuses the existing object
+ * download URL as the media source — no new backend endpoint, per the
+ * "never invent a custom protocol" rule in CONTRIBUTING.md. Image/video/audio
+ * are rendered via native HTML media elements; text is fetched and shown as
+ * plain text, since there is no inline "view" mode on the download endpoint.
+ */
+export function ImagePreviewModal({kind, name, src, previewSrc, onClose}: ObjectPreviewModalProps) {
+    useEffect(() => {
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') onClose()
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [onClose])
+
+    return (
+        <div className="copy-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+            <div className="image-preview-modal">
+                <div className="image-preview-header">
+                    <span className="image-preview-name" title={name}>{name}</span>
+                    <div className="image-preview-actions">
+                        <a className="icon-btn" href={src} title={`Download ${name}`}>
+                            <Download size={14}/>
+                        </a>
+                        <button className="icon-btn" type="button" onClick={onClose} title="Close">
+                            <X size={14}/>
+                        </button>
+                    </div>
+                </div>
+                <div className="image-preview-body">
+                    {kind === 'image' && <ImagePreview src={src} name={name}/>}
+                    {kind === 'video' && <video src={src} controls autoPlay={false}/>}
+                    {kind === 'audio' && <audio src={src} controls autoPlay={false} style={{width: '100%'}}/>}
+                    {kind === 'text' && <TextPreview src={src}/>}
+                    {kind === 'pdf' && <iframe className="object-pdf-preview" src={previewSrc} title={name}/>}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function ImagePreview({src, name}: {src: string; name: string}) {
+    const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
+    return (
+        <>
+            {status === 'loading' && <PreviewStatus label="Loading preview…"/>}
+            {status === 'error' && <PreviewStatus label="Could not load a preview for this object." isError/>}
+            <img
+                src={src}
+                alt={name}
+                style={{display: status === 'loaded' ? 'block' : 'none'}}
+                onLoad={() => setStatus('loaded')}
+                onError={() => setStatus('error')}
+            />
+        </>
+    )
+}
+
+function TextPreview({src}: {src: string}) {
+    const [state, setState] = useState<{status: 'loading' | 'loaded' | 'error'; text: string; truncated: boolean}>({
+        status: 'loading', text: '', truncated: false,
+    })
+
+    useEffect(() => {
+        let cancelled = false
+        setState({status: 'loading', text: '', truncated: false})
+        fetch(src)
+            .then((res) => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`)
+                return res.text()
+            })
+            .then((text) => {
+                if (cancelled) return
+                const truncated = text.length > TEXT_PREVIEW_LIMIT
+                setState({status: 'loaded', text: truncated ? text.slice(0, TEXT_PREVIEW_LIMIT) : text, truncated})
+            })
+            .catch(() => {
+                if (!cancelled) setState({status: 'error', text: '', truncated: false})
+            })
+        return () => { cancelled = true }
+    }, [src])
+
+    if (state.status === 'loading') return <PreviewStatus label="Loading preview…"/>
+    if (state.status === 'error') return <PreviewStatus label="Could not load a preview for this object." isError/>
+
+    return (
+        <pre className="object-text-preview">
+            {state.text}
+            {state.truncated && '\n\n… truncated'}
+        </pre>
+    )
+}
+
+function PreviewStatus({label, isError}: {label: string; isError?: boolean}) {
+    return (
+        <div className="image-preview-status">
+            {isError ? <AlertTriangle size={20}/> : <Loader2 size={20} className="spin"/>}
+            <span>{label}</span>
+        </div>
+    )
+}

--- a/packages/frontend/src/components/ObjectThumbnail.tsx
+++ b/packages/frontend/src/components/ObjectThumbnail.tsx
@@ -1,0 +1,44 @@
+import {useState} from 'react'
+import {File, FileAudio, FileSpreadsheet, FileText, FileType, FileVideo} from 'lucide-react'
+import type {ObjectIconKind} from '@/lib/format'
+
+interface ObjectThumbnailProps {
+    kind: ObjectIconKind
+    src: string
+    name: string
+}
+
+const KIND_ICON: Record<Exclude<ObjectIconKind, 'image'>, typeof File> = {
+    video: FileVideo,
+    audio: FileAudio,
+    text: FileText,
+    pdf: FileType,
+    document: FileText,
+    spreadsheet: FileSpreadsheet,
+}
+
+/**
+ * Row icon for a recognized object type. Images get a real square thumbnail
+ * (falling back to the generic file icon on load failure — e.g. the
+ * extension heuristic guessed wrong). Every other recognized kind gets a
+ * type-specific icon instead of a rendered thumbnail.
+ */
+export function ObjectThumbnail({kind, src, name}: ObjectThumbnailProps) {
+    const [failed, setFailed] = useState(false)
+
+    if (kind !== 'image' || failed) {
+        const Icon = kind === 'image' ? File : KIND_ICON[kind]
+        return <Icon size={14}/>
+    }
+
+    return (
+        <img
+            className="object-thumbnail"
+            src={src}
+            alt=""
+            title={name}
+            loading="lazy"
+            onError={() => setFailed(true)}
+        />
+    )
+}

--- a/packages/frontend/src/components/StorageObjectBrowser.tsx
+++ b/packages/frontend/src/components/StorageObjectBrowser.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react'
-import {ChevronLeft, ChevronRight, Copy, Download, File, Folder, Loader2, RefreshCw, Search, Trash2, Upload, X} from 'lucide-react'
+import {ChevronLeft, ChevronRight, Copy, Download, Eye, File, Folder, Loader2, RefreshCw, Search, Trash2, Upload, X} from 'lucide-react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
     copyStorageObject,
@@ -8,13 +8,16 @@ import {
     listCloudResources,
     listStorageObjects,
     storageObjectDownloadUrl,
+    storageObjectPreviewUrl,
     uploadStorageObject,
 } from '@/api/cloudProxyClient'
 import {capabilityEnabled, capabilityFor, normalizeCapabilities, withRuntimeState} from '@/lib/capabilities'
 import type {CloudProvider} from '@/types/cloud'
 import type {CloudResource, StorageObject} from '@/types/resource'
 import type {CapabilitySchema, ObjectActionName} from '@/types/schema'
-import {formatBytes} from '@/lib/format'
+import {formatBytes, objectIconKind, objectPreviewKind} from '@/lib/format'
+import {ImagePreviewModal} from '@/components/ImagePreviewModal'
+import {ObjectThumbnail} from '@/components/ObjectThumbnail'
 
 interface StorageObjectBrowserProps {
     cloud: CloudProvider
@@ -37,6 +40,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
     const [search, setSearch] = useState('')
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
     const [bulkDeleting, setBulkDeleting] = useState(false)
+    const [previewObject, setPreviewObject] = useState<StorageObject | null>(null)
 
     const resolvedCapabilities = withRuntimeState(normalizeCapabilities(capabilities), runtimeReachable)
     const uploadCapability = capabilityFor(resolvedCapabilities, 'upload')
@@ -59,6 +63,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
         setCopyObject(null)
         setSearch('')
         setSelectedKeys(new Set())
+        setPreviewObject(null)
         onSelectObject(undefined)
     }, [resource?.id, onSelectObject])
 
@@ -123,6 +128,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
         setSearch('')
         setSelectedKeys(new Set())
         setDeleteConfirm(null)
+        setPreviewObject(null)
         onSelectObject(undefined)
     }
 
@@ -170,6 +176,16 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
 
     return (
         <section className="object-browser">
+            {previewObject && resource && objectPreviewKind(previewObject.name) && (
+                <ImagePreviewModal
+                    kind={objectPreviewKind(previewObject.name)!}
+                    name={previewObject.name}
+                    src={storageObjectDownloadUrl(cloud, resource.id, previewObject.key)}
+                    previewSrc={storageObjectPreviewUrl(cloud, resource.id, previewObject.key)}
+                    onClose={() => setPreviewObject(null)}
+                />
+            )}
+
             {copyObject && resource && (
                 <MoveOrCopyModal
                     cloud={cloud}
@@ -332,6 +348,8 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                         ))}
                         {filteredFiles.map((object) => {
                             const isSelected = selectedKeys.has(object.key)
+                            const iconKind = objectIconKind(object.name)
+                            const previewKind = objectPreviewKind(object.name)
                             return (
                                 <tr
                                     key={object.key}
@@ -355,7 +373,11 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     </td>
                                     <td onClick={() => onSelectObject(object)} style={{cursor: 'pointer'}}>
                                         <span className="object-name">
-                                            <File size={14}/>
+                                            {iconKind ? (
+                                                <ObjectThumbnail kind={iconKind} src={storageObjectDownloadUrl(cloud, resource.id, object.key)} name={object.name}/>
+                                            ) : (
+                                                <File size={14}/>
+                                            )}
                                             {object.name}
                                         </span>
                                     </td>
@@ -363,6 +385,11 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     <td>{object.size === null ? '—' : formatBytes(object.size)}</td>
                                     <td>{object.lastModified ?? '—'}</td>
                                     <td className="table-actions">
+                                        {previewKind && (
+                                            <button className="icon-btn" type="button" title={`Preview ${object.name}`} onClick={(e) => { e.stopPropagation(); setPreviewObject(object) }}>
+                                                <Eye size={13}/>
+                                            </button>
+                                        )}
                                         {downloadCapability && (
                                             <a className={`icon-btn ${canDownload ? '' : 'disabled'}`} href={canDownload ? storageObjectDownloadUrl(cloud, resource.id, object.key) : undefined} title={downloadCapability.reason ?? `Download ${object.name}`}>
                                                 <Download size={13}/>

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -2966,6 +2966,108 @@ button.console-service-card {
     justify-content: flex-end;
 }
 
+/* ─── Object thumbnail (Storage image preview) ──────────────────────────── */
+.object-thumbnail {
+    width: 18px;
+    height: 18px;
+    object-fit: cover;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+    flex-shrink: 0;
+    background: var(--surface-2, var(--surface));
+}
+
+.image-preview-modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    width: min(880px, 90vw);
+    max-height: 85vh;
+    overflow: hidden;
+}
+
+.image-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.image-preview-name {
+    font-size: 12px;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+.image-preview-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.image-preview-body {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    min-height: 160px;
+}
+
+.image-preview-body img,
+.image-preview-body video {
+    max-width: 100%;
+    max-height: calc(85vh - 90px);
+    object-fit: contain;
+    border-radius: 4px;
+}
+
+.object-pdf-preview {
+    width: 100%;
+    height: calc(85vh - 90px);
+    min-height: 400px;
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    background: #fff;
+}
+
+.object-text-preview {
+    width: 100%;
+    max-height: calc(85vh - 90px);
+    overflow: auto;
+    margin: 0;
+    padding: 12px;
+    background: var(--code-bg, var(--surface-2, var(--surface)));
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: var(--mono, ui-monospace, monospace);
+    font-size: 12px;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    text-align: left;
+}
+
+.image-preview-status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-2);
+    padding: 24px;
+}
+
 /* ─── Table checkboxes ───────────────────────────────────────────────────── */
 .table input[type="checkbox"] {
     width: 14px;

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -41,6 +41,55 @@ export function formatRelativeTime(value: unknown, now: number = Date.now()): st
     return formatter.format(0, 'second')
 }
 
+/** Kinds that render inside the preview modal. */
+export type ObjectPreviewKind = 'image' | 'video' | 'audio' | 'text' | 'pdf'
+
+/**
+ * Kinds recognized for a distinct row icon. A superset of ObjectPreviewKind —
+ * 'document' (Word) and 'spreadsheet' (Excel) get an icon but no in-browser
+ * preview, since rendering them needs a client-side parser (mammoth, xlsx)
+ * that this project doesn't depend on yet.
+ */
+export type ObjectIconKind = ObjectPreviewKind | 'document' | 'spreadsheet'
+
+const PREVIEW_EXTENSIONS: Record<ObjectPreviewKind, Set<string>> = {
+    image: new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif']),
+    video: new Set(['mp4', 'webm', 'ogv', 'mov']),
+    audio: new Set(['mp3', 'wav', 'ogg', 'oga', 'm4a', 'flac']),
+    text: new Set(['txt', 'json', 'log', 'md', 'yaml', 'yml', 'csv', 'xml', 'html', 'css', 'js', 'ts']),
+    pdf: new Set(['pdf']),
+}
+
+const ICON_ONLY_EXTENSIONS: Record<Exclude<ObjectIconKind, ObjectPreviewKind>, Set<string>> = {
+    document: new Set(['doc', 'docx', 'rtf', 'odt']),
+    spreadsheet: new Set(['xls', 'xlsx', 'xlsm', 'ods']),
+}
+
+/**
+ * Best-effort preview/icon-kind detection from an object key/name. Storage
+ * list APIs (S3 ListObjectsV2, Azure list blobs) do not return content-type
+ * per item — only a HEAD/GET on the object would — so this is an extension
+ * heuristic. A wrong guess just fails to render the thumbnail/preview, it
+ * never blocks any other action.
+ */
+export function objectIconKind(name: string): ObjectIconKind | null {
+    const ext = name.split('.').pop()?.toLowerCase()
+    if (!ext) return null
+    for (const kind of Object.keys(PREVIEW_EXTENSIONS) as ObjectPreviewKind[]) {
+        if (PREVIEW_EXTENSIONS[kind].has(ext)) return kind
+    }
+    for (const kind of Object.keys(ICON_ONLY_EXTENSIONS) as Array<'document' | 'spreadsheet'>) {
+        if (ICON_ONLY_EXTENSIONS[kind].has(ext)) return kind
+    }
+    return null
+}
+
+/** Narrower than {@link objectIconKind}: only kinds the preview modal can render. */
+export function objectPreviewKind(name: string): ObjectPreviewKind | null {
+    const kind = objectIconKind(name)
+    return kind === 'document' || kind === 'spreadsheet' ? null : kind
+}
+
 /** Stable class-name fragment for a status value. */
 export function slugify(value: string): string {
     return value


### PR DESCRIPTION
Adds an inline preview for storage objects in the Cloud Explorer object browser, following the "Add object preview panel to the bucket explorer" example from CONTRIBUTING.md.

- Detect object kind by extension: image, video, audio, text, and pdf get real previews; document (docx) and spreadsheet (xlsx) get a distinct row icon only (no client-side parser yet)
- Show a real image thumbnail in the object table row, and a type-specific icon for every other recognized kind
- Add an Eye action per row that opens a lightbox/preview modal: `<img>`/`<video>`/`<audio>` for media, fetched plain text for text-like files, and an `<iframe>` for PDF
- Add an `inline=1` query flag on the existing object download route so previews render instead of forcing a download, without changing the default (attachment) download behavior
- Cover the new inline vs attachment `Content-Disposition` behavior with backend tests
- No new backend endpoint and no new protocol — reuses the existing object route per the SPI rules in AGENTS.md

`pnpm lint`, `pnpm type-check`, `pnpm test` and `pnpm build` all pass.
