### PR TITLE
feat(aws): add Secrets Manager resource adapter

### DIFF
--- a/packages/api/src/adapter-aws/AwsSecretsAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsSecretsAdapter.test.ts
@@ -1,0 +1,56 @@
+import {describe, expect, test} from 'bun:test'
+import {AwsSecretsAdapter} from './AwsSecretsAdapter'
+
+function clientReturning(...pages: {SecretList?: unknown[]; NextToken?: string}[]) {
+    let call = 0
+    return {
+        send: async () => pages[call++] ?? {},
+    } as never
+}
+
+describe('AwsSecretsAdapter', () => {
+    test('lists secrets as resources so the console can count them', async () => {
+        const adapter = new AwsSecretsAdapter(clientReturning({
+            SecretList: [
+                {Name: 'a-secret', ARN: 'arn:aws:secretsmanager:eu-west-2:000000000000:secret:a-secret-AbCdEf'},
+                {Name: 'b-secret'},
+            ],
+        }))
+
+        const resources = await adapter.list()
+
+        expect(resources).toHaveLength(2)
+        expect(resources[0]).toMatchObject({name: 'a-secret', service: 'secrets', type: 'secret', status: 'active'})
+    })
+
+    test('never exposes a secret value', async () => {
+        // The guarantee is structural (GetSecretValue is not imported), but a value
+        // leaking in through metadata would be just as bad, so assert on the shape.
+        const adapter = new AwsSecretsAdapter(clientReturning({
+            SecretList: [{Name: 'a-secret', ARN: 'arn:x'}],
+        }))
+
+        const serialized = JSON.stringify(await adapter.list())
+
+        expect(serialized).not.toContain('SecretString')
+        expect(serialized).not.toContain('secretString')
+        expect(serialized).not.toContain('SecretBinary')
+    })
+
+    test('paginates, so a count past one page is not silently short', async () => {
+        const adapter = new AwsSecretsAdapter(clientReturning(
+            {SecretList: [{Name: 'one'}], NextToken: 'next'},
+            {SecretList: [{Name: 'two'}]},
+        ))
+
+        expect(await adapter.list()).toHaveLength(2)
+    })
+
+    test('marks a secret pending deletion rather than reporting it healthy', async () => {
+        const adapter = new AwsSecretsAdapter(clientReturning({
+            SecretList: [{Name: 'gone', DeletedDate: new Date('2026-01-01T00:00:00Z')}],
+        }))
+
+        expect((await adapter.list())[0]?.status).toBe('deleted')
+    })
+})

--- a/packages/api/src/adapter-aws/AwsSecretsAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsSecretsAdapter.ts
@@ -1,0 +1,116 @@
+import {ListSecretsCommand, DescribeSecretCommand, type SecretsManagerClient} from '@aws-sdk/client-secrets-manager'
+import {secretsManager as defaultSecretsManager} from '../aws'
+import {NotSupportedError} from '../cloud-spi/errors'
+import {awsSecretsSchema} from '../cloud-spi/secretsSchema'
+import type {
+    CloudResource,
+    CloudServiceAdapter,
+    CreateResourceInput,
+    ResourceQuery,
+    ServiceSchema,
+} from '../cloud-spi/types'
+
+/**
+ * Secrets Manager as a Cloud Explorer service, so the console can count secrets
+ * instead of falling back to a dash.
+ *
+ * Deliberately metadata-only: this file imports ListSecrets and DescribeSecret
+ * and NOT GetSecretValue, so no code path here can return a secret value. That
+ * is a structural guarantee rather than a convention — adding value disclosure
+ * would require adding an import.
+ *
+ * Read-only for the same reason: create would need a value field on the schema.
+ */
+export class AwsSecretsAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'secrets' as const
+
+    constructor(private readonly client: SecretsManagerClient = defaultSecretsManager) {}
+
+    schema(): ServiceSchema {
+        return awsSecretsSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const resources: CloudResource[] = []
+        let nextToken: string | undefined
+
+        // Paginated: a single ListSecrets page caps at 100, and an unpaginated
+        // count silently under-reports past that.
+        do {
+            const res = await this.client.send(new ListSecretsCommand({NextToken: nextToken}))
+            for (const secret of res.SecretList ?? []) {
+                resources.push(toResource(secret))
+            }
+            nextToken = res.NextToken
+        } while (nextToken)
+
+        return filterBySearch(resources, query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        try {
+            const res = await this.client.send(new DescribeSecretCommand({SecretId: id}))
+            return toResource(res)
+        } catch (error) {
+            if (isNotFound(error)) return null
+            throw error
+        }
+    }
+
+    async create(_input: CreateResourceInput): Promise<CloudResource> {
+        throw new NotSupportedError('Secret creation is not supported from the dynamic Cloud Explorer.')
+    }
+
+    async delete(_id: string): Promise<void> {
+        throw new NotSupportedError('Secret deletion is not supported from the dynamic Cloud Explorer.')
+    }
+}
+
+interface SecretMetadata {
+    Name?: string
+    ARN?: string
+    CreatedDate?: Date
+    LastChangedDate?: Date
+    DeletedDate?: Date
+    Description?: string
+    RotationEnabled?: boolean
+    KmsKeyId?: string
+    Tags?: {Key?: string; Value?: string}[]
+}
+
+function toResource(secret: SecretMetadata): CloudResource {
+    const name = secret.Name ?? ''
+    return {
+        id: name,
+        name,
+        cloud: 'aws',
+        service: 'secrets',
+        type: 'secret',
+        region: null,
+        createdAt: secret.CreatedDate?.toISOString() ?? null,
+        // A deleted secret lingers in the list during its recovery window, so the
+        // status has to distinguish it rather than reading as healthy.
+        status: secret.DeletedDate ? 'deleted' : 'active',
+        metadata: {
+            arn: secret.ARN,
+            description: secret.Description,
+            rotationEnabled: secret.RotationEnabled ?? false,
+            kmsKeyId: secret.KmsKeyId,
+            lastChangedDate: secret.LastChangedDate?.toISOString() ?? null,
+            tags: (secret.Tags ?? []).map((tag) => ({key: tag.Key, value: tag.Value})),
+        },
+    }
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((resource) => resource.name.toLowerCase().includes(normalized))
+}
+
+function isNotFound(error: unknown): boolean {
+    if (typeof error !== 'object' || error === null) return false
+    const e = error as {name?: string; $metadata?: {httpStatusCode?: number}}
+    return e.name === 'ResourceNotFoundException' || e.$metadata?.httpStatusCode === 404
+}

--- a/packages/api/src/cloud-spi/secretsSchema.ts
+++ b/packages/api/src/cloud-spi/secretsSchema.ts
@@ -66,3 +66,28 @@ export function azureSecretsSchema(): ServiceSchema {
     }
 }
 
+// AWS list/describe return metadata only; the value is deliberately never read,
+// so this schema advertises no value field and no create action.
+const awsSecretsColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Secret Name'},
+    {name: 'status', label: 'Status'},
+    {name: 'createdAt', label: 'Created At', format: 'datetime'},
+]
+
+export function awsSecretsSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'secrets',
+        displayName: 'AWS Secrets Manager',
+        fields: [],
+        actions: ['list', 'inspect'],
+        filters: secretsFilters,
+        columns: awsSecretsColumns,
+        capabilities: {
+            resourceActions: [
+                {name: 'list', label: 'List secrets', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'inspect', label: 'Inspect metadata', enabled: true, status: 'available', runtimeRequired: true},
+            ],
+        },
+    }
+}

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -94,9 +94,6 @@ export const SERVICE_CATALOG = {
         // Azure Key Vault is a normal Cloud Explorer service, so it uses the catalog
         // slug rather than the legacy standalone page AWS still points at.
         routeByCloud: {azure: 'secrets'},
-        // Migration debt: the AWS Secrets Manager page still lives outside Cloud
-        // Explorer, so there is no adapter to derive availability from.
-        legacyAvailability: {aws: 'available'},
     },
     iac: {
         displayName: 'Infrastructure as Code',

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -18,6 +18,7 @@ import {AzureKeyVaultAdapter} from './adapter-azure/AzureKeyVaultAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
 import {AwsApiGatewayAdapter} from './adapter-aws/AwsApiGatewayAdapter'
 import {AwsCloudFormationAdapter} from './adapter-aws/AwsCloudFormationAdapter'
+import {AwsSecretsAdapter} from './adapter-aws/AwsSecretsAdapter'
 import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
@@ -46,6 +47,7 @@ export function createCloudAdapterRegistry(accountId?: string | null): CloudAdap
         new AwsServerlessAdapter(clients.lambda),
         new AwsApiGatewayAdapter(clients.apiGateway),
         new AwsCloudFormationAdapter(clients.cloudformation),
+        new AwsSecretsAdapter(clients.secretsManager),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new AzureComputeAdapter(),

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -512,12 +512,18 @@ describe('service descriptors', () => {
         expect(serverless.reason).toContain('501')
     })
 
-    test('keeps the legacy Secrets Manager page available on AWS only', async () => {
-        const aws = await (await appWithRoutes().request('/api/clouds/aws/services')).json()
+    test('keeps the Secrets Manager page route while taking availability from the adapter', async () => {
+        // Availability now comes from adapter registration like every other service,
+        // but the absolute route is kept so the card still links to the standalone
+        // page instead of Cloud Explorer. Without an adapter it reads coming_soon.
+        const withAdapter = appWithRoutes([mockAdapter('aws'), mockAdapter('aws', {service: 'secrets'})])
+        const aws = await (await withAdapter.request('/api/clouds/aws/services')).json()
+        const bare = await (await appWithRoutes().request('/api/clouds/aws/services')).json()
         const gcp = await (await appWithRoutes().request('/api/clouds/gcp/services')).json()
         const secretsFor = (body: Array<{service: string}>) => body.find((d) => d.service === 'secrets')
 
         expect(secretsFor(aws)).toMatchObject({availability: 'available', route: '/secretsmanager'})
+        expect(secretsFor(bare)).toMatchObject({availability: 'coming_soon'})
         expect(secretsFor(gcp)).toMatchObject({availability: 'coming_soon'})
     })
 })

--- a/packages/frontend/src/features/cloud-console/useCloudConsoleHomeData.ts
+++ b/packages/frontend/src/features/cloud-console/useCloudConsoleHomeData.ts
@@ -33,10 +33,12 @@ export function useCloudConsoleHomeData(cloud: CloudProvider) {
     const status = statusQuery.data
     const services = useMemo(() => servicesQuery.data ?? [], [servicesQuery.data])
 
-    // Services on their own route are counted through the generic list endpoint;
-    // a legacy absolute-route page has no such endpoint, so it shows no count.
+    // Availability is derived from adapter registration, so an available service
+    // always has the generic list endpoint. Route shape only decides where the
+    // card links, not whether it can be counted -- a legacy absolute-route page
+    // (AWS Secrets Manager) is still counted through its adapter.
     const countable = useMemo(
-        () => services.filter((service) => service.availability === 'available' && !service.route.startsWith('/')),
+        () => services.filter((service) => service.availability === 'available'),
         [services],
     )
 


### PR DESCRIPTION
The console's Secrets Manager card shows `-` where every other available
service shows a resource count.

`GET /api/clouds/aws/services/secrets/resources` returns:

    {"error":"Operation is not supported by this adapter",
     "code":"operation_not_supported",
     "detail":"No adapter registered for aws/secrets"}

Two causes compound:

1. No resource adapter is registered for `aws/secrets`, so the count cannot be
   computed. `packages/api/src/cloud-spi/serviceCatalog.ts` already flags this as
   migration debt and prescribes the fix: *"Migration debt: the AWS Secrets
   Manager page still lives outside Cloud Explorer, so there is no adapter to
   derive availability from"*, with `legacyAvailability` documented as *"delete
   the field once a real adapter exists"*.
2. `useCloudConsoleHomeData.ts` excludes absolute-route services from the count
   query, on the premise that *"a legacy absolute-route page has no such
   endpoint"*. Once the adapter exists that premise no longer holds.

### What this changes

- Adds `AwsSecretsAdapter` (`list`, `get`) plus `awsSecretsSchema()`, registered
  in `cloudProxy.ts`.
- Deletes `legacyAvailability` for `aws.secrets`, so availability derives from
  adapter registration like every other service.
- Keeps `route: '/secretsmanager'`, so the card still links to the existing
  standalone page rather than to Cloud Explorer. Nothing is orphaned.
- Console home counts every available service. Route shape now decides only
  where a card links, not whether it can be counted.

### Security: metadata only

The adapter imports `ListSecretsCommand` and `DescribeSecretCommand` and **not**
`GetSecretValueCommand`, so no code path in it can return a secret value. That
is a structural guarantee, not a convention — exposing a value would require
adding an import. It is read-only for the same reason: `create` would require a
value field on the schema. `create`/`delete` throw `NotSupportedError`, matching
`AwsEksAdapter`.

A test asserts the serialized list contains no `SecretString`, `secretString` or
`SecretBinary`.

### Other notes

- `list` paginates on `NextToken`. A single `ListSecrets` page caps at 100, so an
  unpaginated count silently under-reports past that.
- A secret pending deletion reports `status: 'deleted'` rather than reading as
  healthy, since it lingers in the list during its recovery window.
- `type: 'secret'` already existed in the `CloudResource` union.

### Verification

`bun test` in `packages/api`: **506 pass, 0 fail** (was 501 pass with 1 failing
test that asserted the old `legacyAvailability` behaviour; that test is updated
to assert availability now comes from the adapter). `tsc --noEmit` and `eslint`
clean in `packages/api` and `packages/frontend`; `vite build` succeeds.

Against a live Floci with 5 secrets, `/api/clouds/aws/services/secrets/resources`
returns 5 and the card renders `5`.
