### PR TITLE
fix(ec2): include catalog AMIs in launch selector

### DIFF
--- a/packages/api/src/services/ec2.test.ts
+++ b/packages/api/src/services/ec2.test.ts
@@ -27,6 +27,7 @@ import {
     DeregisterImageCommand,
     DescribeAddressesCommand,
     DescribeAvailabilityZonesCommand,
+    DescribeImagesCommand,
     DescribeInstanceTypesCommand,
     DescribeInternetGatewaysCommand,
     DescribeKeyPairsCommand,
@@ -156,6 +157,34 @@ describe('ec2Service.deregisterImage', () => {
         const client: EC2Client = {send: async (cmd: unknown) => { sent.push(cmd); return {} }} as unknown as EC2Client
         await createEc2Service(client).deregisterImage('ami-old')
         expect(sent[0]).toBeInstanceOf(DeregisterImageCommand)
+    })
+})
+
+describe('ec2Service.listAmis', () => {
+    test('requests the complete image catalog and maps launchable AMIs', async () => {
+        const sent: unknown[] = []
+        const client: EC2Client = {
+            send: async (cmd: unknown) => {
+                sent.push(cmd)
+                return {
+                    Images: [{
+                        ImageId: 'ami-amazonlinux2023',
+                        Name: 'Amazon Linux 2023',
+                    }],
+                }
+            },
+        } as unknown as EC2Client
+
+        const result = await createEc2Service(client).listAmis()
+
+        expect(sent[0]).toBeInstanceOf(DescribeImagesCommand)
+        expect((sent[0] as DescribeImagesCommand).input).toEqual({})
+        expect(result).toEqual([
+            expect.objectContaining({
+                imageId: 'ami-amazonlinux2023',
+                name: 'Amazon Linux 2023',
+            }),
+        ])
     })
 })
 

--- a/packages/api/src/services/ec2.ts
+++ b/packages/api/src/services/ec2.ts
@@ -559,7 +559,7 @@ export function createEc2Service(client: EC2Client = awsClients.ec2) {
 
         async listAmis(): Promise<Ec2Image[]> {
             try {
-                const res = await client.send(new DescribeImagesCommand({Owners: ['self']}))
+                const res = await client.send(new DescribeImagesCommand({}))
                 return (res.Images ?? []).map(toEc2Image)
             } catch (error) {
                 if (isUnsupportedOperation(error)) return []


### PR DESCRIPTION
## Summary

Fix the empty AMI dropdown in AWS Compute → Create Resource.

The Floci UI API was calling `DescribeImages` with `Owners: ['self']`. Floci’s built-in launchable AMIs are catalog images rather than self-owned images, so `/api/ec2/amis` returned an empty array even though Floci core’s `DescribeImages` returned the AMI catalog.

This change requests the complete image catalog using `DescribeImagesCommand({})`.

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [x] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

Reproduced against AWS EC2 via Floci core:

- Floci core `DescribeImages` returned the built-in AMI catalog.
- Floci UI `GET /api/ec2/amis` returned HTTP 200 with `[]`.
- The AWS Compute create-resource form consequently displayed no AMI options.
- Other EC2 UI endpoints, including VPCs, subnets, and security groups, returned valid data.
- No browser console errors occurred.

Added a regression test verifying that `listAmis()`:

- Calls `DescribeImagesCommand` without the `Owners: ['self']` filter.
- Maps catalog images into the UI’s `Ec2Image` response.

The repository’s GitHub Actions checks will verify linting, type-checking, tests, and the production build.

## Checklist

- [x] Commit messages / PR title follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org/)
- [ ] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [x] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder