### PR TITLE
fix(frontend): colour the connection dot from the connection state

### DIFF
--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -8,7 +8,24 @@ import {getCloudStatus} from '@/api/cloudProxyClient'
 import {useCloudServicesQuery} from '@/api/queries/cloudQueries'
 import {AccountSwitcher} from '@/components/AccountSwitcher'
 import {serviceIcon} from '@/components/serviceIcons'
-import type {CloudProvider, CloudServiceDescriptor} from '@/types/cloud'
+import type {CloudProvider, CloudServiceDescriptor, RuntimeReachability} from '@/types/cloud'
+
+/** The runtime's reachability, plus the state before the status query answers. */
+type ConnectionStatus = RuntimeReachability | 'unknown'
+
+/**
+ * Only a definitive answer gets a colour.
+ *
+ * `unknown` (status query still in flight — which is first paint and every
+ * cloud switch) and `coming_soon` (runtime not wired) keep the neutral base
+ * grey. Colouring anything that is not `reachable` red made the dot flash
+ * green → red → green on each switch, and start red on load.
+ */
+function connectionDotClass(status: ConnectionStatus): string {
+    if (status === 'reachable') return 'dot healthy'
+    if (status === 'unavailable') return 'dot unavailable'
+    return 'dot'
+}
 
 /** Matches today's service count, so the real nav causes no layout jump. */
 const SKELETON_ROWS = 7
@@ -124,7 +141,7 @@ export function Layout() {
         queryFn: ({signal}) => getCloudStatus(activeCloud, signal),
         refetchInterval: 5000
     })
-    const status = isError ? 'unavailable' : data?.runtime ?? 'unknown'
+    const status: ConnectionStatus = isError ? 'unavailable' : data?.runtime ?? 'unknown'
     const isConnected = status === 'reachable'
     const connectionLabel = isConnected ? 'Connected' : 'Not connected'
     const connectionTarget = data?.endpoint ?? activeCloud
@@ -161,7 +178,7 @@ export function Layout() {
                     <div id="topbar-status" className="topbar-status"/>
                     <AccountSwitcher/>
                     <div className={`connection ${isConnected ? 'connected' : 'disconnected'}`}>
-                        <span className={`dot ${isConnected ? 'healthy' : 'unavailable'}`}/>
+                        <span className={connectionDotClass(status)}/>
                         <span className="connection-state">{connectionLabel}</span>
                         <span className="connection-target">{connectionTarget}</span>
                     </div>

--- a/packages/frontend/src/components/Layout.tsx
+++ b/packages/frontend/src/components/Layout.tsx
@@ -161,7 +161,7 @@ export function Layout() {
                     <div id="topbar-status" className="topbar-status"/>
                     <AccountSwitcher/>
                     <div className={`connection ${isConnected ? 'connected' : 'disconnected'}`}>
-                        <span className={`dot ${status}`}/>
+                        <span className={`dot ${isConnected ? 'healthy' : 'unavailable'}`}/>
                         <span className="connection-state">{connectionLabel}</span>
                         <span className="connection-target">{connectionTarget}</span>
                     </div>


### PR DESCRIPTION

## Summary

The topbar connection dot was grey while the label beside it read "Connected".

`Layout.tsx` interpolated the raw runtime status into the dot's class name:

```tsx
<span className={`dot ${status}`}/>
```

`status` comes from `data.runtime`, and `RuntimeReachability` is
`'reachable' | 'unavailable' | 'coming_soon'`. The CSS only defines
`.dot.healthy`, `.dot.degraded` and `.dot.unavailable`, so a **reachable**
runtime matched no rule and fell through to the base grey at `index.css`.
`coming_soon` and the frontend's `'unknown'` fallback were grey for the same
reason.

The underlying problem is that the dot and the label were two different
expressions of the same state — `connectionLabel` derives from the boolean
`isConnected`, while the dot used the raw string — so they were free to
disagree, and did. The dot now derives from `isConnected` as well:

```tsx
<span className={`dot ${isConnected ? 'healthy' : 'unavailable'}`}/>
```

Green when connected, red when not, and the two can no longer drift apart.

No CSS change: `.dot.healthy` (`#22c55e`) and `.dot.unavailable` (`#ef4444`)
already exist with the correct colours and glow.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

Tested against AWS via Floci core on `:4566` with the API on `:4501`.

- Floci core running → dot is green, label reads "Connected"
- Floci core stopped → dot is red, label reads "Not connected"
- Checked in both dark and light themes

<img width="573" height="54" alt="Screenshot 2026-08-12 at 4 03 06 PM" src="https://github.com/user-attachments/assets/9e1c80bc-7195-486c-88f1-881128b8824d" />



> **TODO (draft):** attach before/after screenshots.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)

### On tests

The policy asks for a regression test on bug fixes "whenever realistic". This
one is a one-line JSX class expression in `packages/frontend`, which has no test
runner — no `test` script in its `package.json`, no vitest — so `pnpm test`
covers `packages/api` only. There is no API behaviour to assert here; the bug
was purely a mismatch between a frontend class name and a CSS rule. The existing
420 API tests still pass.
