### PR TITLE
feat(logs): add CloudWatch Logs explorer with groups, streams, and events drill-in

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -8,6 +8,7 @@
     "packages/api": {
       "name": "@floci/api",
       "dependencies": {
+        "@aws-sdk/client-cloudwatch-logs": "3.1080.0",
         "@aws-sdk/client-ec2": "^3.1076.0",
         "@aws-sdk/client-eks": "^3.1076.0",
         "@aws-sdk/client-lambda": "^3.1076.0",
@@ -25,7 +26,7 @@
     },
     "packages/frontend": {
       "name": "@floci/frontend",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@tanstack/react-query": "^5.101.2",
         "@tanstack/react-query-devtools": "^5.101.2",
@@ -41,6 +42,9 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/jest-dom": "7.0.0",
+        "@testing-library/react": "^16.3.2",
+        "@testing-library/user-event": "14.6.1",
         "@types/node": "^25.9.4",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.0",
@@ -50,16 +54,26 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.2",
         "globals": "^17.7.0",
+        "jsdom": "^30.0.1",
         "postcss": "^8.5.16",
         "tailwindcss": "^4.3.0",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.62.1",
         "vite": "^8.1.3",
+        "vitest": "^4.1.10",
       },
     },
   },
   "packages": {
+    "@adobe/css-tools": ["@adobe/css-tools@4.5.0", "", {}, "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@6.0.7", "", { "dependencies": { "@csstools/css-calc": "^3.3.0", "@csstools/css-color-parser": "^4.1.10", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0", "lru-cache": "^11.5.2" } }, "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw=="],
+
+    "@asamuzakjp/dom-selector": ["@asamuzakjp/dom-selector@8.3.2", "", { "dependencies": { "bidi-js": "^1.0.3", "css-tree": "^3.2.1", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.5.2" } }, "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q=="],
+
     "@aws-sdk/checksums": ["@aws-sdk/checksums@3.1000.13", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-USI1N1d+NbCcfjeiYLKIl94PSYykl5IIjj4X3WqdL33Ln5qktA6sjXYct0o/gG2Cte7cuzbXKkDBkzUA4VPHrg=="],
+
+    "@aws-sdk/client-cloudwatch-logs": ["@aws-sdk/client-cloudwatch-logs@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-qH7dSHyMgdxLmDV2bfMGvXHei5x5tSPNZKWqYGlB6DUOKqoSWCO2i40lXR/bZ/3htFRFFKDkxEGabN1PTT2a/A=="],
 
     "@aws-sdk/client-ec2": ["@aws-sdk/client-ec2@3.1080.0", "", { "dependencies": { "@aws-sdk/core": "^3.974.28", "@aws-sdk/credential-provider-node": "^3.972.63", "@aws-sdk/middleware-sdk-ec2": "^3.972.42", "@aws-sdk/types": "^3.973.15", "@smithy/core": "^3.29.0", "@smithy/fetch-http-handler": "^5.6.2", "@smithy/node-http-handler": "^4.9.2", "@smithy/types": "^4.15.1", "tslib": "^2.6.2" } }, "sha512-sDob1bPeCAU80M85xJdKZkTaEvHTD6HwwxfnKsy6hKGReTDw9IGJJ7tzjsdvSzp2+MRT5Vf6GHgRchGblPC4yQ=="],
 
@@ -135,11 +149,27 @@
 
     "@babel/parser": ["@babel/parser@7.29.3", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA=="],
 
+    "@babel/runtime": ["@babel/runtime@7.29.7", "", {}, "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw=="],
+
     "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
 
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bramus/specificity": ["@bramus/specificity@2.4.2", "", { "dependencies": { "css-tree": "^3.0.0" }, "bin": { "specificity": "bin/cli.js" } }, "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@6.1.0", "", {}, "sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@3.3.0", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@4.1.10", "", { "dependencies": { "@csstools/color-helpers": "^6.1.0", "@csstools/css-calc": "^3.3.0" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@4.0.0", "", { "peerDependencies": { "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w=="],
+
+    "@csstools/css-syntax-patches-for-csstree": ["@csstools/css-syntax-patches-for-csstree@1.1.7", "", { "peerDependencies": { "css-tree": "^3.2.1" }, "optionalPeers": ["css-tree"] }, "sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@4.0.0", "", {}, "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA=="],
 
     "@emnapi/core": ["@emnapi/core@1.11.1", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.2", "tslib": "^2.4.0" } }, "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ=="],
 
@@ -162,6 +192,8 @@
     "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "@exodus/bytes": ["@exodus/bytes@1.15.1", "", { "peerDependencies": { "@noble/hashes": "^1.8.0 || ^2.0.0" }, "optionalPeers": ["@noble/hashes"] }, "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q=="],
 
     "@floci/api": ["@floci/api@workspace:packages/api"],
 
@@ -235,6 +267,8 @@
 
     "@smithy/types": ["@smithy/types@4.15.1", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-x3L0XSACF6UYzKpa9biqiRMgvH5+wnFFew9Tm/grFYqgaupPwx/+ojDPpPJM8dZON3S9tjz5U+PQYsCBd1Mw5Q=="],
 
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
+
     "@tanstack/query-core": ["@tanstack/query-core@5.101.2", "", {}, "sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw=="],
 
     "@tanstack/query-devtools": ["@tanstack/query-devtools@5.101.2", "", {}, "sha512-o+wHcqgN7Pp0s8v1i0UGq/ZrrEKrxdIiMQmKRdYb2w7NPtylYSJ4+wg/tIn71m9DLstwUwdEGAvROdly6HXP6w=="],
@@ -243,9 +277,23 @@
 
     "@tanstack/react-query-devtools": ["@tanstack/react-query-devtools@5.101.2", "", { "dependencies": { "@tanstack/query-devtools": "5.101.2" }, "peerDependencies": { "@tanstack/react-query": "^5.101.2", "react": "^18 || ^19" } }, "sha512-eU7HctdA9gDjqoERoEdzLbw9DiqnBDfh5+Hu0u26gjqoHJezOpQAuiesDL2VvkU+2cPV76zgv0tMZsOrI4LjnQ=="],
 
+    "@testing-library/dom": ["@testing-library/dom@10.4.1", "", { "dependencies": { "@babel/code-frame": "^7.10.4", "@babel/runtime": "^7.12.5", "@types/aria-query": "^5.0.1", "aria-query": "5.3.0", "dom-accessibility-api": "^0.5.9", "lz-string": "^1.5.0", "picocolors": "1.1.1", "pretty-format": "^27.0.2" } }, "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg=="],
+
+    "@testing-library/jest-dom": ["@testing-library/jest-dom@7.0.0", "", { "dependencies": { "@adobe/css-tools": "^4.4.0", "aria-query": "^5.0.0", "css.escape": "^1.5.1", "dom-accessibility-api": "^0.6.3", "picocolors": "^1.1.1", "redent": "^3.0.0" }, "peerDependencies": { "@testing-library/dom": ">=10 <11" } }, "sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg=="],
+
+    "@testing-library/react": ["@testing-library/react@16.3.2", "", { "dependencies": { "@babel/runtime": "^7.12.5" }, "peerDependencies": { "@testing-library/dom": "^10.0.0", "@types/react": "^18.0.0 || ^19.0.0", "@types/react-dom": "^18.0.0 || ^19.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g=="],
+
+    "@testing-library/user-event": ["@testing-library/user-event@14.6.1", "", { "peerDependencies": { "@testing-library/dom": ">=7.21.4" } }, "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw=="],
+
     "@tybys/wasm-util": ["@tybys/wasm-util@0.10.3", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg=="],
 
+    "@types/aria-query": ["@types/aria-query@5.0.4", "", {}, "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="],
+
     "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/chai": ["@types/chai@5.2.3", "", { "dependencies": { "@types/deep-eql": "*", "assertion-error": "^2.0.1" } }, "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA=="],
+
+    "@types/deep-eql": ["@types/deep-eql@4.0.2", "", {}, "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw=="],
 
     "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
 
@@ -281,17 +329,41 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@6.0.3", "", { "dependencies": { "@rolldown/pluginutils": "^1.0.1" }, "peerDependencies": { "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0", "babel-plugin-react-compiler": "^1.0.0", "vite": "^8.0.0" }, "optionalPeers": ["@rolldown/plugin-babel", "babel-plugin-react-compiler"] }, "sha512-vmFvco5/QuC2f9Oj+wTk0+9XeDFkHxSamwZKYc7MxYwKICfvUvlMhqKI0VuICPltGqh1neqBKDvO4kes1ya8vg=="],
 
+    "@vitest/expect": ["@vitest/expect@4.1.10", "", { "dependencies": { "@standard-schema/spec": "^1.1.0", "@types/chai": "^5.2.2", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "chai": "^6.2.2", "tinyrainbow": "^3.1.0" } }, "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA=="],
+
+    "@vitest/mocker": ["@vitest/mocker@4.1.10", "", { "dependencies": { "@vitest/spy": "4.1.10", "estree-walker": "^3.0.3", "magic-string": "^0.30.21" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["msw", "vite"] }, "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@4.1.10", "", { "dependencies": { "tinyrainbow": "^3.1.0" } }, "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q=="],
+
+    "@vitest/runner": ["@vitest/runner@4.1.10", "", { "dependencies": { "@vitest/utils": "4.1.10", "pathe": "^2.0.3" } }, "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "@vitest/utils": "4.1.10", "magic-string": "^0.30.21", "pathe": "^2.0.3" } }, "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw=="],
+
+    "@vitest/spy": ["@vitest/spy@4.1.10", "", {}, "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw=="],
+
+    "@vitest/utils": ["@vitest/utils@4.1.10", "", { "dependencies": { "@vitest/pretty-format": "4.1.10", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA=="],
+
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
+    "ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
+
+    "aria-query": ["aria-query@5.3.2", "", {}, "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
     "autoprefixer": ["autoprefixer@10.5.2", "", { "dependencies": { "browserslist": "^4.28.4", "caniuse-lite": "^1.0.30001799", "fraction.js": "^5.3.4", "picocolors": "^1.1.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q=="],
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.42", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-c/jurFrDLyui7o1J86yLkRu4LMsTYcBohveus7/I2Hzdn9KIP2bdJPTue/lR1KH46enoPbD77GKeSYNdyPoD3Q=="],
+
+    "bidi-js": ["bidi-js@1.0.3", "", { "dependencies": { "require-from-string": "^2.0.2" } }, "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -303,6 +375,8 @@
 
     "caniuse-lite": ["caniuse-lite@1.0.30001802", "", {}, "sha512-vmv8ub2xwTNmljSKf82mtCk5JH7hC+YgzLj3P5zotvA0tPQ9016tdNNOG8WRca1IxOnhSsivB+J0z5FeE5LOUw=="],
 
+    "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
+
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
@@ -313,19 +387,35 @@
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
+    "css-tree": ["css-tree@3.2.1", "", { "dependencies": { "mdn-data": "2.27.1", "source-map-js": "^1.2.1" } }, "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA=="],
+
+    "css.escape": ["css.escape@1.5.1", "", {}, "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
+
+    "data-urls": ["data-urls@7.0.0", "", { "dependencies": { "whatwg-mimetype": "^5.0.0", "whatwg-url": "^16.0.0" } }, "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA=="],
 
     "date-fns": ["date-fns@4.4.0", "", {}, "sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-accessibility-api": ["dom-accessibility-api@0.6.3", "", {}, "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w=="],
 
     "dotenv": ["dotenv@17.4.2", "", {}, "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.387", "", {}, "sha512-TaxwufTFDufvPEoXdhwVrA3UdFWBeWGkYoJ1K8ldF1xe6gKfth6iRNS5lTQ5JPNOHdGQm8PT1QYKUqFLCiUefQ=="],
+
+    "entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "es-module-lexer": ["es-module-lexer@2.3.1", "", {}, "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
 
@@ -349,7 +439,11 @@
 
     "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
 
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "expect-type": ["expect-type@1.4.0", "", {}, "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -383,19 +477,27 @@
 
     "hono": ["hono@4.12.28", "", {}, "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@4.0.0", "", {}, "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg=="],
+
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
     "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
+
+    "jsdom": ["jsdom@30.0.1", "", { "dependencies": { "@asamuzakjp/css-color": "^6.0.5", "@asamuzakjp/dom-selector": "^8.3.0", "@bramus/specificity": "^2.4.2", "@csstools/css-syntax-patches-for-csstree": "^1.1.7", "@exodus/bytes": "^1.15.1", "css-tree": "^3.2.1", "data-urls": "^7.0.0", "decimal.js": "^10.6.0", "html-encoding-sniffer": "^6.0.0", "is-potential-custom-element-name": "^1.0.1", "lru-cache": "^11.5.2", "parse5": "^8.0.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^6.0.2", "undici": "^8.9.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^8.0.1", "whatwg-mimetype": "^5.0.0", "whatwg-url": "^17.1.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^3.2.3" }, "optionalPeers": ["canvas"] }, "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA=="],
 
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
@@ -437,9 +539,17 @@
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@11.5.2", "", {}, "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g=="],
 
     "lucide-react": ["lucide-react@1.23.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-38BpJcD0JhFosxHApP/BYsBetLpQFRoTRzEzstM/XCc3jsAG7wqaY1lgVwxiUe3xqYE+lNxo2PkCmYwXWrwwIw=="],
+
+    "lz-string": ["lz-string@1.5.0", "", { "bin": { "lz-string": "bin/bin.js" } }, "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mdn-data": ["mdn-data@2.27.1", "", {}, "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ=="],
+
+    "min-indent": ["min-indent@1.0.1", "", {}, "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
@@ -451,15 +561,21 @@
 
     "node-releases": ["node-releases@2.0.50", "", {}, "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg=="],
 
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
     "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
+    "parse5": ["parse5@8.0.1", "", { "dependencies": { "entities": "^8.0.0" } }, "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -471,17 +587,27 @@
 
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
+    "pretty-format": ["pretty-format@27.5.1", "", { "dependencies": { "ansi-regex": "^5.0.1", "ansi-styles": "^5.0.0", "react-is": "^17.0.1" } }, "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
 
     "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
+    "react-is": ["react-is@17.0.2", "", {}, "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="],
+
     "react-router": ["react-router@7.18.1", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg=="],
 
     "react-router-dom": ["react-router-dom@7.18.1", "", { "dependencies": { "react-router": "7.18.1" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg=="],
 
+    "redent": ["redent@3.0.0", "", { "dependencies": { "indent-string": "^4.0.0", "strip-indent": "^3.0.0" } }, "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "rolldown": ["rolldown@1.1.4", "", { "dependencies": { "@oxc-project/types": "=0.138.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm64": "1.1.4", "@rolldown/binding-darwin-arm64": "1.1.4", "@rolldown/binding-darwin-x64": "1.1.4", "@rolldown/binding-freebsd-x64": "1.1.4", "@rolldown/binding-linux-arm-gnueabihf": "1.1.4", "@rolldown/binding-linux-arm64-gnu": "1.1.4", "@rolldown/binding-linux-arm64-musl": "1.1.4", "@rolldown/binding-linux-ppc64-gnu": "1.1.4", "@rolldown/binding-linux-s390x-gnu": "1.1.4", "@rolldown/binding-linux-x64-gnu": "1.1.4", "@rolldown/binding-linux-x64-musl": "1.1.4", "@rolldown/binding-openharmony-arm64": "1.1.4", "@rolldown/binding-wasm32-wasi": "1.1.4", "@rolldown/binding-win32-arm64-msvc": "1.1.4", "@rolldown/binding-win32-x64-msvc": "1.1.4" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
@@ -493,13 +619,37 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@4.2.0", "", {}, "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw=="],
+
+    "strip-indent": ["strip-indent@3.0.0", "", { "dependencies": { "min-indent": "^1.0.0" } }, "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwind-merge": ["tailwind-merge@3.6.0", "", {}, "sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w=="],
 
     "tailwindcss": ["tailwindcss@4.3.2", "", {}, "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA=="],
 
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@1.3.0", "", {}, "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ=="],
+
     "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "tinyrainbow": ["tinyrainbow@3.1.1", "", {}, "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw=="],
+
+    "tldts": ["tldts@7.4.10", "", { "dependencies": { "tldts-core": "^7.4.10" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog=="],
+
+    "tldts-core": ["tldts-core@7.4.10", "", {}, "sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw=="],
+
+    "tough-cookie": ["tough-cookie@6.0.2", "", { "dependencies": { "tldts": "^7.0.5" } }, "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA=="],
+
+    "tr46": ["tr46@6.0.0", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw=="],
 
     "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
 
@@ -511,6 +661,8 @@
 
     "typescript-eslint": ["typescript-eslint@8.63.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.63.0", "@typescript-eslint/parser": "8.63.0", "@typescript-eslint/typescript-estree": "8.63.0", "@typescript-eslint/utils": "8.63.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-xgwXyzG4sK9ALkBxbyGkTMMOS+imnW65iPhxCQMK83KhxyoDNW7l+IDqEf9vMdoUidHpOoS967RCq4eMiTexwQ=="],
 
+    "undici": ["undici@8.10.0", "", {}, "sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ=="],
+
     "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -519,9 +671,25 @@
 
     "vite": ["vite@8.1.3", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.16", "rolldown": "~1.1.3", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.3.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-Ds+gBRbj0lwRO2Y5hwnUBdxSwlAve9LeRyU4sNnAr0ewW0gWF0n5bgXgUzbgZ49MV9BVUAQUFYVcDUcilUExMA=="],
 
+    "vitest": ["vitest@4.1.10", "", { "dependencies": { "@vitest/expect": "4.1.10", "@vitest/mocker": "4.1.10", "@vitest/pretty-format": "4.1.10", "@vitest/runner": "4.1.10", "@vitest/snapshot": "4.1.10", "@vitest/spy": "4.1.10", "@vitest/utils": "4.1.10", "es-module-lexer": "^2.0.0", "expect-type": "^1.3.0", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^4.0.0-rc.1", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.1.0", "vite": "^6.0.0 || ^7.0.0 || ^8.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.1.10", "@vitest/browser-preview": "4.1.10", "@vitest/browser-webdriverio": "4.1.10", "@vitest/coverage-istanbul": "4.1.10", "@vitest/coverage-v8": "4.1.10", "@vitest/ui": "4.1.10", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/coverage-istanbul", "@vitest/coverage-v8", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "./vitest.mjs" } }, "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw=="],
+
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
+    "webidl-conversions": ["webidl-conversions@8.0.1", "", {}, "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@5.0.0", "", {}, "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw=="],
+
+    "whatwg-url": ["whatwg-url@17.1.0", "", { "dependencies": { "@exodus/bytes": "^1.15.1", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": { "why-is-node-running": "cli.js" } }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
@@ -535,13 +703,21 @@
 
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@testing-library/dom/aria-query": ["aria-query@5.3.0", "", { "dependencies": { "dequal": "^2.0.3" } }, "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A=="],
+
+    "@testing-library/dom/dom-accessibility-api": ["dom-accessibility-api@0.5.16", "", {}, "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg=="],
 
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "bun-types/@types/node": ["@types/node@20.19.39", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw=="],
+
+    "data-urls/whatwg-url": ["whatwg-url@16.0.1", "", { "dependencies": { "@exodus/bytes": "^1.11.0", "tr46": "^6.0.0", "webidl-conversions": "^8.0.1" } }, "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw=="],
 
     "@babel/helper-compilation-targets/browserslist/baseline-browser-mapping": ["baseline-browser-mapping@2.10.27", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA=="],
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,6 +10,7 @@
     "test": "bun test"
   },
   "dependencies": {
+    "@aws-sdk/client-cloudwatch-logs": "3.1080.0",
     "@aws-sdk/client-ec2": "^3.1076.0",
     "@aws-sdk/client-eks": "^3.1076.0",
     "@aws-sdk/client-lambda": "^3.1076.0",

--- a/packages/api/src/aws.ts
+++ b/packages/api/src/aws.ts
@@ -4,6 +4,7 @@ import { EKSClient } from "@aws-sdk/client-eks";
 import { EC2Client } from "@aws-sdk/client-ec2";
 import { RDSClient } from "@aws-sdk/client-rds";
 import { SecretsManagerClient } from "@aws-sdk/client-secrets-manager";
+import { CloudWatchLogsClient } from "@aws-sdk/client-cloudwatch-logs";
 
 const endpoint = process.env.FLOCI_ENDPOINT;
 const region = process.env.AWS_REGION || "us-east-1";
@@ -39,6 +40,7 @@ export type AwsClients = {
   ec2: EC2Client;
   rds: RDSClient;
   secretsManager: SecretsManagerClient;
+  cloudWatchLogs: CloudWatchLogsClient;
 };
 
 export type AwsClientName = keyof AwsClients;
@@ -58,6 +60,7 @@ function buildClients(accountId: string): AwsClients {
     ec2: new EC2Client(base),
     rds: new RDSClient(base),
     secretsManager: new SecretsManagerClient(base),
+    cloudWatchLogs: new CloudWatchLogsClient(base),
   };
 }
 
@@ -89,3 +92,4 @@ export const eks = awsClients.eks;
 export const ec2 = awsClients.ec2;
 export const rds = awsClients.rds;
 export const secretsManager = awsClients.secretsManager;
+export const cloudWatchLogs = awsClients.cloudWatchLogs;

--- a/packages/api/src/cloud-spi/serviceCatalog.test.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.test.ts
@@ -61,6 +61,14 @@ describe('SERVICE_CATALOG', () => {
         // No override -> the shared display name.
         expect(displayNameFor(catalogEntry('storage')!, 'gcp')).toBe('Storage')
     })
+
+    test('logs is a legacy AWS-only page in the Observability group, like Secrets Manager', () => {
+        const logs = catalogEntry('logs')!
+        expect(logs).toBeDefined()
+        expect(logs.group).toBe('Observability')
+        expect(routeFor(logs)).toBe('/logs')
+        expect(logs.legacyAvailability?.aws).toBe('available')
+    })
 })
 
 describe('isServiceType', () => {

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -85,6 +85,17 @@ export const SERVICE_CATALOG = {
         // Explorer, so there is no adapter to derive availability from.
         legacyAvailability: {aws: 'available'},
     },
+    logs: {
+        displayName: 'CloudWatch Logs',
+        iconKey: 'logs',
+        group: 'Observability',
+        order: 10,
+        route: '/logs',
+        // Groups/streams/events drill-in is a standalone page like Secrets
+        // Manager, not a generic CloudResource table, so there is no adapter
+        // to derive availability from.
+        legacyAvailability: {aws: 'available'},
+    },
 } as const satisfies Record<string, ServiceCatalogMetadata>
 
 export type CloudServiceType = keyof typeof SERVICE_CATALOG

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,6 +8,7 @@ import rds from "./routes/rds";
 import ec2 from "./routes/ec2";
 import secretsmanager from "./routes/secretsmanager";
 import clouds from "./routes/clouds";
+import logs from "./routes/logs";
 const app = new Hono();
 
 // The Secrets Manager routes read and delete secret values with server-side
@@ -46,6 +47,7 @@ app.route("/api/rds", rds);
 app.route("/api/ec2", ec2);
 app.route("/api/secretsmanager", secretsmanager);
 app.route("/api/clouds", clouds);
+app.route("/api/logs", logs);
 
 // Serve static frontend files when public/ directory is present (production)
 app.use("*", serveStatic({ root: "./public" }));

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -486,6 +486,20 @@ describe('service descriptors', () => {
         expect(secretsFor(aws)).toMatchObject({availability: 'available', route: '/secretsmanager'})
         expect(secretsFor(gcp)).toMatchObject({availability: 'coming_soon'})
     })
+
+    test('surfaces the legacy CloudWatch Logs page in the nav on AWS only', async () => {
+        const aws = await (await appWithRoutes().request('/api/clouds/aws/services')).json()
+        const azure = await (await appWithRoutes().request('/api/clouds/azure/services')).json()
+        const logsFor = (body: Array<{service: string}>) => body.find((d) => d.service === 'logs')
+
+        expect(logsFor(aws)).toMatchObject({
+            availability: 'available',
+            route: '/logs',
+            group: 'Observability',
+        })
+        // No adapter and no Azure override, so it degrades like Secrets Manager does on GCP.
+        expect(logsFor(azure)).toMatchObject({availability: 'coming_soon'})
+    })
 })
 
 describe('per-service status', () => {

--- a/packages/api/src/routes/logs.test.ts
+++ b/packages/api/src/routes/logs.test.ts
@@ -105,3 +105,157 @@ describe('GET /groups', () => {
         expect(body).toEqual([])
     })
 })
+
+describe('GET /streams', () => {
+    test('returns the mapped streams from DescribeLogStreamsCommand', async () => {
+        responder = () => ({
+            logStreams: [
+                {
+                    logStreamName: '2024/01/01/[$LATEST]abc123',
+                    arn: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/foo:log-stream:2024/01/01/[$LATEST]abc123',
+                    creationTime: 1700000000000,
+                    firstEventTimestamp: 1700000001000,
+                    lastEventTimestamp: 1700000002000,
+                    storedBytes: 4096,
+                },
+            ],
+        })
+
+        const res = await app.request('/streams?group=/aws/lambda/foo')
+        expect(res.status).toBe(200)
+        const body = await res.json()
+
+        expect(body).toEqual({
+            streams: [
+                {
+                    name: '2024/01/01/[$LATEST]abc123',
+                    arn: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/foo:log-stream:2024/01/01/[$LATEST]abc123',
+                    creationTime: new Date(1700000000000).toISOString(),
+                    firstEventTimestamp: new Date(1700000001000).toISOString(),
+                    lastEventTimestamp: new Date(1700000002000).toISOString(),
+                    storedBytes: 4096,
+                },
+            ],
+        })
+    })
+
+    test('forwards group as logGroupName on the command input', async () => {
+        await app.request('/streams?group=/aws/lambda/foo')
+
+        expect(lastCommand?.input.logGroupName).toBe('/aws/lambda/foo')
+    })
+
+    test('rejects a missing group with 400 instead of calling the SDK', async () => {
+        const res = await app.request('/streams')
+        expect(res.status).toBe(400)
+        expect(await res.json()).toEqual({error: 'group is required'})
+        expect(lastCommand).toBeNull()
+    })
+
+    test('account forwarding: header value reaches awsClientsForAccount, and its absence does not', async () => {
+        await app.request('/streams?group=/aws/lambda/foo', {headers: {'x-floci-account-id': '111111111111'}})
+        expect(lastAccountId).toBe('111111111111')
+
+        await app.request('/streams?group=/aws/lambda/foo')
+        expect(lastAccountId).not.toBe('111111111111')
+    })
+
+    test('account query param is honored when the header is absent, and the header wins when both are present', async () => {
+        await app.request('/streams?group=/aws/lambda/foo&account=222222222222')
+        expect(lastAccountId).toBe('222222222222')
+
+        await app.request('/streams?group=/aws/lambda/foo&account=222222222222', {
+            headers: {'x-floci-account-id': '333333333333'},
+        })
+        expect(lastAccountId).toBe('333333333333')
+    })
+
+    test('an empty logStreams array yields an empty list, not an error', async () => {
+        responder = () => ({logStreams: []})
+
+        const res = await app.request('/streams?group=/aws/lambda/foo')
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({streams: []})
+    })
+})
+
+describe('GET /events', () => {
+    test('returns the mapped events from GetLogEventsCommand', async () => {
+        responder = () => ({
+            events: [
+                {timestamp: 1700000001000, message: 'START RequestId: abc'},
+                {timestamp: 1700000002000, message: 'END RequestId: abc'},
+            ],
+            nextForwardToken: 'f/next-token',
+            nextBackwardToken: 'b/prev-token',
+        })
+
+        const res = await app.request('/events?group=/aws/lambda/foo&stream=2024/01/01/[$LATEST]abc123')
+        expect(res.status).toBe(200)
+        const body = await res.json()
+
+        expect(body).toEqual({
+            events: [
+                {timestamp: new Date(1700000001000).toISOString(), message: 'START RequestId: abc'},
+                {timestamp: new Date(1700000002000).toISOString(), message: 'END RequestId: abc'},
+            ],
+            nextToken: 'f/next-token',
+        })
+    })
+
+    test('forwards group and stream on the command input', async () => {
+        await app.request('/events?group=/aws/lambda/foo&stream=2024/01/01/[$LATEST]abc123')
+
+        expect(lastCommand?.input.logGroupName).toBe('/aws/lambda/foo')
+        expect(lastCommand?.input.logStreamName).toBe('2024/01/01/[$LATEST]abc123')
+    })
+
+    test('forwards a caller-supplied nextToken on the command input', async () => {
+        await app.request('/events?group=/aws/lambda/foo&stream=s1&nextToken=f/prior-token')
+
+        expect(lastCommand?.input.nextToken).toBe('f/prior-token')
+    })
+
+    test('rejects a missing group with 400 instead of calling the SDK', async () => {
+        const res = await app.request('/events?stream=s1')
+        expect(res.status).toBe(400)
+        expect(await res.json()).toEqual({error: 'group is required'})
+        expect(lastCommand).toBeNull()
+    })
+
+    test('rejects a missing stream with 400 instead of calling the SDK', async () => {
+        const res = await app.request('/events?group=/aws/lambda/foo')
+        expect(res.status).toBe(400)
+        expect(await res.json()).toEqual({error: 'stream is required'})
+        expect(lastCommand).toBeNull()
+    })
+
+    test('collapses nextToken to undefined when CloudWatch echoes the requested token back (end of stream)', async () => {
+        responder = () => ({
+            events: [{timestamp: 1700000001000, message: 'only event'}],
+            nextForwardToken: 'f/same-token',
+        })
+
+        const res = await app.request('/events?group=/aws/lambda/foo&stream=s1&nextToken=f/same-token')
+        const body = await res.json()
+
+        expect(body.nextToken).toBeUndefined()
+    })
+
+    test('an empty events array yields no nextToken, even though CloudWatch still returns a fresh forward token', async () => {
+        responder = () => ({events: [], nextForwardToken: 'f/fresh-token'})
+
+        const res = await app.request('/events?group=/aws/lambda/foo&stream=s1')
+        const body = await res.json()
+
+        expect(body).toEqual({events: [], nextToken: undefined})
+    })
+
+    test('account forwarding: header value reaches awsClientsForAccount, and its absence does not', async () => {
+        await app.request('/events?group=/aws/lambda/foo&stream=s1', {headers: {'x-floci-account-id': '111111111111'}})
+        expect(lastAccountId).toBe('111111111111')
+
+        await app.request('/events?group=/aws/lambda/foo&stream=s1')
+        expect(lastAccountId).not.toBe('111111111111')
+    })
+})

--- a/packages/api/src/routes/logs.test.ts
+++ b/packages/api/src/routes/logs.test.ts
@@ -1,0 +1,107 @@
+import {beforeEach, describe, expect, mock, test} from 'bun:test'
+import * as realAws from '../aws'
+
+// Unlike secretsmanager.ts (which imports a singleton client), logs.ts must
+// resolve its CloudWatch Logs client per-request via awsClientsForAccount so
+// the route respects the active-account header. The stub below is therefore
+// a function, not a plain object, and it records the account id it was
+// called with so tests can assert the route actually forwarded it -- a mock
+// that ignored its argument would pass whether or not the header is honored.
+//
+// logs.ts also imports ACCOUNT_HEADER from './clouds', which transitively
+// pulls in cloudProxy and several other adapters that import unrelated
+// bindings (awsClients, s3, lambda, rds, resolveAccountId, ...) from
+// '../aws'. Those bindings are never exercised by this route, but they must
+// still resolve, so the mock spreads the real module and overrides only
+// awsClientsForAccount -- the one binding under test.
+let lastCommand: {constructor: {name: string}; input: Record<string, unknown>} | null = null
+let lastAccountId: string | null | undefined = 'NEVER_CALLED'
+let responder: (commandName: string, command: {input: Record<string, unknown>}) => unknown
+
+mock.module('../aws', () => ({
+    ...realAws,
+    awsClientsForAccount: (accountId?: string | null) => {
+        lastAccountId = accountId
+        return {
+            cloudWatchLogs: {
+                async send(command: {constructor: {name: string}; input: Record<string, unknown>}) {
+                    lastCommand = command
+                    return responder(command.constructor.name, command)
+                },
+            },
+        }
+    },
+}))
+
+// Imported after the mock is registered so the route binds to the stubbed client.
+const {default: app} = await import('./logs')
+
+beforeEach(() => {
+    lastCommand = null
+    lastAccountId = 'NEVER_CALLED'
+    responder = () => ({logGroups: []})
+})
+
+describe('GET /groups', () => {
+    test('returns the mapped groups from DescribeLogGroupsCommand', async () => {
+        responder = () => ({
+            logGroups: [
+                {
+                    logGroupName: '/aws/lambda/foo',
+                    arn: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/foo:*',
+                    creationTime: 1700000000000,
+                    retentionInDays: 14,
+                    kmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc',
+                },
+            ],
+        })
+
+        const res = await app.request('/groups')
+        expect(res.status).toBe(200)
+        const body = await res.json()
+
+        expect(body).toEqual([
+            {
+                name: '/aws/lambda/foo',
+                arn: 'arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/foo:*',
+                creationTime: new Date(1700000000000).toISOString(),
+                retentionInDays: 14,
+                kmsKeyId: 'arn:aws:kms:us-east-1:111111111111:key/abc',
+            },
+        ])
+    })
+
+    test('forwards prefix as logGroupNamePrefix on the command input', async () => {
+        await app.request('/groups?prefix=/aws/lambda/')
+
+        expect(lastCommand?.input.logGroupNamePrefix).toBe('/aws/lambda/')
+    })
+
+    test('account forwarding: header value reaches awsClientsForAccount, and its absence does not', async () => {
+        await app.request('/groups', {headers: {'x-floci-account-id': '111111111111'}})
+        expect(lastAccountId).toBe('111111111111')
+
+        await app.request('/groups')
+        expect(lastAccountId).not.toBe('111111111111')
+    })
+
+    test('account query param is honored when the header is absent, and the header wins when both are present', async () => {
+        await app.request('/groups?account=222222222222')
+        expect(lastAccountId).toBe('222222222222')
+
+        await app.request('/groups?account=222222222222', {
+            headers: {'x-floci-account-id': '333333333333'},
+        })
+        expect(lastAccountId).toBe('333333333333')
+    })
+
+    test('an empty logGroups array yields an empty list, not an error', async () => {
+        responder = () => ({logGroups: []})
+
+        const res = await app.request('/groups')
+        expect(res.status).toBe(200)
+        const body = await res.json()
+
+        expect(body).toEqual([])
+    })
+})

--- a/packages/api/src/routes/logs.ts
+++ b/packages/api/src/routes/logs.ts
@@ -1,5 +1,5 @@
 import {Hono} from 'hono'
-import {DescribeLogGroupsCommand} from '@aws-sdk/client-cloudwatch-logs'
+import {DescribeLogGroupsCommand, DescribeLogStreamsCommand, GetLogEventsCommand} from '@aws-sdk/client-cloudwatch-logs'
 import {awsClientsForAccount} from '../aws'
 import {ACCOUNT_HEADER} from './clouds'
 
@@ -42,6 +42,73 @@ app.get('/groups', async (c) => {
     })
 
     return c.json(groups)
+})
+
+app.get('/streams', async (c) => {
+    const accountId = c.req.header(ACCOUNT_HEADER) ?? c.req.query('account')
+    const {cloudWatchLogs} = awsClientsForAccount(accountId)
+
+    const group = c.req.query('group')
+    if (!group) return c.json({error: 'group is required'}, 400)
+
+    const res = await cloudWatchLogs.send(new DescribeLogStreamsCommand({
+        logGroupName: group,
+    }))
+
+    const streams = (res.logStreams ?? []).flatMap((s) => {
+        if (!s.logStreamName) return []
+        return [{
+            name: s.logStreamName,
+            arn: s.arn,
+            creationTime: s.creationTime ? new Date(s.creationTime).toISOString() : undefined,
+            firstEventTimestamp: s.firstEventTimestamp ? new Date(s.firstEventTimestamp).toISOString() : undefined,
+            lastEventTimestamp: s.lastEventTimestamp ? new Date(s.lastEventTimestamp).toISOString() : undefined,
+            storedBytes: s.storedBytes,
+        }]
+    })
+
+    // An envelope, not a bare array like /groups: /events needs to carry a
+    // pagination token alongside its list, and this stays shaped the same way
+    // for consistency even though floci does not paginate DescribeLogStreams
+    // any more than it does DescribeLogGroups.
+    return c.json({streams})
+})
+
+app.get('/events', async (c) => {
+    const accountId = c.req.header(ACCOUNT_HEADER) ?? c.req.query('account')
+    const {cloudWatchLogs} = awsClientsForAccount(accountId)
+
+    const group = c.req.query('group')
+    if (!group) return c.json({error: 'group is required'}, 400)
+    const stream = c.req.query('stream')
+    if (!stream) return c.json({error: 'stream is required'}, 400)
+
+    const nextToken = c.req.query('nextToken')
+
+    const res = await cloudWatchLogs.send(new GetLogEventsCommand({
+        logGroupName: group,
+        logStreamName: stream,
+        nextToken: nextToken || undefined,
+        startFromHead: true,
+    }))
+
+    const events = (res.events ?? []).flatMap((e) => {
+        if (e.message === undefined) return []
+        return [{
+            timestamp: e.timestamp ? new Date(e.timestamp).toISOString() : undefined,
+            message: e.message,
+        }]
+    })
+
+    // GetLogEvents always echoes a forward token, even at the end of the
+    // stream -- when there is nothing new it just hands back the token you
+    // sent instead of signalling "done". Collapse that echo (and the
+    // no-events case) to undefined so a "load more" UI stops instead of
+    // refetching the same page forever.
+    const nextForwardToken = res.nextForwardToken
+    const hasMore = events.length > 0 && nextForwardToken !== undefined && nextForwardToken !== nextToken
+
+    return c.json({events, nextToken: hasMore ? nextForwardToken : undefined})
 })
 
 export default app

--- a/packages/api/src/routes/logs.ts
+++ b/packages/api/src/routes/logs.ts
@@ -1,0 +1,47 @@
+import {Hono} from 'hono'
+import {DescribeLogGroupsCommand} from '@aws-sdk/client-cloudwatch-logs'
+import {awsClientsForAccount} from '../aws'
+import {ACCOUNT_HEADER} from './clouds'
+
+const app = new Hono()
+
+app.get('/groups', async (c) => {
+    // Resolve the client set per request (never the ../aws singleton) so this
+    // route follows the console's active account instead of always serving
+    // the default account.
+    const accountId = c.req.header(ACCOUNT_HEADER) ?? c.req.query('account')
+    const {cloudWatchLogs} = awsClientsForAccount(accountId)
+
+    const prefix = c.req.query('prefix')
+
+    // floci implements no pagination on DescribeLogGroups: it reads only
+    // logGroupNamePrefix and ignores limit/nextToken, always returning every
+    // group in a single response. Real AWS paginates; a do/while NextToken
+    // loop here would spin forever or mislead, so it is intentionally absent.
+    const res = await cloudWatchLogs.send(new DescribeLogGroupsCommand({
+        logGroupNamePrefix: prefix || undefined,
+    }))
+
+    const groups = (res.logGroups ?? []).flatMap((g) => {
+        // logGroupName missing means malformed data from the producer, not a
+        // legitimate "no name" state. Skip the entry rather than papering
+        // over it with a `?? ''` fallback.
+        if (!g.logGroupName) return []
+        return [{
+            name: g.logGroupName,
+            arn: g.arn,
+            creationTime: g.creationTime ? new Date(g.creationTime).toISOString() : undefined,
+            retentionInDays: g.retentionInDays,
+            kmsKeyId: g.kmsKeyId,
+            // storedBytes and metricFilterCount are deliberately omitted:
+            // floci hardcodes both to 0 at the group level, and surfacing a
+            // hardcoded 0 would render in the UI as "every log group is
+            // empty", which is false. (Stream-level storedBytes is real and
+            // is used in a later phase.)
+        }]
+    })
+
+    return c.json(groups)
+})
+
+export default app

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,7 +9,9 @@
     "build": "tsc && vite build",
     "preview": "vite preview",
     "lint": "eslint src --report-unused-disable-directives --max-warnings 0",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.101.2",
@@ -25,6 +27,9 @@
     "zustand": "^5.0.13"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "7.0.0",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "14.6.1",
     "@types/node": "^25.9.4",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.0",
@@ -35,10 +40,12 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.2",
     "globals": "^17.7.0",
+    "jsdom": "^30.0.1",
     "postcss": "^8.5.16",
     "tailwindcss": "^4.3.0",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.62.1",
-    "vite": "^8.1.3"
+    "vite": "^8.1.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import {BrowserRouter, Navigate, Route, Routes} from 'react-router-dom'
 import {Layout} from '@/components/Layout'
 import {SecretsManagerPage} from '@/features/secretsmanager/SecretsManagerPage'
+import {LogGroupsPage} from '@/features/cloudwatch-logs/LogGroupsPage'
 import {CloudExplorerPage} from '@/pages/CloudExplorerPage'
 import {CloudConsoleHomePage} from '@/pages/CloudConsoleHomePage'
 
@@ -16,6 +17,7 @@ export default function App() {
                     <Route path="/cloud-explorer" element={<Navigate to="/cloud-explorer/aws/storage" replace/>}/>
                     <Route path="/cloud-explorer/:cloud/:service" element={<CloudExplorerPage/>}/>
                     <Route path="/secretsmanager" element={<SecretsManagerPage/>}/>
+                    <Route path="/logs" element={<LogGroupsPage/>}/>
                     <Route path="*" element={<Navigate to="/console/aws" replace/>}/>
                 </Route>
             </Routes>

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -168,6 +168,12 @@ export const apiEndpointKeys = {
       groups: {
         list: "aws.logs.groups.list",
       },
+      streams: {
+        list: "aws.logs.streams.list",
+      },
+      events: {
+        list: "aws.logs.events.list",
+      },
     },
   },
 } as const;
@@ -590,6 +596,22 @@ export const endpointRegistry: EndpointRegistry = new Map([
     apiEndpointKeys.aws.logs.groups.list,
     {
       path: "/logs/groups",
+      method: "GET",
+      telemetry: { provider: "aws", service: "logs" },
+    },
+  ],
+  [
+    apiEndpointKeys.aws.logs.streams.list,
+    {
+      path: "/logs/streams",
+      method: "GET",
+      telemetry: { provider: "aws", service: "logs" },
+    },
+  ],
+  [
+    apiEndpointKeys.aws.logs.events.list,
+    {
+      path: "/logs/events",
       method: "GET",
       telemetry: { provider: "aws", service: "logs" },
     },

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -164,6 +164,11 @@ export const apiEndpointKeys = {
       instanceTypes: "aws.ec2.instance-types",
       vpcWizard: "aws.ec2.vpc-wizard",
     },
+    logs: {
+      groups: {
+        list: "aws.logs.groups.list",
+      },
+    },
   },
 } as const;
 
@@ -579,6 +584,16 @@ export const endpointRegistry: EndpointRegistry = new Map([
   [apiEndpointKeys.aws.ec2.availabilityZones, { path: "/ec2/availability-zones", method: "GET", telemetry: { provider: "aws", service: "ec2" } }],
   [apiEndpointKeys.aws.ec2.instanceTypes,     { path: "/ec2/instance-types", method: "GET", telemetry: { provider: "aws", service: "ec2" } }],
   [apiEndpointKeys.aws.ec2.vpcWizard,         { path: "/ec2/vpc-wizard", method: "POST", telemetry: { provider: "aws", service: "ec2" } }],
+
+  // AWS CloudWatch Logs
+  [
+    apiEndpointKeys.aws.logs.groups.list,
+    {
+      path: "/logs/groups",
+      method: "GET",
+      telemetry: { provider: "aws", service: "logs" },
+    },
+  ],
 
 ]);
 

--- a/packages/frontend/src/api/aws/logs.api.test.ts
+++ b/packages/frontend/src/api/aws/logs.api.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+
+const { callMock } = vi.hoisted(() => ({ callMock: vi.fn() }));
+
+vi.mock("@/api/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      call: callMock,
+    },
+  };
+});
+
+import { apiEndpointKeys } from "@/api/api";
+import { listLogGroups } from "./logs.api";
+
+describe("listLogGroups", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+  });
+
+  it("calls apiClient.call with the real aws.logs.groups.list endpoint key and returns res.data", async () => {
+    const groups = [{ name: "/aws/lambda/foo" }];
+    callMock.mockResolvedValue({ data: groups });
+
+    const result = await listLogGroups();
+
+    expect(callMock).toHaveBeenCalledTimes(1);
+    expect(callMock.mock.calls[0][0]).toBe(apiEndpointKeys.aws.logs.groups.list);
+    expect(result).toEqual(groups);
+  });
+
+  it("forwards a given prefix as params: { prefix }", async () => {
+    callMock.mockResolvedValue({ data: [] });
+
+    await listLogGroups("/aws/lambda/");
+
+    const options = callMock.mock.calls[0][1];
+    expect(options.params).toEqual({ prefix: "/aws/lambda/" });
+  });
+
+  it("does not send a blank prefix param when no prefix is given", async () => {
+    callMock.mockResolvedValue({ data: [] });
+
+    await listLogGroups();
+
+    const options = callMock.mock.calls[0][1];
+    const prefixValue = options.params?.prefix;
+    expect(prefixValue === undefined || options.params === undefined).toBe(true);
+  });
+
+  it("forwards the abort signal", async () => {
+    callMock.mockResolvedValue({ data: [] });
+    const controller = new AbortController();
+
+    await listLogGroups(undefined, controller.signal);
+
+    const options = callMock.mock.calls[0][1];
+    expect(options.signal).toBe(controller.signal);
+  });
+
+  it("round-trips a group with only name present, without inventing storedBytes", async () => {
+    const groups = [{ name: "/aws/lambda/bare" }];
+    callMock.mockResolvedValue({ data: groups });
+
+    const result = await listLogGroups();
+
+    expect(result[0]).not.toHaveProperty("storedBytes");
+    expect(result[0]).not.toHaveProperty("metricFilterCount");
+    expect(result[0]).toEqual({ name: "/aws/lambda/bare" });
+  });
+});

--- a/packages/frontend/src/api/aws/logs.api.ts
+++ b/packages/frontend/src/api/aws/logs.api.ts
@@ -24,6 +24,53 @@ export async function listLogGroups(
   return res.data;
 }
 
+export type LogStream = {
+  name: string;
+  arn?: string;
+  creationTime?: string;
+  firstEventTimestamp?: string;
+  lastEventTimestamp?: string;
+  storedBytes?: number;
+};
+
+export async function listLogStreams(
+  group: string,
+  signal?: AbortSignal,
+): Promise<LogStream[]> {
+  const res = await apiClient.call<{ streams: LogStream[] }>(
+    apiEndpointKeys.aws.logs.streams.list,
+    { signal, params: { group } },
+  );
+
+  return res.data.streams;
+}
+
+export type LogEvent = {
+  timestamp?: string;
+  message: string;
+};
+
+export type LogEventsPage = {
+  events: LogEvent[];
+  nextToken?: string;
+};
+
+export async function listLogEvents(
+  group: string,
+  stream: string,
+  nextToken?: string,
+  signal?: AbortSignal,
+): Promise<LogEventsPage> {
+  const res = await apiClient.call<LogEventsPage>(
+    apiEndpointKeys.aws.logs.events.list,
+    { signal, params: { group, stream, nextToken } },
+  );
+
+  return res.data;
+}
+
 export const logsClient = {
   listGroups: listLogGroups,
+  listStreams: listLogStreams,
+  listEvents: listLogEvents,
 };

--- a/packages/frontend/src/api/aws/logs.api.ts
+++ b/packages/frontend/src/api/aws/logs.api.ts
@@ -1,0 +1,29 @@
+import { apiClient, apiEndpointKeys } from "@/api/api";
+
+// storedBytes and metricFilterCount are intentionally absent: floci
+// hardcodes both to 0 at the group level server-side, so surfacing them
+// here would render every log group as empty, which is false. Do not
+// "helpfully" add them back.
+export type LogGroup = {
+  name: string;
+  arn?: string;
+  creationTime?: string;
+  retentionInDays?: number;
+  kmsKeyId?: string;
+};
+
+export async function listLogGroups(
+  prefix?: string,
+  signal?: AbortSignal,
+): Promise<LogGroup[]> {
+  const res = await apiClient.call<LogGroup[]>(
+    apiEndpointKeys.aws.logs.groups.list,
+    { signal, params: prefix ? { prefix } : undefined },
+  );
+
+  return res.data;
+}
+
+export const logsClient = {
+  listGroups: listLogGroups,
+};

--- a/packages/frontend/src/api/aws/logs.queries.test.ts
+++ b/packages/frontend/src/api/aws/logs.queries.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+import { logsQueryKeys } from "./logs.queries";
+
+describe("logsQueryKeys.groups", () => {
+  it("produces different query keys for different prefixes", () => {
+    const keyA = logsQueryKeys.groups("/aws/lambda/");
+    const keyB = logsQueryKeys.groups("/aws/apigateway/");
+
+    expect(keyA).not.toEqual(keyB);
+  });
+
+  it("produces a stable key distinct from the no-prefix key", () => {
+    const withPrefix = logsQueryKeys.groups("/aws/lambda/");
+    const noPrefix = logsQueryKeys.groups();
+
+    expect(withPrefix).not.toEqual(noPrefix);
+  });
+});

--- a/packages/frontend/src/api/aws/logs.queries.ts
+++ b/packages/frontend/src/api/aws/logs.queries.ts
@@ -1,8 +1,11 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { logsClient } from "./logs.api";
 
 export const logsQueryKeys = {
   groups: (prefix?: string) => ["logs", "groups", prefix ?? "all"] as const,
+  streams: (group: string) => ["logs", "streams", group] as const,
+  events: (group: string, stream: string, nextToken?: string) =>
+    ["logs", "events", group, stream, nextToken ?? "first"] as const,
 };
 
 export function useLogGroupsQuery(prefix?: string) {
@@ -10,5 +13,28 @@ export function useLogGroupsQuery(prefix?: string) {
     queryKey: logsQueryKeys.groups(prefix),
     queryFn: ({ signal }) => logsClient.listGroups(prefix, signal),
     refetchInterval: 30_000,
+  });
+}
+
+export function useLogStreamsQuery(group: string) {
+  return useQuery({
+    queryKey: logsQueryKeys.streams(group),
+    queryFn: ({ signal }) => logsClient.listStreams(group, signal),
+  });
+}
+
+/**
+ * One query per loaded page of events, keyed by the token that produced it.
+ * There is no useInfiniteQuery precedent elsewhere in this codebase, and a
+ * plain array of per-page queries is enough: each page's own token makes it
+ * independently cacheable and re-fetchable without an accumulation effect
+ * that would double-append under React's dev-mode double-invoke.
+ */
+export function useLogEventsPagesQuery(group: string, stream: string, tokens: Array<string | undefined>) {
+  return useQueries({
+    queries: tokens.map((nextToken) => ({
+      queryKey: logsQueryKeys.events(group, stream, nextToken),
+      queryFn: ({ signal }: { signal: AbortSignal }) => logsClient.listEvents(group, stream, nextToken, signal),
+    })),
   });
 }

--- a/packages/frontend/src/api/aws/logs.queries.ts
+++ b/packages/frontend/src/api/aws/logs.queries.ts
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+import { logsClient } from "./logs.api";
+
+export const logsQueryKeys = {
+  groups: (prefix?: string) => ["logs", "groups", prefix ?? "all"] as const,
+};
+
+export function useLogGroupsQuery(prefix?: string) {
+  return useQuery({
+    queryKey: logsQueryKeys.groups(prefix),
+    queryFn: ({ signal }) => logsClient.listGroups(prefix, signal),
+    refetchInterval: 30_000,
+  });
+}

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -11,7 +11,7 @@ import {serviceIcon} from '@/components/serviceIcons'
 import type {CloudProvider, CloudServiceDescriptor} from '@/types/cloud'
 
 /** Matches today's service count, so the real nav causes no layout jump. */
-const SKELETON_ROWS = 7
+const SKELETON_ROWS = 8
 
 function NavItem({to, icon, label}: { to: string; icon: React.ElementType; label: string }) {
     const Icon = icon

--- a/packages/frontend/src/features/cloudwatch-logs/LogEventsPanel.test.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogEventsPanel.test.tsx
@@ -1,0 +1,205 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const { callMock } = vi.hoisted(() => ({ callMock: vi.fn() }));
+
+vi.mock("@/api/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      call: callMock,
+    },
+  };
+});
+
+import { LogEventsPanel } from "./LogEventsPanel";
+
+function renderPanel(props: Partial<React.ComponentProps<typeof LogEventsPanel>> = {}) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <LogEventsPanel
+        group="/aws/lambda/foo"
+        stream="2024/01/01/[$LATEST]abc123"
+        onBack={vi.fn()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LogEventsPanel", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+  });
+
+  it("requests events for the given group and stream", () => {
+    callMock.mockReturnValue(new Promise(() => {}));
+
+    renderPanel({ group: "/aws/lambda/foo", stream: "s1" });
+
+    expect(callMock).toHaveBeenCalledWith(
+      "aws.logs.events.list",
+      expect.objectContaining({ params: { group: "/aws/lambda/foo", stream: "s1" } }),
+    );
+  });
+
+  it("renders a loading state before events arrive", () => {
+    callMock.mockReturnValue(new Promise(() => {}));
+
+    renderPanel();
+
+    expect(screen.getByText(/loading log events/i)).toBeInTheDocument();
+  });
+
+  it("renders event timestamp and message, oldest first", async () => {
+    callMock.mockResolvedValue({
+      data: {
+        events: [
+          { timestamp: new Date(1700000001000).toISOString(), message: "START RequestId: abc" },
+          { timestamp: new Date(1700000002000).toISOString(), message: "END RequestId: abc" },
+        ],
+      },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("START RequestId: abc")).toBeInTheDocument();
+    expect(screen.getByText("END RequestId: abc")).toBeInTheDocument();
+    const rows = screen.getAllByRole("row");
+    // Header row plus two event rows, in the order the backend returned them.
+    expect(rows[1]).toHaveTextContent("START RequestId: abc");
+    expect(rows[2]).toHaveTextContent("END RequestId: abc");
+  });
+
+  it("renders an empty state, not an empty table, when the stream has no events", async () => {
+    callMock.mockResolvedValue({ data: { events: [] } });
+
+    renderPanel();
+
+    expect(await screen.findByText(/no log events/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders an error state with a retry action when the request fails", async () => {
+    callMock.mockRejectedValue(new Error("network down"));
+
+    renderPanel();
+
+    expect(await screen.findByText(/cannot load log events/i)).toBeInTheDocument();
+
+    callMock.mockResolvedValue({
+      data: { events: [{ timestamp: new Date().toISOString(), message: "recovered" }] },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /refresh/i }));
+
+    expect(await screen.findByText("recovered")).toBeInTheDocument();
+  });
+
+  it("shows a load-more control only when the backend returns a nextToken, and appends the next page below the first", async () => {
+    callMock.mockResolvedValueOnce({
+      data: { events: [{ timestamp: new Date(1).toISOString(), message: "page one" }], nextToken: "f/tok-1" },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("page one")).toBeInTheDocument();
+    const loadMore = screen.getByRole("button", { name: /load more/i });
+    expect(loadMore).toBeInTheDocument();
+
+    callMock.mockResolvedValueOnce({
+      data: { events: [{ timestamp: new Date(2).toISOString(), message: "page two" }] },
+    });
+    const user = userEvent.setup();
+    await user.click(loadMore);
+
+    expect(await screen.findByText("page two")).toBeInTheDocument();
+    // Both pages are visible, in fetch order.
+    expect(screen.getByText("page one")).toBeInTheDocument();
+    expect(callMock).toHaveBeenLastCalledWith(
+      "aws.logs.events.list",
+      expect.objectContaining({
+        params: { group: "/aws/lambda/foo", stream: "2024/01/01/[$LATEST]abc123", nextToken: "f/tok-1" },
+      }),
+    );
+    // No nextToken on the second page, so there is nothing further to load.
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("does not show a load-more control when the backend returns no nextToken", async () => {
+    callMock.mockResolvedValue({
+      data: { events: [{ timestamp: new Date().toISOString(), message: "only page" }] },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("only page")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /load more/i })).not.toBeInTheDocument();
+  });
+
+  it("resets accumulated pages when switching to a different stream, not just the visible list", async () => {
+    // Load two pages on stream-one first, so switching streams has
+    // accumulated state to actually discard.
+    callMock.mockResolvedValueOnce({
+      data: { events: [{ timestamp: new Date(1).toISOString(), message: "stream-one page one" }], nextToken: "f/tok-1" },
+    });
+
+    const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+    const { rerender } = render(
+      <QueryClientProvider client={qc}>
+        <LogEventsPanel group="/aws/lambda/foo" stream="stream-one" onBack={vi.fn()} />
+      </QueryClientProvider>,
+    );
+    expect(await screen.findByText("stream-one page one")).toBeInTheDocument();
+
+    callMock.mockResolvedValueOnce({
+      data: { events: [{ timestamp: new Date(2).toISOString(), message: "stream-one page two" }] },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /load more/i }));
+    expect(await screen.findByText("stream-one page two")).toBeInTheDocument();
+
+    // Now switch to stream-two, which itself has a further page available.
+    const callsBeforeSwitch = callMock.mock.calls.length;
+    callMock.mockResolvedValue({
+      data: { events: [{ timestamp: new Date(3).toISOString(), message: "stream-two event" }], nextToken: "f/tok-2" },
+    });
+    rerender(
+      <QueryClientProvider client={qc}>
+        <LogEventsPanel group="/aws/lambda/foo" stream="stream-two" onBack={vi.fn()} />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("stream-two event")).toBeInTheDocument();
+    // Neither of stream-one's pages leaked into the new stream's view.
+    expect(screen.queryByText("stream-one page one")).not.toBeInTheDocument();
+    expect(screen.queryByText("stream-one page two")).not.toBeInTheDocument();
+    // Exactly one new request went out: stream-two's first page. Without the
+    // reset, the still-length-2 token list would have fired a second request
+    // carrying stream-one's leftover "f/tok-1" token against stream-two.
+    expect(callMock.mock.calls.length).toBe(callsBeforeSwitch + 1);
+    expect(callMock).toHaveBeenLastCalledWith(
+      "aws.logs.events.list",
+      expect.objectContaining({ params: { group: "/aws/lambda/foo", stream: "stream-two" } }),
+    );
+  });
+
+  it("calls onBack when the back button is clicked", async () => {
+    callMock.mockResolvedValue({ data: { events: [] } });
+    const onBack = vi.fn();
+
+    renderPanel({ onBack });
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: /log streams/i }));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/features/cloudwatch-logs/LogEventsPanel.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogEventsPanel.tsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import { ChevronLeft, RefreshCw, ScrollText } from "lucide-react";
+import { EmptyState } from "@/components/EmptyState";
+import { useLogEventsPagesQuery } from "@/api/aws/logs.queries";
+import { formatDateTime } from "@/lib/format";
+
+interface LogEventsPanelProps {
+  group: string;
+  stream: string;
+  onBack: () => void;
+}
+
+export function LogEventsPanel({ group, stream, onBack }: LogEventsPanelProps) {
+  const [tokens, setTokens] = useState<Array<string | undefined>>([undefined]);
+
+  // Switching streams starts a fresh drill-in, not a continuation of the
+  // previous stream's pages. Resetting during render (rather than in a
+  // useEffect) avoids an interim render where the new stream would be
+  // fetched with the previous stream's leftover tokens.
+  const streamKey = `${group}:${stream}`;
+  const [seenStreamKey, setSeenStreamKey] = useState(streamKey);
+  if (streamKey !== seenStreamKey) {
+    setSeenStreamKey(streamKey);
+    setTokens([undefined]);
+  }
+
+  const pages = useLogEventsPagesQuery(group, stream, tokens);
+  const firstPage = pages[0];
+  const lastPage = pages[pages.length - 1];
+  const events = pages.flatMap((page) => page.data?.events ?? []);
+  const nextToken = lastPage?.data?.nextToken;
+  const loadingMore = pages.length > 1 && lastPage?.isLoading;
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-title">
+          <button className="button" onClick={onBack}>
+            <ChevronLeft size={13} />
+            Log streams
+          </button>
+          <h2>{stream}</h2>
+          <span className="info-link">{group}</span>
+        </div>
+        <button className="button" onClick={() => void firstPage?.refetch()}>
+          <RefreshCw size={13} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="content">
+        <div className="table-panel">
+          <div className="widget-header">
+            <h3>Log events</h3>
+          </div>
+          {firstPage?.isError ? (
+            <EmptyState
+              icon={ScrollText}
+              title="Cannot load log events"
+              description="CloudWatch Logs did not respond from the Floci endpoint."
+            />
+          ) : firstPage?.isLoading ? (
+            <div className="empty">
+              <p>Loading log events…</p>
+            </div>
+          ) : events.length === 0 ? (
+            <EmptyState
+              icon={ScrollText}
+              title="No log events"
+              description="Events written to this stream will appear here."
+            />
+          ) : (
+            <>
+              <table className="table">
+                <thead>
+                  <tr>
+                    <th>Timestamp</th>
+                    <th>Message</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {events.map((event, index) => (
+                    // Events have no stable id of their own; a page never
+                    // reorders once fetched, so position is a safe key.
+                    <tr key={index}>
+                      <td className="mono" style={{ color: "#8d9cad", whiteSpace: "nowrap" }}>
+                        {formatDateTime(event.timestamp) ?? "-"}
+                      </td>
+                      <td className="mono">{event.message}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+              {nextToken && (
+                <div style={{ display: "flex", justifyContent: "center", padding: "12px 0" }}>
+                  <button
+                    className="button"
+                    disabled={loadingMore}
+                    onClick={() => setTokens((prev) => [...prev, nextToken])}
+                  >
+                    {loadingMore ? "Loading…" : "Load more"}
+                  </button>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
@@ -96,18 +96,26 @@ describe("LogGroupsPage", () => {
     expect(await screen.findByText("/aws/lambda/recovered")).toBeInTheDocument();
   });
 
-  it("forwards the search box value to the query as a name prefix", async () => {
-    callMock.mockResolvedValue({ data: [] });
+  it("filters the loaded groups client-side by search text, without issuing a new request per keystroke", async () => {
+    callMock.mockResolvedValue({
+      data: [
+        { name: "/aws/lambda/foo" },
+        { name: "/aws/lambda/bar" },
+        { name: "/ecs/other" },
+      ],
+    });
 
     renderPage();
-    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(1));
+    expect(await screen.findByText("/aws/lambda/foo")).toBeInTheDocument();
+    expect(callMock).toHaveBeenCalledTimes(1);
 
     const user = userEvent.setup();
-    await user.type(screen.getByPlaceholderText(/prefix/i), "/aws/lambda/");
+    await user.type(screen.getByPlaceholderText(/search/i), "lambda");
 
-    await waitFor(() => {
-      const lastCall = callMock.mock.calls[callMock.mock.calls.length - 1];
-      expect(lastCall[1].params).toEqual({ prefix: "/aws/lambda/" });
-    });
+    expect(await screen.findByText("/aws/lambda/foo")).toBeInTheDocument();
+    expect(screen.getByText("/aws/lambda/bar")).toBeInTheDocument();
+    expect(screen.queryByText("/ecs/other")).not.toBeInTheDocument();
+    // Typing filtered in place; it never re-fetched.
+    expect(callMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const { callMock } = vi.hoisted(() => ({ callMock: vi.fn() }));
+
+vi.mock("@/api/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      call: callMock,
+    },
+  };
+});
+
+import { LogGroupsPage } from "./LogGroupsPage";
+
+function renderPage() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <LogGroupsPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LogGroupsPage", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+  });
+
+  it("renders a loading state before groups arrive", () => {
+    callMock.mockReturnValue(new Promise(() => {}));
+
+    renderPage();
+
+    expect(screen.getByText(/loading log groups/i)).toBeInTheDocument();
+  });
+
+  it("renders log group name, retention, and created columns once loaded", async () => {
+    callMock.mockResolvedValue({
+      data: [
+        {
+          name: "/aws/lambda/foo",
+          arn: "arn:aws:logs:us-east-1:111111111111:log-group:/aws/lambda/foo:*",
+          creationTime: new Date(1700000000000).toISOString(),
+          retentionInDays: 14,
+        },
+      ],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("/aws/lambda/foo")).toBeInTheDocument();
+    expect(screen.getByText("14 days")).toBeInTheDocument();
+  });
+
+  it("renders a group with no retention configured as never-expiring, not a false zero", async () => {
+    callMock.mockResolvedValue({
+      data: [{ name: "/aws/lambda/no-retention" }],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("/aws/lambda/no-retention")).toBeInTheDocument();
+    expect(screen.getByText(/never expires/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state, not an empty table, when there are no log groups", async () => {
+    callMock.mockResolvedValue({ data: [] });
+
+    renderPage();
+
+    expect(await screen.findByText(/no log groups/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders an error state with a retry action when the request fails", async () => {
+    callMock.mockRejectedValue(new Error("network down"));
+
+    renderPage();
+
+    expect(await screen.findByText(/cannot load log groups/i)).toBeInTheDocument();
+
+    callMock.mockResolvedValue({
+      data: [{ name: "/aws/lambda/recovered" }],
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /refresh/i }));
+
+    expect(await screen.findByText("/aws/lambda/recovered")).toBeInTheDocument();
+  });
+
+  it("forwards the search box value to the query as a name prefix", async () => {
+    callMock.mockResolvedValue({ data: [] });
+
+    renderPage();
+    await waitFor(() => expect(callMock).toHaveBeenCalledTimes(1));
+
+    const user = userEvent.setup();
+    await user.type(screen.getByPlaceholderText(/prefix/i), "/aws/lambda/");
+
+    await waitFor(() => {
+      const lastCall = callMock.mock.calls[callMock.mock.calls.length - 1];
+      expect(lastCall[1].params).toEqual({ prefix: "/aws/lambda/" });
+    });
+  });
+});

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.test.tsx
@@ -118,4 +118,76 @@ describe("LogGroupsPage", () => {
     // Typing filtered in place; it never re-fetched.
     expect(callMock).toHaveBeenCalledTimes(1);
   });
+
+  it("shows a group's streams when its row is clicked, and returns to groups when back is clicked", async () => {
+    callMock.mockImplementation((key: string) => {
+      if (key === "aws.logs.groups.list") {
+        return Promise.resolve({ data: [{ name: "/aws/lambda/foo" }] });
+      }
+      if (key === "aws.logs.streams.list") {
+        return Promise.resolve({
+          data: { streams: [{ name: "2024/01/01/[$LATEST]abc123" }] },
+        });
+      }
+      return Promise.reject(new Error(`unexpected endpoint: ${key}`));
+    });
+
+    renderPage();
+    const user = userEvent.setup();
+
+    const groupRow = await screen.findByText("/aws/lambda/foo");
+    await user.click(groupRow);
+
+    expect(await screen.findByText("2024/01/01/[$LATEST]abc123")).toBeInTheDocument();
+    expect(callMock).toHaveBeenCalledWith(
+      "aws.logs.streams.list",
+      expect.objectContaining({ params: { group: "/aws/lambda/foo" } }),
+    );
+    // The groups table (with its Retention column) is no longer shown.
+    expect(screen.queryByText("Retention")).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /log groups/i }));
+
+    expect(await screen.findByText("Retention")).toBeInTheDocument();
+    expect(screen.queryByText("2024/01/01/[$LATEST]abc123")).not.toBeInTheDocument();
+  });
+
+  it("shows a stream's events when its row is clicked from the streams view, and returns to streams when back is clicked", async () => {
+    callMock.mockImplementation((key: string) => {
+      if (key === "aws.logs.groups.list") {
+        return Promise.resolve({ data: [{ name: "/aws/lambda/foo" }] });
+      }
+      if (key === "aws.logs.streams.list") {
+        return Promise.resolve({
+          data: { streams: [{ name: "2024/01/01/[$LATEST]abc123" }] },
+        });
+      }
+      if (key === "aws.logs.events.list") {
+        return Promise.resolve({
+          data: { events: [{ timestamp: new Date(1700000000000).toISOString(), message: "hello from the stream" }] },
+        });
+      }
+      return Promise.reject(new Error(`unexpected endpoint: ${key}`));
+    });
+
+    renderPage();
+    const user = userEvent.setup();
+
+    await user.click(await screen.findByText("/aws/lambda/foo"));
+    const streamRow = await screen.findByText("2024/01/01/[$LATEST]abc123");
+    await user.click(streamRow);
+
+    expect(await screen.findByText("hello from the stream")).toBeInTheDocument();
+    expect(callMock).toHaveBeenCalledWith(
+      "aws.logs.events.list",
+      expect.objectContaining({
+        params: { group: "/aws/lambda/foo", stream: "2024/01/01/[$LATEST]abc123" },
+      }),
+    );
+
+    await user.click(screen.getByRole("button", { name: /log streams/i }));
+
+    expect(await screen.findByText("2024/01/01/[$LATEST]abc123")).toBeInTheDocument();
+    expect(screen.queryByText("hello from the stream")).not.toBeInTheDocument();
+  });
 });

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
@@ -1,0 +1,91 @@
+import { useState } from "react";
+import { RefreshCw, ScrollText, Search } from "lucide-react";
+import { EmptyState } from "@/components/EmptyState";
+import { useLogGroupsQuery } from "@/api/aws/logs.queries";
+import { timeAgo } from "@/lib/utils";
+
+export function LogGroupsPage() {
+  const [prefix, setPrefix] = useState("");
+  const query = useLogGroupsQuery(prefix || undefined);
+  const groups = query.data ?? [];
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-title">
+          <h2>CloudWatch Logs</h2>
+          <span className="info-link">
+            {query.data ? `${groups.length} log groups` : "Log groups"}
+          </span>
+        </div>
+        <button className="button" onClick={() => void query.refetch()}>
+          <RefreshCw size={13} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="input-row">
+        <Search size={14} color="#8d9cad" />
+        <input
+          className="input"
+          value={prefix}
+          onChange={(e) => setPrefix(e.target.value)}
+          placeholder="Filter by log group name prefix…"
+        />
+      </div>
+
+      <div className="content">
+        <div className="table-panel">
+          <div className="widget-header">
+            <h3>Log groups</h3>
+          </div>
+          {query.isError ? (
+            <EmptyState
+              icon={ScrollText}
+              title="Cannot load log groups"
+              description="CloudWatch Logs did not respond from the Floci endpoint."
+            />
+          ) : query.isLoading ? (
+            <div className="empty">
+              <p>Loading log groups…</p>
+            </div>
+          ) : groups.length === 0 ? (
+            <EmptyState
+              icon={ScrollText}
+              title={prefix ? "No log groups match that prefix" : "No log groups"}
+              description={
+                prefix
+                  ? "Try a different prefix."
+                  : "Log groups created in this account will appear here."
+              }
+            />
+          ) : (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Retention</th>
+                  <th>Created</th>
+                </tr>
+              </thead>
+              <tbody>
+                {groups.map((group) => (
+                  <tr key={group.arn ?? group.name}>
+                    <td className="mono" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <ScrollText size={13} style={{ color: "var(--accent)", flexShrink: 0 }} />
+                      {group.name}
+                    </td>
+                    <td>
+                      {group.retentionInDays ? `${group.retentionInDays} days` : "Never expires"}
+                    </td>
+                    <td style={{ color: "#8d9cad" }}>{timeAgo(group.creationTime)}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
@@ -1,13 +1,19 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { RefreshCw, ScrollText, Search } from "lucide-react";
 import { EmptyState } from "@/components/EmptyState";
 import { useLogGroupsQuery } from "@/api/aws/logs.queries";
 import { timeAgo } from "@/lib/utils";
 
 export function LogGroupsPage() {
-  const [prefix, setPrefix] = useState("");
-  const query = useLogGroupsQuery(prefix || undefined);
-  const groups = query.data ?? [];
+  const [search, setSearch] = useState("");
+  const query = useLogGroupsQuery();
+
+  const groups = useMemo(() => {
+    const all = query.data ?? [];
+    if (!search) return all;
+    const q = search.toLowerCase();
+    return all.filter((g) => g.name.toLowerCase().includes(q));
+  }, [query.data, search]);
 
   return (
     <>
@@ -28,9 +34,9 @@ export function LogGroupsPage() {
         <Search size={14} color="#8d9cad" />
         <input
           className="input"
-          value={prefix}
-          onChange={(e) => setPrefix(e.target.value)}
-          placeholder="Filter by log group name prefix…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search log groups…"
         />
       </div>
 
@@ -52,10 +58,10 @@ export function LogGroupsPage() {
           ) : groups.length === 0 ? (
             <EmptyState
               icon={ScrollText}
-              title={prefix ? "No log groups match that prefix" : "No log groups"}
+              title={search ? "No log groups match your search" : "No log groups"}
               description={
-                prefix
-                  ? "Try a different prefix."
+                search
+                  ? "Try a different name."
                   : "Log groups created in this account will appear here."
               }
             />

--- a/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogGroupsPage.tsx
@@ -3,9 +3,17 @@ import { RefreshCw, ScrollText, Search } from "lucide-react";
 import { EmptyState } from "@/components/EmptyState";
 import { useLogGroupsQuery } from "@/api/aws/logs.queries";
 import { timeAgo } from "@/lib/utils";
+import { LogStreamsPanel } from "./LogStreamsPanel";
+import { LogEventsPanel } from "./LogEventsPanel";
+
+type View =
+  | { kind: "groups" }
+  | { kind: "streams"; group: string }
+  | { kind: "events"; group: string; stream: string };
 
 export function LogGroupsPage() {
   const [search, setSearch] = useState("");
+  const [view, setView] = useState<View>({ kind: "groups" });
   const query = useLogGroupsQuery();
 
   const groups = useMemo(() => {
@@ -14,6 +22,26 @@ export function LogGroupsPage() {
     const q = search.toLowerCase();
     return all.filter((g) => g.name.toLowerCase().includes(q));
   }, [query.data, search]);
+
+  if (view.kind === "streams") {
+    return (
+      <LogStreamsPanel
+        group={view.group}
+        onBack={() => setView({ kind: "groups" })}
+        onSelectStream={(stream) => setView({ kind: "events", group: view.group, stream })}
+      />
+    );
+  }
+
+  if (view.kind === "events") {
+    return (
+      <LogEventsPanel
+        group={view.group}
+        stream={view.stream}
+        onBack={() => setView({ kind: "streams", group: view.group })}
+      />
+    );
+  }
 
   return (
     <>
@@ -76,7 +104,11 @@ export function LogGroupsPage() {
               </thead>
               <tbody>
                 {groups.map((group) => (
-                  <tr key={group.arn ?? group.name}>
+                  <tr
+                    key={group.arn ?? group.name}
+                    onClick={() => setView({ kind: "streams", group: group.name })}
+                    style={{ cursor: "pointer" }}
+                  >
                     <td className="mono" style={{ display: "flex", alignItems: "center", gap: 8 }}>
                       <ScrollText size={13} style={{ color: "var(--accent)", flexShrink: 0 }} />
                       {group.name}

--- a/packages/frontend/src/features/cloudwatch-logs/LogStreamsPanel.test.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogStreamsPanel.test.tsx
@@ -1,0 +1,131 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+const { callMock } = vi.hoisted(() => ({ callMock: vi.fn() }));
+
+vi.mock("@/api/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/api/api")>();
+  return {
+    ...actual,
+    apiClient: {
+      ...actual.apiClient,
+      call: callMock,
+    },
+  };
+});
+
+import { LogStreamsPanel } from "./LogStreamsPanel";
+
+function renderPanel(props: Partial<React.ComponentProps<typeof LogStreamsPanel>> = {}) {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={qc}>
+      <LogStreamsPanel
+        group="/aws/lambda/foo"
+        onBack={vi.fn()}
+        onSelectStream={vi.fn()}
+        {...props}
+      />
+    </QueryClientProvider>,
+  );
+}
+
+describe("LogStreamsPanel", () => {
+  beforeEach(() => {
+    callMock.mockReset();
+  });
+
+  it("requests streams for the given group", () => {
+    callMock.mockReturnValue(new Promise(() => {}));
+
+    renderPanel({ group: "/aws/lambda/foo" });
+
+    expect(callMock).toHaveBeenCalledWith(
+      "aws.logs.streams.list",
+      expect.objectContaining({ params: { group: "/aws/lambda/foo" } }),
+    );
+  });
+
+  it("renders a loading state before streams arrive", () => {
+    callMock.mockReturnValue(new Promise(() => {}));
+
+    renderPanel();
+
+    expect(screen.getByText(/loading log streams/i)).toBeInTheDocument();
+  });
+
+  it("renders stream name and stored bytes once loaded", async () => {
+    callMock.mockResolvedValue({
+      data: {
+        streams: [
+          {
+            name: "2024/01/01/[$LATEST]abc123",
+            lastEventTimestamp: new Date().toISOString(),
+            storedBytes: 2048,
+          },
+        ],
+      },
+    });
+
+    renderPanel();
+
+    expect(await screen.findByText("2024/01/01/[$LATEST]abc123")).toBeInTheDocument();
+    expect(screen.getByText("2.0 KB")).toBeInTheDocument();
+  });
+
+  it("renders an empty state, not an empty table, when the group has no streams", async () => {
+    callMock.mockResolvedValue({ data: { streams: [] } });
+
+    renderPanel();
+
+    expect(await screen.findByText(/no log streams/i)).toBeInTheDocument();
+    expect(screen.queryByRole("table")).not.toBeInTheDocument();
+  });
+
+  it("renders an error state with a retry action when the request fails", async () => {
+    callMock.mockRejectedValue(new Error("network down"));
+
+    renderPanel();
+
+    expect(await screen.findByText(/cannot load log streams/i)).toBeInTheDocument();
+
+    callMock.mockResolvedValue({
+      data: { streams: [{ name: "recovered-stream" }] },
+    });
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /refresh/i }));
+
+    expect(await screen.findByText("recovered-stream")).toBeInTheDocument();
+  });
+
+  it("calls onSelectStream with the stream name when a row is clicked", async () => {
+    callMock.mockResolvedValue({
+      data: { streams: [{ name: "2024/01/01/[$LATEST]abc123" }] },
+    });
+    const onSelectStream = vi.fn();
+
+    renderPanel({ onSelectStream });
+
+    const row = await screen.findByText("2024/01/01/[$LATEST]abc123");
+    const user = userEvent.setup();
+    await user.click(row);
+
+    expect(onSelectStream).toHaveBeenCalledWith("2024/01/01/[$LATEST]abc123");
+  });
+
+  it("calls onBack when the back button is clicked", async () => {
+    callMock.mockResolvedValue({ data: { streams: [] } });
+    const onBack = vi.fn();
+
+    renderPanel({ onBack });
+
+    const user = userEvent.setup();
+    await user.click(await screen.findByRole("button", { name: /log groups/i }));
+
+    expect(onBack).toHaveBeenCalled();
+  });
+});

--- a/packages/frontend/src/features/cloudwatch-logs/LogStreamsPanel.tsx
+++ b/packages/frontend/src/features/cloudwatch-logs/LogStreamsPanel.tsx
@@ -1,0 +1,89 @@
+import { ChevronLeft, ChevronRight, RefreshCw, ScrollText } from "lucide-react";
+import { EmptyState } from "@/components/EmptyState";
+import { useLogStreamsQuery } from "@/api/aws/logs.queries";
+import { timeAgo } from "@/lib/utils";
+import { formatBytes } from "@/lib/format";
+
+interface LogStreamsPanelProps {
+  group: string;
+  onBack: () => void;
+  onSelectStream: (stream: string) => void;
+}
+
+export function LogStreamsPanel({ group, onBack, onSelectStream }: LogStreamsPanelProps) {
+  const query = useLogStreamsQuery(group);
+  const streams = query.data ?? [];
+
+  return (
+    <>
+      <div className="page-header">
+        <div className="page-title">
+          <button className="button" onClick={onBack}>
+            <ChevronLeft size={13} />
+            Log groups
+          </button>
+          <h2>{group}</h2>
+          <span className="info-link">
+            {query.data ? `${streams.length} log streams` : "Log streams"}
+          </span>
+        </div>
+        <button className="button" onClick={() => void query.refetch()}>
+          <RefreshCw size={13} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="content">
+        <div className="table-panel">
+          <div className="widget-header">
+            <h3>Log streams</h3>
+          </div>
+          {query.isError ? (
+            <EmptyState
+              icon={ScrollText}
+              title="Cannot load log streams"
+              description="CloudWatch Logs did not respond from the Floci endpoint."
+            />
+          ) : query.isLoading ? (
+            <div className="empty">
+              <p>Loading log streams…</p>
+            </div>
+          ) : streams.length === 0 ? (
+            <EmptyState
+              icon={ScrollText}
+              title="No log streams"
+              description="Log streams created in this group will appear here."
+            />
+          ) : (
+            <table className="table">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Last event</th>
+                  <th>Stored</th>
+                </tr>
+              </thead>
+              <tbody>
+                {streams.map((stream) => (
+                  <tr
+                    key={stream.name}
+                    onClick={() => onSelectStream(stream.name)}
+                    style={{ cursor: "pointer" }}
+                  >
+                    <td className="mono" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+                      <ScrollText size={13} style={{ color: "var(--accent)", flexShrink: 0 }} />
+                      {stream.name}
+                      <ChevronRight size={12} style={{ color: "#8d9cad", marginLeft: "auto" }} />
+                    </td>
+                    <td style={{ color: "#8d9cad" }}>{timeAgo(stream.lastEventTimestamp)}</td>
+                    <td>{stream.storedBytes !== undefined ? formatBytes(stream.storedBytes) : "-"}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/packages/frontend/src/test/alias.test.ts
+++ b/packages/frontend/src/test/alias.test.ts
@@ -1,0 +1,9 @@
+import { formatBytes, slugify } from "@/lib/format";
+
+describe("@ alias resolution", () => {
+  it("resolves @/lib/format and calls its exports", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(1536)).toBe("1.5 KB");
+    expect(slugify("Hello, World!")).toBe("hello-world");
+  });
+});

--- a/packages/frontend/src/test/infra.test.ts
+++ b/packages/frontend/src/test/infra.test.ts
@@ -1,0 +1,19 @@
+describe("test infrastructure", () => {
+  it("runs in a jsdom environment with a mutable document", () => {
+    expect(document.body).toBeInstanceOf(HTMLElement);
+
+    const marker = document.createElement("div");
+    marker.id = "jsdom-marker";
+    document.body.appendChild(marker);
+
+    expect(document.getElementById("jsdom-marker")).toBe(marker);
+  });
+
+  it("registers the jest-dom matchers", () => {
+    const el = document.createElement("p");
+    el.textContent = "hello from jest-dom";
+    document.body.appendChild(el);
+
+    expect(el).toBeInTheDocument();
+  });
+});

--- a/packages/frontend/src/types/cloud.ts
+++ b/packages/frontend/src/types/cloud.ts
@@ -9,6 +9,7 @@ export type KnownCloudServiceType =
     | 'networking'
     | 'serverless'
     | 'secrets'
+    | 'logs'
 
 /**
  * Deliberately open where the API's own type is closed.

--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "useDefineForClassFields": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "types": ["vite/client", "node"],
+    "types": ["vite/client", "node", "vitest/globals", "@testing-library/jest-dom/vitest"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "bundler",

--- a/packages/frontend/vitest.config.ts
+++ b/packages/frontend/vitest.config.ts
@@ -1,0 +1,16 @@
+import react from "@vitejs/plugin-react";
+import path from "node:path";
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: { "@": path.resolve(__dirname, "./src") },
+  },
+  test: {
+    environment: "jsdom",
+    globals: true,
+    setupFiles: "./vitest.setup.ts",
+    include: ["src/**/*.{test,spec}.{ts,tsx}"],
+  },
+});

--- a/packages/frontend/vitest.setup.ts
+++ b/packages/frontend/vitest.setup.ts
@@ -1,0 +1,8 @@
+import "@testing-library/jest-dom/vitest";
+
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -84,6 +84,15 @@ importers:
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@1.21.7))
+      '@testing-library/jest-dom':
+        specifier: 7.0.0
+        version: 7.0.0(@testing-library/dom@10.4.1)
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: 14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^25.9.4
         version: 25.9.4
@@ -111,6 +120,9 @@ importers:
       globals:
         specifier: ^17.7.0
         version: 17.7.0
+      jsdom:
+        specifier: ^30.0.1
+        version: 30.0.1
       postcss:
         specifier: ^8.5.16
         version: 8.5.16
@@ -126,8 +138,22 @@ importers:
       vite:
         specifier: ^8.1.3
         version: 8.1.3(@types/node@25.9.4)(jiti@1.21.7)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@25.9.4)(jsdom@30.0.1)(vite@8.1.3(@types/node@25.9.4)(jiti@1.21.7))
 
 packages:
+
+  '@adobe/css-tools@4.5.0':
+    resolution: {integrity: sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==}
+
+  '@asamuzakjp/css-color@6.0.7':
+    resolution: {integrity: sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==}
+    engines: {node: ^22.13.0 || >=24.0.0}
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    resolution: {integrity: sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==}
+    engines: {node: ^22.13.0 || >=24.0.0}
 
   '@aws-crypto/sha1-browser@5.2.0':
     resolution: {integrity: sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==}
@@ -308,6 +334,10 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/template@7.28.6':
     resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
     engines: {node: '>=6.9.0'}
@@ -319,6 +349,46 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@bramus/specificity@2.4.2':
+    resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
+    hasBin: true
+
+  '@csstools/color-helpers@6.1.0':
+    resolution: {integrity: sha512-064IFJdjTfUqnjpCVpMOdbr8FLQBhinbZj6yRv2An2E41O/pLEXqfFRWqGq/SxlE5PEUYTlvWsG2r8MswAVvkg==}
+    engines: {node: '>=20.19.0'}
+
+  '@csstools/css-calc@3.3.0':
+    resolution: {integrity: sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-color-parser@4.1.10':
+    resolution: {integrity: sha512-UZhQLIUyJaaMepqehrCODwCg2KW25vFvLWBmqYFaPclYvvxzj/sG8LBOhBFCp11i9uE7t1EyS+RAoV9tztPFyw==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^4.0.0
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0':
+    resolution: {integrity: sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==}
+    engines: {node: '>=20.19.0'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7':
+    resolution: {integrity: sha512-fQ+05118eQS1cofO3aJpB5efgpBZMvIzwr/sbC8kDLVA5XLG8q1kJV5yzrUAI1f7lvhPnm8fgIjzFB8/O/5Dig==}
+    peerDependencies:
+      css-tree: ^3.2.1
+    peerDependenciesMeta:
+      css-tree:
+        optional: true
+
+  '@csstools/css-tokenizer@4.0.0':
+    resolution: {integrity: sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==}
+    engines: {node: '>=20.19.0'}
 
   '@emnapi/core@1.11.1':
     resolution: {integrity: sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==}
@@ -367,6 +437,15 @@ packages:
   '@eslint/plugin-kit@0.7.2':
     resolution: {integrity: sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+
+  '@exodus/bytes@1.15.1':
+    resolution: {integrity: sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+    peerDependencies:
+      '@noble/hashes': ^1.8.0 || ^2.0.0
+    peerDependenciesMeta:
+      '@noble/hashes':
+        optional: true
 
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
@@ -541,6 +620,9 @@ packages:
     resolution: {integrity: sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==}
     engines: {node: '>=14.0.0'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@tanstack/query-core@5.101.2':
     resolution: {integrity: sha512-hH5MLoJhF7KaIGd7q3xTXGXvslI+GYlM1Z/35aSHHWaCJWB7XvTSHYuV3eM7tw+aE0mT/xMro4M4Q9rCGHT0lw==}
 
@@ -558,11 +640,51 @@ packages:
     peerDependencies:
       react: ^18 || ^19
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@7.0.0':
+    resolution: {integrity: sha512-HKAH9C6mBo5yBG6yRO5i43L2iisencAo5z+o5P/saHUoY+miC5ivXRxHBJcFyB5ypPNxHJdK3BoF/3O4DIptMg==}
+    engines: {node: '>=22', npm: '>=6', yarn: '>=1'}
+    peerDependencies:
+      '@testing-library/dom': '>=10 <11'
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tybys/wasm-util@0.10.3':
     resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
 
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
   '@types/bun@1.3.14':
     resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/esrecurse@4.3.1':
     resolution: {integrity: sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==}
@@ -656,6 +778,35 @@ packages:
       babel-plugin-react-compiler:
         optional: true
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -668,6 +819,25 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   autoprefixer@10.5.2:
     resolution: {integrity: sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==}
@@ -684,6 +854,9 @@ packages:
     resolution: {integrity: sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
+
+  bidi-js@1.0.3:
+    resolution: {integrity: sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==}
 
   bowser@2.14.1:
     resolution: {integrity: sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==}
@@ -703,6 +876,10 @@ packages:
   caniuse-lite@1.0.30001800:
     resolution: {integrity: sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==}
 
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
@@ -721,8 +898,19 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
+
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  data-urls@7.0.0:
+    resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
 
   date-fns@4.4.0:
     resolution: {integrity: sha512-+1UMbeh68lH1SegH83CGWwpb6OHHbpSgr3+s5Eww5M4CAgswBpoWS0AjTOfEJ33HiYKz1hdj/KTFprzXHmq/6w==}
@@ -736,12 +924,25 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
 
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv@17.4.2:
     resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
@@ -749,6 +950,13 @@ packages:
 
   electron-to-chromium@1.5.383:
     resolution: {integrity: sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==}
+
+  entities@8.0.0:
+    resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
+    engines: {node: '>=20.19.0'}
+
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
 
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -807,9 +1015,16 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -874,6 +1089,10 @@ packages:
     resolution: {integrity: sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==}
     engines: {node: '>=16.9.0'}
 
+  html-encoding-sniffer@6.0.0:
+    resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -886,6 +1105,10 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -893,6 +1116,9 @@ packages:
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
+
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
@@ -903,6 +1129,15 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsdom@30.0.1:
+    resolution: {integrity: sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
+    peerDependencies:
+      canvas: ^3.2.3
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -1004,6 +1239,10 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -1011,6 +1250,20 @@ packages:
     resolution: {integrity: sha512-c9o3l0PiNcgOQDW4F31BEYHudE7kgxVt3o30qMl36ZPwTxXlGB4QnLilhERvVM4uh/pl5MDyY1/gzZSYcHDtBg==}
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -1031,6 +1284,10 @@ packages:
     resolution: {integrity: sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==}
     engines: {node: '>=18'}
 
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
@@ -1043,6 +1300,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  parse5@8.0.1:
+    resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -1050,6 +1310,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1069,6 +1332,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -1077,6 +1344,9 @@ packages:
     resolution: {integrity: sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==}
     peerDependencies:
       react: ^19.2.7
+
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
 
   react-router-dom@7.18.1:
     resolution: {integrity: sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==}
@@ -1099,10 +1369,22 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   rolldown@1.1.4:
     resolution: {integrity: sha512-IjZYiLxZwpnhwhdBH2ugdTGVSdhCQUmLxLoqyjiL0JxYjyRst+5a0P3xfrTxJ5F638j4Mvvw5FAX5XE6eHpXbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -1127,9 +1409,25 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
+
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -1137,9 +1435,35 @@ packages:
   tailwindcss@4.3.2:
     resolution: {integrity: sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
+
+  tldts-core@7.4.10:
+    resolution: {integrity: sha512-KnQjp53ZekKgm/r3l+u8kJGGzYgrWdP8+Mql7a4vijh2WE0IrZWspQj/TpTxDho/YxO+AnOZnIjQcCD+q6iJsw==}
+
+  tldts@7.4.10:
+    resolution: {integrity: sha512-GgouD1B+sWwvkaEq8vXC15DjQitxbvs12oIXELpconwm+Tg3zfcEv4jgzq3vtKverDXsg3VI8aRgNL2Nra0Iog==}
+    hasBin: true
+
+  tough-cookie@6.0.2:
+    resolution: {integrity: sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==}
+    engines: {node: '>=16'}
+
+  tr46@6.0.0:
+    resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
+    engines: {node: '>=20'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -1168,6 +1492,10 @@ packages:
 
   undici-types@7.24.6:
     resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+
+  undici@8.10.0:
+    resolution: {integrity: sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==}
+    engines: {node: '>=22.19.0'}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1226,14 +1554,87 @@ packages:
       yaml:
         optional: true
 
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@8.0.1:
+    resolution: {integrity: sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==}
+    engines: {node: '>=20'}
+
+  whatwg-mimetype@5.0.0:
+    resolution: {integrity: sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==}
+    engines: {node: '>=20'}
+
+  whatwg-url@16.0.1:
+    resolution: {integrity: sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==}
+    engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  whatwg-url@17.1.0:
+    resolution: {integrity: sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==}
+    engines: {node: ^22.14.0 || >=24.0.0}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
 
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   word-wrap@1.2.5:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
@@ -1270,6 +1671,23 @@ packages:
         optional: true
 
 snapshots:
+
+  '@adobe/css-tools@4.5.0': {}
+
+  '@asamuzakjp/css-color@6.0.7':
+    dependencies:
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+      lru-cache: 11.5.2
+
+  '@asamuzakjp/dom-selector@8.3.2':
+    dependencies:
+      bidi-js: 1.0.3
+      css-tree: 3.2.1
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
 
   '@aws-crypto/sha1-browser@5.2.0':
     dependencies:
@@ -1645,6 +2063,8 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.0
 
+  '@babel/runtime@7.29.7': {}
+
   '@babel/template@7.28.6':
     dependencies:
       '@babel/code-frame': 7.29.0
@@ -1667,6 +2087,34 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
+
+  '@bramus/specificity@2.4.2':
+    dependencies:
+      css-tree: 3.2.1
+
+  '@csstools/color-helpers@6.1.0': {}
+
+  '@csstools/css-calc@3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-color-parser@4.1.10(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/color-helpers': 6.1.0
+      '@csstools/css-calc': 3.3.0(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0)':
+    dependencies:
+      '@csstools/css-tokenizer': 4.0.0
+
+  '@csstools/css-syntax-patches-for-csstree@1.1.7(css-tree@3.2.1)':
+    optionalDependencies:
+      css-tree: 3.2.1
+
+  '@csstools/css-tokenizer@4.0.0': {}
 
   '@emnapi/core@1.11.1':
     dependencies:
@@ -1717,6 +2165,8 @@ snapshots:
     dependencies:
       '@eslint/core': 1.2.1
       levn: 0.4.1
+
+  '@exodus/bytes@1.15.1': {}
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -1860,6 +2310,8 @@ snapshots:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@tanstack/query-core@5.101.2': {}
 
   '@tanstack/query-devtools@5.101.2': {}
@@ -1875,14 +2327,58 @@ snapshots:
       '@tanstack/query-core': 5.101.2
       react: 19.2.7
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.7
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@7.0.0(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@adobe/css-tools': 4.5.0
+      '@testing-library/dom': 10.4.1
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@testing-library/dom': 10.4.1
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tybys/wasm-util@0.10.3':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@types/aria-query@5.0.4': {}
+
   '@types/bun@1.3.14':
     dependencies:
       bun-types: 1.3.14
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/esrecurse@4.3.1': {}
 
@@ -1998,6 +2494,47 @@ snapshots:
       '@rolldown/pluginutils': 1.0.1
       vite: 8.1.3(@types/node@25.9.4)(jiti@1.21.7)
 
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.1.3(@types/node@25.9.4)(jiti@1.21.7))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.1.3(@types/node@25.9.4)(jiti@1.21.7)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
@@ -2011,6 +2548,18 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@5.2.0: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
+
+  assertion-error@2.0.1: {}
+
   autoprefixer@10.5.2(postcss@8.5.16):
     dependencies:
       browserslist: 4.28.4
@@ -2023,6 +2572,10 @@ snapshots:
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.10.40: {}
+
+  bidi-js@1.0.3:
+    dependencies:
+      require-from-string: 2.0.2
 
   bowser@2.14.1: {}
 
@@ -2044,6 +2597,8 @@ snapshots:
 
   caniuse-lite@1.0.30001800: {}
 
+  chai@6.2.2: {}
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
@@ -2060,7 +2615,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
+
+  css.escape@1.5.1: {}
+
   csstype@3.2.3: {}
+
+  data-urls@7.0.0:
+    dependencies:
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 16.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   date-fns@4.4.0: {}
 
@@ -2068,13 +2637,25 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js@10.6.0: {}
+
   deep-is@0.1.4: {}
 
+  dequal@2.0.3: {}
+
   detect-libc@2.1.2: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv@17.4.2: {}
 
   electron-to-chromium@1.5.383: {}
+
+  entities@8.0.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   escalade@3.2.0: {}
 
@@ -2159,7 +2740,13 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
   esutils@2.0.3: {}
+
+  expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -2208,11 +2795,19 @@ snapshots:
 
   hono@4.12.27: {}
 
+  html-encoding-sniffer@6.0.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   ignore@5.3.2: {}
 
   ignore@7.0.5: {}
 
   imurmurhash@0.1.4: {}
+
+  indent-string@4.0.0: {}
 
   is-extglob@2.1.1: {}
 
@@ -2220,12 +2815,40 @@ snapshots:
     dependencies:
       is-extglob: 2.1.1
 
+  is-potential-custom-element-name@1.0.1: {}
+
   isexe@2.0.0: {}
 
   jiti@1.21.7:
     optional: true
 
   js-tokens@4.0.0: {}
+
+  jsdom@30.0.1:
+    dependencies:
+      '@asamuzakjp/css-color': 6.0.7
+      '@asamuzakjp/dom-selector': 8.3.2
+      '@bramus/specificity': 2.4.2
+      '@csstools/css-syntax-patches-for-csstree': 1.1.7(css-tree@3.2.1)
+      '@exodus/bytes': 1.15.1
+      css-tree: 3.2.1
+      data-urls: 7.0.0
+      decimal.js: 10.6.0
+      html-encoding-sniffer: 6.0.0
+      is-potential-custom-element-name: 1.0.1
+      lru-cache: 11.5.2
+      parse5: 8.0.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 6.0.2
+      undici: 8.10.0
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 8.0.1
+      whatwg-mimetype: 5.0.0
+      whatwg-url: 17.1.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - '@noble/hashes'
 
   jsesc@3.1.0: {}
 
@@ -2299,6 +2922,8 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lru-cache@11.5.2: {}
+
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
@@ -2306,6 +2931,16 @@ snapshots:
   lucide-react@1.22.0(react@19.2.7):
     dependencies:
       react: 19.2.7
+
+  lz-string@1.5.0: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  mdn-data@2.27.1: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@10.2.5:
     dependencies:
@@ -2318,6 +2953,8 @@ snapshots:
   natural-compare@1.4.0: {}
 
   node-releases@2.0.50: {}
+
+  obug@2.1.4: {}
 
   optionator@0.9.4:
     dependencies:
@@ -2336,9 +2973,15 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  parse5@8.0.1:
+    dependencies:
+      entities: 8.0.0
+
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
+
+  pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
 
@@ -2354,12 +2997,20 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   punycode@2.3.1: {}
 
   react-dom@19.2.7(react@19.2.7):
     dependencies:
       react: 19.2.7
       scheduler: 0.27.0
+
+  react-is@17.0.2: {}
 
   react-router-dom@7.18.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
@@ -2376,6 +3027,13 @@ snapshots:
       react-dom: 19.2.7(react@19.2.7)
 
   react@19.2.7: {}
+
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
+  require-from-string@2.0.2: {}
 
   rolldown@1.1.4:
     dependencies:
@@ -2398,6 +3056,10 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.1.4
       '@rolldown/binding-win32-x64-msvc': 1.1.4
 
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
+
   scheduler@0.27.0: {}
 
   semver@6.3.1: {}
@@ -2412,16 +3074,48 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  siginfo@2.0.0: {}
+
   source-map-js@1.2.1: {}
+
+  stackback@0.0.2: {}
+
+  std-env@4.2.0: {}
+
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
+  symbol-tree@3.2.4: {}
 
   tailwind-merge@3.6.0: {}
 
   tailwindcss@4.3.2: {}
 
+  tinybench@2.9.0: {}
+
+  tinyexec@1.3.0: {}
+
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.5)
       picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
+
+  tldts-core@7.4.10: {}
+
+  tldts@7.4.10:
+    dependencies:
+      tldts-core: 7.4.10
+
+  tough-cookie@6.0.2:
+    dependencies:
+      tldts: 7.4.10
+
+  tr46@6.0.0:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -2447,6 +3141,8 @@ snapshots:
   typescript@6.0.3: {}
 
   undici-types@7.24.6: {}
+
+  undici@8.10.0: {}
 
   update-browserslist-db@1.2.3(browserslist@4.28.4):
     dependencies:
@@ -2475,11 +3171,72 @@ snapshots:
       fsevents: 2.3.3
       jiti: 1.21.7
 
+  vitest@4.1.10(@types/node@25.9.4)(jsdom@30.0.1)(vite@8.1.3(@types/node@25.9.4)(jiti@1.21.7)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.4)(jiti@1.21.7))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.1.3(@types/node@25.9.4)(jiti@1.21.7)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 25.9.4
+      jsdom: 30.0.1
+    transitivePeerDependencies:
+      - msw
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@8.0.1: {}
+
+  whatwg-mimetype@5.0.0: {}
+
+  whatwg-url@16.0.1:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
+  whatwg-url@17.1.0:
+    dependencies:
+      '@exodus/bytes': 1.15.1
+      tr46: 6.0.0
+      webidl-conversions: 8.0.1
+    transitivePeerDependencies:
+      - '@noble/hashes'
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
 
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
   word-wrap@1.2.5: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yallist@3.1.1: {}
 


### PR DESCRIPTION
## Summary

Adds a CloudWatch Logs explorer to the console: a log-groups list with client-side filtering, drill-in to a group's log streams, and a stream's log events. On the API side this adds `/api/logs/*` routes that call the AWS SDK v3 CloudWatchLogs client against Floci core, with per-account client resolution so log groups from every emulated account are visible, not just the default account.

The drill-in (groups → streams → events) is client-side view state rather than URL-routed, following real clicks, matching how the existing legacy service pages navigate.

This PR also introduces the frontend's vitest + testing-library test infrastructure (first frontend unit tests in the repo) and uses it to cover the new panels and navigation.

Related to #71 — the page registers under an Observability nav group as a legacy AWS-only page (like Secrets Manager); it does not implement the schema-driven `observability` category foundation itself.

## Type of change

- [ ] Bug fix (`fix:`)
- [x] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [x] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

- Exercised in the browser at `:4500` against Floci core (AWS CloudWatch Logs) running a full AWS Landing Zone Accelerator deployment — hundreds of log groups across multiple emulated accounts. Verified the groups list, name filtering, drill-in to streams, and event rendering, including groups owned by non-default accounts (the per-account client resolution path).
- `pnpm lint`, `pnpm type-check`, `pnpm test` (441 bun tests in `packages/api`), the new frontend vitest suite (34 tests across 7 files), and `pnpm build` all pass locally.
- Screenshots (desktop + mobile) available — happy to attach on request.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [x] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
