### PR TITLE
fix(ci): allow floci-ui to run on older cpus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
         working-directory: packages/api
         run: |
           bun install
-          bun build --compile --minify --target=bun-linux-x64-musl \
+          bun build --compile --minify --target=bun-linux-x64-musl-baseline \
             src/index.ts --outfile "$GITHUB_WORKSPACE/native/amd64/server"
           bun build --compile --minify --target=bun-linux-arm64-musl \
             src/index.ts --outfile "$GITHUB_WORKSPACE/native/arm64/server"


### PR DESCRIPTION
## Summary
this PR allows floci-ui to run on older CPUs which DONT support AVX2
https://bun.com/docs/bundler/executables#supported-targets

this was already fixed for the floci docker images but not the UI app
https://github.com/floci-io/floci/pull/303/changes

Closes #188
<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [x] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [x] Build / CI / Docker

## Verification

<!-- How did you verify this? Which cloud + service did you test against
     (e.g. AWS S3 via Floci core, Azure Blob via Floci-AZ)? -->
<!-- For UI changes, please attach before/after screenshots. -->

## Checklist

- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
