### PR TITLE
feat(s3): add inline preview for images, video, audio and text objects

### DIFF
--- a/packages/frontend/src/components/ImagePreviewModal.tsx
+++ b/packages/frontend/src/components/ImagePreviewModal.tsx
@@ -1,0 +1,144 @@
+import {useEffect, useState} from 'react'
+import {AlertTriangle, Download, Loader2, X} from 'lucide-react'
+import type {ObjectPreviewKind} from '@/lib/format'
+
+interface ObjectPreviewModalProps {
+    kind: ObjectPreviewKind
+    name: string
+    src: string
+    onClose: () => void
+}
+
+/** Text previews are fetched inline, so cap how much we pull and render. */
+const TEXT_PREVIEW_LIMIT = 200_000
+
+/**
+ * Lightbox/preview drawer for storage objects. Reuses the existing object
+ * download URL as the media source — no new backend endpoint, per the
+ * "never invent a custom protocol" rule in CONTRIBUTING.md. Image/video/audio
+ * are rendered via native HTML media elements; text is fetched and shown as
+ * plain text, since there is no inline "view" mode on the download endpoint.
+ */
+export function ImagePreviewModal({kind, name, src, onClose}: ObjectPreviewModalProps) {
+    useEffect(() => {
+        function onKeyDown(event: KeyboardEvent) {
+            if (event.key === 'Escape') onClose()
+        }
+        window.addEventListener('keydown', onKeyDown)
+        return () => window.removeEventListener('keydown', onKeyDown)
+    }, [onClose])
+
+    return (
+        <div className="copy-modal-overlay" onClick={(e) => { if (e.target === e.currentTarget) onClose() }}>
+            <div className="image-preview-modal">
+                <div className="image-preview-header">
+                    <span className="image-preview-name" title={name}>{name}</span>
+                    <div className="image-preview-actions">
+                        <a className="icon-btn" href={src} title={`Download ${name}`}>
+                            <Download size={14}/>
+                        </a>
+                        <button className="icon-btn" type="button" onClick={onClose} title="Close">
+                            <X size={14}/>
+                        </button>
+                    </div>
+                </div>
+                <div className="image-preview-body">
+                    {kind === 'image' && <ImagePreview src={src} name={name}/>}
+                    {kind === 'video' && <video src={src} controls autoPlay={false}/>}
+                    {kind === 'audio' && <audio src={src} controls autoPlay={false} style={{width: '100%'}}/>}
+                    {kind === 'text' && <TextPreview src={src}/>}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+function ImagePreview({src, name}: {src: string; name: string}) {
+    const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading')
+    return (
+        <>
+            {status === 'loading' && <PreviewStatus label="Loading preview…"/>}
+            {status === 'error' && <PreviewStatus label="Could not load a preview for this object." isError/>}
+            <img
+                src={src}
+                alt={name}
+                style={{display: status === 'loaded' ? 'block' : 'none'}}
+                onLoad={() => setStatus('loaded')}
+                onError={() => setStatus('error')}
+            />
+        </>
+    )
+}
+
+function TextPreview({src}: {src: string}) {
+    const [state, setState] = useState<{status: 'loading' | 'loaded' | 'error'; text: string; truncated: boolean}>({
+        status: 'loading', text: '', truncated: false,
+    })
+
+    useEffect(() => {
+        const controller = new AbortController()
+        setState({status: 'loading', text: '', truncated: false})
+        readTextPreview(src, controller.signal)
+            .then((result) => setState({status: 'loaded', ...result}))
+            .catch((err) => {
+                if ((err as {name?: string}).name === 'AbortError') return
+                setState({status: 'error', text: '', truncated: false})
+            })
+        return () => controller.abort()
+    }, [src])
+
+    if (state.status === 'loading') return <PreviewStatus label="Loading preview…"/>
+    if (state.status === 'error') return <PreviewStatus label="Could not load a preview for this object." isError/>
+
+    return (
+        <pre className="object-text-preview">
+            {state.text}
+            {state.truncated && '\n\n… truncated'}
+        </pre>
+    )
+}
+
+/**
+ * Fetches only as much of the object as needed for the preview. Stops
+ * reading (and cancels the underlying connection) once TEXT_PREVIEW_LIMIT
+ * characters have been decoded, instead of buffering the full response —
+ * important for large text-like objects, since res.text() would otherwise
+ * transfer and hold the entire body in memory just to show the first slice.
+ */
+async function readTextPreview(src: string, signal: AbortSignal): Promise<{text: string; truncated: boolean}> {
+    const res = await fetch(src, {signal})
+    if (!res.ok || !res.body) throw new Error(`HTTP ${res.status}`)
+
+    const reader = res.body.getReader()
+    const decoder = new TextDecoder()
+    let text = ''
+    let truncated: boolean
+    try {
+        while (text.length < TEXT_PREVIEW_LIMIT) {
+            const {done, value} = await reader.read()
+            if (done) break
+            text += decoder.decode(value, {stream: true})
+        }
+        if (text.length > TEXT_PREVIEW_LIMIT) {
+            text = text.slice(0, TEXT_PREVIEW_LIMIT)
+            truncated = true
+        } else {
+            // Confirm whether more data was actually available before claiming
+            // completeness — the loop can exit exactly at the limit.
+            const {done} = await reader.read()
+            truncated = !done
+        }
+    } finally {
+        void reader.cancel().catch(() => {})
+    }
+    return {text, truncated}
+}
+
+function PreviewStatus({label, isError}: {label: string; isError?: boolean}) {
+    return (
+        <div className="image-preview-status">
+            {isError ? <AlertTriangle size={20}/> : <Loader2 size={20} className="spin"/>}
+            <span>{label}</span>
+        </div>
+    )
+}

--- a/packages/frontend/src/components/ImagePreviewModal.tsx
+++ b/packages/frontend/src/components/ImagePreviewModal.tsx
@@ -121,6 +121,13 @@ async function readTextPreview(src: string, signal: AbortSignal): Promise<{text:
         }
         if (text.length > TEXT_PREVIEW_LIMIT) {
             text = text.slice(0, TEXT_PREVIEW_LIMIT)
+            // A code unit landing exactly on the cut could be the high half of a
+            // surrogate pair (e.g. an emoji) with its low half past the boundary —
+            // slice() doesn't know that, and leaves a lone surrogate that renders
+            // as a replacement glyph. Drop it so the preview only ever ends on a
+            // complete character.
+            const lastCode = text.charCodeAt(text.length - 1)
+            if (lastCode >= 0xd800 && lastCode <= 0xdbff) text = text.slice(0, -1)
             truncated = true
         } else {
             // Confirm whether more data was actually available before claiming

--- a/packages/frontend/src/components/ObjectThumbnail.tsx
+++ b/packages/frontend/src/components/ObjectThumbnail.tsx
@@ -1,0 +1,44 @@
+import {useState} from 'react'
+import {File, FileAudio, FileSpreadsheet, FileText, FileType, FileVideo} from 'lucide-react'
+import type {ObjectIconKind} from '@/lib/format'
+
+interface ObjectThumbnailProps {
+    kind: ObjectIconKind
+    src: string
+    name: string
+}
+
+const KIND_ICON: Record<Exclude<ObjectIconKind, 'image'>, typeof File> = {
+    video: FileVideo,
+    audio: FileAudio,
+    text: FileText,
+    pdf: FileType,
+    document: FileText,
+    spreadsheet: FileSpreadsheet,
+}
+
+/**
+ * Row icon for a recognized object type. Images get a real square thumbnail
+ * (falling back to the generic file icon on load failure — e.g. the
+ * extension heuristic guessed wrong). Every other recognized kind gets a
+ * type-specific icon instead of a rendered thumbnail.
+ */
+export function ObjectThumbnail({kind, src, name}: ObjectThumbnailProps) {
+    const [failed, setFailed] = useState(false)
+
+    if (kind !== 'image' || failed) {
+        const Icon = kind === 'image' ? File : KIND_ICON[kind]
+        return <Icon size={14}/>
+    }
+
+    return (
+        <img
+            className="object-thumbnail"
+            src={src}
+            alt=""
+            title={name}
+            loading="lazy"
+            onError={() => setFailed(true)}
+        />
+    )
+}

--- a/packages/frontend/src/components/ObjectThumbnail.tsx
+++ b/packages/frontend/src/components/ObjectThumbnail.tsx
@@ -1,11 +1,13 @@
 import {useState} from 'react'
-import {File, FileAudio, FileSpreadsheet, FileText, FileType, FileVideo} from 'lucide-react'
+import {File, FileAudio, FileSpreadsheet, FileText, FileType, FileVideo, Image} from 'lucide-react'
 import type {ObjectIconKind} from '@/lib/format'
 
 interface ObjectThumbnailProps {
     kind: ObjectIconKind
     src: string
     name: string
+    /** Whether fetching object content (the Download action) is currently allowed. */
+    canLoad: boolean
 }
 
 const KIND_ICON: Record<Exclude<ObjectIconKind, 'image'>, typeof File> = {
@@ -22,12 +24,17 @@ const KIND_ICON: Record<Exclude<ObjectIconKind, 'image'>, typeof File> = {
  * (falling back to the generic file icon on load failure — e.g. the
  * extension heuristic guessed wrong). Every other recognized kind gets a
  * type-specific icon instead of a rendered thumbnail.
+ *
+ * When `canLoad` is false (download is gated off — runtime unavailable, or
+ * the schema disables it), this never issues the image request: it falls
+ * back to a static icon instead. Otherwise the thumbnail would fetch object
+ * content behind the same capability check the Download button honors.
  */
-export function ObjectThumbnail({kind, src, name}: ObjectThumbnailProps) {
+export function ObjectThumbnail({kind, src, name, canLoad}: ObjectThumbnailProps) {
     const [failed, setFailed] = useState(false)
 
-    if (kind !== 'image' || failed) {
-        const Icon = kind === 'image' ? File : KIND_ICON[kind]
+    if (kind !== 'image' || failed || !canLoad) {
+        const Icon = kind === 'image' ? Image : KIND_ICON[kind]
         return <Icon size={14}/>
     }
 

--- a/packages/frontend/src/components/StorageObjectBrowser.tsx
+++ b/packages/frontend/src/components/StorageObjectBrowser.tsx
@@ -372,7 +372,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     <td onClick={() => onSelectObject(object)} style={{cursor: 'pointer'}}>
                                         <span className="object-name">
                                             {iconKind ? (
-                                                <ObjectThumbnail kind={iconKind} src={storageObjectDownloadUrl(cloud, resource.id, object.key)} name={object.name}/>
+                                                <ObjectThumbnail kind={iconKind} src={storageObjectDownloadUrl(cloud, resource.id, object.key)} name={object.name} canLoad={canDownload}/>
                                             ) : (
                                                 <File size={14}/>
                                             )}
@@ -384,7 +384,13 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     <td>{object.lastModified ?? '—'}</td>
                                     <td className="table-actions">
                                         {previewKind && (
-                                            <button className="icon-btn" type="button" title={`Preview ${object.name}`} onClick={(e) => { e.stopPropagation(); setPreviewObject(object) }}>
+                                            <button
+                                                className="icon-btn"
+                                                type="button"
+                                                disabled={!canDownload}
+                                                title={canDownload ? `Preview ${object.name}` : (downloadCapability?.reason ?? `Preview ${object.name}`)}
+                                                onClick={(e) => { e.stopPropagation(); if (canDownload) setPreviewObject(object) }}
+                                            >
                                                 <Eye size={13}/>
                                             </button>
                                         )}

--- a/packages/frontend/src/components/StorageObjectBrowser.tsx
+++ b/packages/frontend/src/components/StorageObjectBrowser.tsx
@@ -1,5 +1,5 @@
 import {useEffect, useRef, useState} from 'react'
-import {ChevronLeft, ChevronRight, Copy, Download, File, Folder, Loader2, RefreshCw, Search, Trash2, Upload, X} from 'lucide-react'
+import {ChevronLeft, ChevronRight, Copy, Download, Eye, File, Folder, Loader2, RefreshCw, Search, Trash2, Upload, X} from 'lucide-react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {
     copyStorageObject,
@@ -14,7 +14,9 @@ import {capabilityEnabled, capabilityFor, normalizeCapabilities, withRuntimeStat
 import type {CloudProvider} from '@/types/cloud'
 import type {CloudResource, StorageObject} from '@/types/resource'
 import type {CapabilitySchema, ObjectActionName} from '@/types/schema'
-import {formatBytes} from '@/lib/format'
+import {formatBytes, objectIconKind, objectPreviewKind} from '@/lib/format'
+import {ImagePreviewModal} from '@/components/ImagePreviewModal'
+import {ObjectThumbnail} from '@/components/ObjectThumbnail'
 
 interface StorageObjectBrowserProps {
     cloud: CloudProvider
@@ -37,6 +39,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
     const [search, setSearch] = useState('')
     const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set())
     const [bulkDeleting, setBulkDeleting] = useState(false)
+    const [previewObject, setPreviewObject] = useState<StorageObject | null>(null)
 
     const resolvedCapabilities = withRuntimeState(normalizeCapabilities(capabilities), runtimeReachable)
     const uploadCapability = capabilityFor(resolvedCapabilities, 'upload')
@@ -59,6 +62,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
         setCopyObject(null)
         setSearch('')
         setSelectedKeys(new Set())
+        setPreviewObject(null)
         onSelectObject(undefined)
     }, [resource?.id, onSelectObject])
 
@@ -123,6 +127,7 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
         setSearch('')
         setSelectedKeys(new Set())
         setDeleteConfirm(null)
+        setPreviewObject(null)
         onSelectObject(undefined)
     }
 
@@ -170,6 +175,15 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
 
     return (
         <section className="object-browser">
+            {previewObject && resource && objectPreviewKind(previewObject.name) && (
+                <ImagePreviewModal
+                    kind={objectPreviewKind(previewObject.name)!}
+                    name={previewObject.name}
+                    src={storageObjectDownloadUrl(cloud, resource.id, previewObject.key)}
+                    onClose={() => setPreviewObject(null)}
+                />
+            )}
+
             {copyObject && resource && (
                 <MoveOrCopyModal
                     cloud={cloud}
@@ -332,6 +346,8 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                         ))}
                         {filteredFiles.map((object) => {
                             const isSelected = selectedKeys.has(object.key)
+                            const iconKind = objectIconKind(object.name)
+                            const previewKind = objectPreviewKind(object.name)
                             return (
                                 <tr
                                     key={object.key}
@@ -355,7 +371,11 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     </td>
                                     <td onClick={() => onSelectObject(object)} style={{cursor: 'pointer'}}>
                                         <span className="object-name">
-                                            <File size={14}/>
+                                            {iconKind ? (
+                                                <ObjectThumbnail kind={iconKind} src={storageObjectDownloadUrl(cloud, resource.id, object.key)} name={object.name}/>
+                                            ) : (
+                                                <File size={14}/>
+                                            )}
                                             {object.name}
                                         </span>
                                     </td>
@@ -363,6 +383,11 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
                                     <td>{object.size === null ? '—' : formatBytes(object.size)}</td>
                                     <td>{object.lastModified ?? '—'}</td>
                                     <td className="table-actions">
+                                        {previewKind && (
+                                            <button className="icon-btn" type="button" title={`Preview ${object.name}`} onClick={(e) => { e.stopPropagation(); setPreviewObject(object) }}>
+                                                <Eye size={13}/>
+                                            </button>
+                                        )}
                                         {downloadCapability && (
                                             <a className={`icon-btn ${canDownload ? '' : 'disabled'}`} href={canDownload ? storageObjectDownloadUrl(cloud, resource.id, object.key) : undefined} title={downloadCapability.reason ?? `Download ${object.name}`}>
                                                 <Download size={13}/>

--- a/packages/frontend/src/components/StorageObjectBrowser.tsx
+++ b/packages/frontend/src/components/StorageObjectBrowser.tsx
@@ -53,6 +53,16 @@ export function StorageObjectBrowser({cloud, resource, capabilities = [], runtim
     const canCreateFolder = capabilityEnabled(createFolderCapability)
     const canCopy = capabilityEnabled(copyCapability)
 
+    // Runtime reachability can flip while a preview is already open (it's polled
+    // independently of this component). Re-checking canDownload only at the
+    // moment the Eye button is clicked isn't enough — close an already-open
+    // preview the instant download capability is revoked, so its modal can't
+    // keep serving object content (img/video/audio src, the Download link,
+    // an in-flight text fetch) after the gate that allowed it closes.
+    useEffect(() => {
+        if (!canDownload) setPreviewObject(null)
+    }, [canDownload])
+
     useEffect(() => {
         setPrefix('')
         setUploadPrefix('')

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -2966,6 +2966,98 @@ button.console-service-card {
     justify-content: flex-end;
 }
 
+/* ─── Object thumbnail (Storage image preview) ──────────────────────────── */
+.object-thumbnail {
+    width: 18px;
+    height: 18px;
+    object-fit: cover;
+    border-radius: 3px;
+    border: 1px solid var(--border);
+    flex-shrink: 0;
+    background: var(--surface-2, var(--surface));
+}
+
+.image-preview-modal {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    display: flex;
+    flex-direction: column;
+    width: min(880px, 90vw);
+    max-height: 85vh;
+    overflow: hidden;
+}
+
+.image-preview-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 10px 14px;
+    border-bottom: 1px solid var(--border);
+    flex-shrink: 0;
+}
+
+.image-preview-name {
+    font-size: 12px;
+    color: var(--text);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    min-width: 0;
+}
+
+.image-preview-actions {
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+}
+
+.image-preview-body {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 16px;
+    overflow: auto;
+    min-height: 160px;
+}
+
+.image-preview-body img,
+.image-preview-body video {
+    max-width: 100%;
+    max-height: calc(85vh - 90px);
+    object-fit: contain;
+    border-radius: 4px;
+}
+
+.object-text-preview {
+    width: 100%;
+    max-height: calc(85vh - 90px);
+    overflow: auto;
+    margin: 0;
+    padding: 12px;
+    background: var(--code-bg, var(--surface-2, var(--surface)));
+    border: 1px solid var(--border);
+    border-radius: 4px;
+    font-family: var(--mono, ui-monospace, monospace);
+    font-size: 12px;
+    color: var(--text);
+    white-space: pre-wrap;
+    word-break: break-word;
+    text-align: left;
+}
+
+.image-preview-status {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 8px;
+    font-size: 12px;
+    color: var(--text-2);
+    padding: 24px;
+}
 /* ─── Table checkboxes ───────────────────────────────────────────────────── */
 .table input[type="checkbox"] {
     width: 14px;

--- a/packages/frontend/src/lib/format.ts
+++ b/packages/frontend/src/lib/format.ts
@@ -41,6 +41,61 @@ export function formatRelativeTime(value: unknown, now: number = Date.now()): st
     return formatter.format(0, 'second')
 }
 
+/** Kinds that render inside the preview modal. */
+export type ObjectPreviewKind = 'image' | 'video' | 'audio' | 'text'
+
+/**
+ * Kinds recognized for a distinct row icon. A superset of ObjectPreviewKind —
+ * these get an icon but no in-browser preview:
+ * - 'pdf': native PDF-in-iframe support is unreliable across browsers (some
+ *   ship without a built-in PDF viewer, and browsers/ad-blockers can flag an
+ *   iframe navigation that falls back to a download as an automatic-download
+ *   attack pattern and block it outright). Download still works normally.
+ * - 'document' (Word) / 'spreadsheet' (Excel): rendering needs a client-side
+ *   parser (mammoth, xlsx) that this project doesn't depend on yet.
+ */
+export type ObjectIconKind = ObjectPreviewKind | 'pdf' | 'document' | 'spreadsheet'
+
+const PREVIEW_EXTENSIONS: Record<ObjectPreviewKind, Set<string>> = {
+    image: new Set(['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg', 'bmp', 'ico', 'avif']),
+    video: new Set(['mp4', 'webm', 'ogv', 'mov']),
+    audio: new Set(['mp3', 'wav', 'ogg', 'oga', 'm4a', 'flac']),
+    text: new Set(['txt', 'json', 'log', 'md', 'yaml', 'yml', 'csv', 'xml', 'html', 'css', 'js', 'ts']),
+}
+
+const ICON_ONLY_EXTENSIONS: Record<Exclude<ObjectIconKind, ObjectPreviewKind>, Set<string>> = {
+    pdf: new Set(['pdf']),
+    document: new Set(['doc', 'docx', 'rtf', 'odt']),
+    spreadsheet: new Set(['xls', 'xlsx', 'xlsm', 'ods']),
+}
+
+/**
+ * Best-effort preview/icon-kind detection from an object key/name. Storage
+ * list APIs (S3 ListObjectsV2, Azure list blobs) do not return content-type
+ * per item — only a HEAD/GET on the object would — so this is an extension
+ * heuristic. A wrong guess just fails to render the thumbnail/preview, it
+ * never blocks any other action.
+ */
+export function objectIconKind(name: string): ObjectIconKind | null {
+    const ext = name.split('.').pop()?.toLowerCase()
+    if (!ext) return null
+    for (const kind of Object.keys(PREVIEW_EXTENSIONS) as ObjectPreviewKind[]) {
+        if (PREVIEW_EXTENSIONS[kind].has(ext)) return kind
+    }
+    for (const kind of Object.keys(ICON_ONLY_EXTENSIONS) as Array<'pdf' | 'document' | 'spreadsheet'>) {
+        if (ICON_ONLY_EXTENSIONS[kind].has(ext)) return kind
+    }
+    return null
+}
+
+const ICON_ONLY_KINDS = new Set(Object.keys(ICON_ONLY_EXTENSIONS))
+
+/** Narrower than {@link objectIconKind}: only kinds the preview modal can render. */
+export function objectPreviewKind(name: string): ObjectPreviewKind | null {
+    const kind = objectIconKind(name)
+    return kind && !ICON_ONLY_KINDS.has(kind) ? kind as ObjectPreviewKind : null
+}
+
 /** Stable class-name fragment for a status value. */
 export function slugify(value: string): string {
     return value


### PR DESCRIPTION
Adds an inline preview for storage objects in the Cloud Explorer object browser, following the "Add object preview panel to the bucket explorer" example from CONTRIBUTING.md.

- Detect object kind by extension: image, video, audio, and text get a real in-browser preview; pdf/document (docx)/spreadsheet (xlsx) get a distinct row icon only, no preview.
- Show a real image thumbnail in the object table row, and a type-specific icon for every other recognized kind.
- Add an Eye action per row that opens a lightbox/preview modal: `<img>`/`<video>`/`<audio>` for media, streamed plain text for text-like files — reads the response body in chunks and cancels once the display cap is hit, instead of buffering the full object into memory.
- No backend changes and no new endpoint — reuses the existing object download route and its `Content-Disposition: attachment` behavior as-is, per the SPI rules in AGENTS.md.

**Why no PDF preview:** an earlier version of this PR rendered PDFs in an iframe with an `inline=1` variant of the download route. That turned out to be unreliable across browsers/configurations — some ship without a built-in PDF viewer, and several browsers/ad-blockers (Brave Shields included) flag the resulting download-like iframe navigation as an automatic-download attack pattern and block it outright (`net::ERR_BLOCKED_BY_CLIENT`), regardless of headers or `sandbox` settings tried. Rather than ship something that silently fails to render for a chunk of users, PDFs get a distinct icon and rely on the regular Download button, same as docx/xlsx.

`pnpm lint`, `pnpm type-check`, `pnpm test` and `pnpm build` all pass. No changes to `packages/api` in this version — purely a frontend addition.
