### PR TITLE
feat(eks): Manage nodegroups and Fargate profiles via Cloud Proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,10 @@ Current gaps:
 AWS only, through the unified shell.
 
 - EKS clusters can be listed and inspected.
-- Cluster metadata, node groups, and related details are surfaced when returned by Floci AWS Core.
+- A selected cluster lists its managed nodegroups and Fargate profiles.
+- Create and delete managed nodegroups, including role, subnets, instance types, and scaling configuration.
+- Create and delete Fargate profiles, including pod execution role, selectors, labels, and optional subnets.
+- These nested EKS operations use the unified Cloud Proxy, not the legacy `/api/eks/*` routes.
 
 Current gaps:
 

--- a/packages/api/src/adapter-aws/AwsEksAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsEksAdapter.test.ts
@@ -1,0 +1,67 @@
+import {describe, expect, test} from 'bun:test'
+import {AwsEksAdapter} from './AwsEksAdapter'
+
+function fakeEksService() {
+    return {
+        listClusters: async () => [],
+        describeCluster: async () => ({name: 'cluster-a', tags: {}}),
+        listNodegroups: async (clusterName: string) => [{
+            name: 'workers', clusterName, arn: 'arn:aws:eks:us-east-1:000000000000:nodegroup/cluster-a/workers/id',
+            status: 'ACTIVE', version: '1.30', releaseVersion: '1.30.0-20260801',
+            instanceTypes: ['t3.medium'], subnets: ['subnet-a'], nodeRole: 'arn:aws:iam::000000000000:role/workers',
+            scalingConfig: {minSize: 1, desiredSize: 2, maxSize: 3}, labels: {workload: 'api'}, tags: {team: 'platform'},
+        }],
+        createNodegroup: async (clusterName: string, input: unknown) => ({
+            name: (input as {name: string}).name, clusterName, instanceTypes: [], subnets: [], labels: {}, tags: {},
+        }),
+        deleteNodegroup: async () => ({name: 'workers', clusterName: 'cluster-a', instanceTypes: [], subnets: [], labels: {}, tags: {}}),
+        listFargateProfiles: async (clusterName: string) => [{
+            name: 'default', clusterName, arn: 'arn:aws:eks:us-east-1:000000000000:fargateprofile/cluster-a/default/id',
+            status: 'ACTIVE', podExecutionRoleArn: 'arn:aws:iam::000000000000:role/fargate', subnets: ['subnet-a'],
+            selectors: [{namespace: 'default', labels: {app: 'api'}}], tags: {team: 'platform'},
+        }],
+        createFargateProfile: async (clusterName: string, input: unknown) => ({
+            name: (input as {name: string}).name, clusterName, subnets: [], selectors: [], tags: {},
+        }),
+        deleteFargateProfile: async () => ({name: 'default', clusterName: 'cluster-a', subnets: [], selectors: [], tags: {}}),
+    }
+}
+
+describe('AwsEksAdapter', () => {
+    test('maps EKS nodegroups through the provider-neutral contract', async () => {
+        const adapter = new AwsEksAdapter(fakeEksService())
+
+        await expect(adapter.listKubernetesNodegroups('cluster-a')).resolves.toEqual([expect.objectContaining({
+            id: 'workers',
+            clusterId: 'cluster-a',
+            capacityType: null,
+            scalingConfig: {minSize: 1, desiredSize: 2, maxSize: 3},
+        })])
+    })
+
+    test('validates nodegroup input before calling the runtime', async () => {
+        const adapter = new AwsEksAdapter(fakeEksService())
+
+        await expect(adapter.createKubernetesNodegroup('cluster-a', {
+            name: 'workers', nodeRole: '', subnets: ['subnet-a'],
+        })).rejects.toThrow('Node role ARN is required')
+    })
+
+    test('maps EKS Fargate profiles through the provider-neutral contract', async () => {
+        const adapter = new AwsEksAdapter(fakeEksService())
+
+        await expect(adapter.listKubernetesFargateProfiles('cluster-a')).resolves.toEqual([expect.objectContaining({
+            id: 'default',
+            clusterId: 'cluster-a',
+            selectors: [{namespace: 'default', labels: {app: 'api'}}],
+        })])
+    })
+
+    test('validates that a Fargate profile has a selector namespace', async () => {
+        const adapter = new AwsEksAdapter(fakeEksService())
+
+        await expect(adapter.createKubernetesFargateProfile('cluster-a', {
+            name: 'default', podExecutionRoleArn: 'arn:aws:iam::000000000000:role/fargate', selectors: [],
+        })).rejects.toThrow('At least one selector namespace is required')
+    })
+})

--- a/packages/api/src/adapter-aws/AwsEksAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsEksAdapter.ts
@@ -3,13 +3,28 @@ import {awsEksSchema} from '../cloud-spi/eksSchema'
 import type {
     CloudResource,
     CloudServiceAdapter,
+    CreateKubernetesFargateProfileInput,
+    CreateKubernetesNodegroupInput,
     CreateResourceInput,
+    KubernetesFargateProfile,
+    KubernetesNodegroup,
     ResourceQuery,
     ServiceSchema,
 } from '../cloud-spi/types'
-import {eksService, type EksCluster} from '../services/eks'
+import {ValidationError} from '../cloud-spi/errors'
+import {eksService, type EksCluster, type EksFargateProfile, type EksNodegroup} from '../services/eks'
 
-type EksServiceShape = Pick<typeof eksService, 'listClusters' | 'describeCluster'>
+type EksServiceShape = Pick<
+    typeof eksService,
+    | 'listClusters'
+    | 'describeCluster'
+    | 'listNodegroups'
+    | 'createNodegroup'
+    | 'deleteNodegroup'
+    | 'listFargateProfiles'
+    | 'createFargateProfile'
+    | 'deleteFargateProfile'
+>
 
 export class AwsEksAdapter implements CloudServiceAdapter {
     readonly cloud = 'aws' as const
@@ -41,6 +56,38 @@ export class AwsEksAdapter implements CloudServiceAdapter {
 
     async delete(_id: string): Promise<void> {
         throw new NotSupportedError('EKS cluster deletion is not supported from the dynamic Cloud Explorer.')
+    }
+
+    async listKubernetesNodegroups(clusterId: string): Promise<KubernetesNodegroup[]> {
+        return (await this.eks.listNodegroups(clusterId)).map(toNodegroup)
+    }
+
+    async createKubernetesNodegroup(
+        clusterId: string,
+        input: CreateKubernetesNodegroupInput,
+    ): Promise<KubernetesNodegroup> {
+        validateNodegroupInput(input)
+        return toNodegroup(await this.eks.createNodegroup(clusterId, input))
+    }
+
+    async deleteKubernetesNodegroup(clusterId: string, nodegroupId: string): Promise<void> {
+        await this.eks.deleteNodegroup(clusterId, nodegroupId)
+    }
+
+    async listKubernetesFargateProfiles(clusterId: string): Promise<KubernetesFargateProfile[]> {
+        return (await this.eks.listFargateProfiles(clusterId)).map(toFargateProfile)
+    }
+
+    async createKubernetesFargateProfile(
+        clusterId: string,
+        input: CreateKubernetesFargateProfileInput,
+    ): Promise<KubernetesFargateProfile> {
+        validateFargateProfileInput(input)
+        return toFargateProfile(await this.eks.createFargateProfile(clusterId, input))
+    }
+
+    async deleteKubernetesFargateProfile(clusterId: string, profileId: string): Promise<void> {
+        await this.eks.deleteFargateProfile(clusterId, profileId)
     }
 }
 
@@ -78,4 +125,59 @@ function hasHttpStatus(error: unknown, status: number): boolean {
     if (typeof error !== 'object' || error === null) return false
     const metadata = (error as {$metadata?: {httpStatusCode?: number}}).$metadata
     return metadata?.httpStatusCode === status
+}
+
+function toNodegroup(nodegroup: EksNodegroup): KubernetesNodegroup {
+    return {
+        id: nodegroup.name,
+        name: nodegroup.name,
+        clusterId: nodegroup.clusterName,
+        arn: nodegroup.arn ?? null,
+        status: nodegroup.status ?? null,
+        version: nodegroup.version ?? null,
+        releaseVersion: nodegroup.releaseVersion ?? null,
+        createdAt: nodegroup.createdAt ?? null,
+        modifiedAt: nodegroup.modifiedAt ?? null,
+        capacityType: nodegroup.capacityType ?? null,
+        instanceTypes: nodegroup.instanceTypes,
+        subnets: nodegroup.subnets,
+        nodeRole: nodegroup.nodeRole ?? null,
+        scalingConfig: nodegroup.scalingConfig ?? null,
+        labels: nodegroup.labels,
+        tags: nodegroup.tags,
+    }
+}
+
+function toFargateProfile(profile: EksFargateProfile): KubernetesFargateProfile {
+    return {
+        id: profile.name,
+        name: profile.name,
+        clusterId: profile.clusterName,
+        arn: profile.arn ?? null,
+        status: profile.status ?? null,
+        createdAt: profile.createdAt ?? null,
+        podExecutionRoleArn: profile.podExecutionRoleArn ?? null,
+        subnets: profile.subnets,
+        selectors: profile.selectors.map((selector) => ({
+            namespace: selector.namespace ?? null,
+            labels: selector.labels,
+        })),
+        tags: profile.tags,
+    }
+}
+
+function validateNodegroupInput(input: CreateKubernetesNodegroupInput): void {
+    if (typeof input.name !== 'string' || !input.name.trim()) throw new ValidationError('Nodegroup name is required')
+    if (typeof input.nodeRole !== 'string' || !input.nodeRole.trim()) throw new ValidationError('Node role ARN is required')
+    if (!Array.isArray(input.subnets) || input.subnets.length === 0 || input.subnets.some((subnet) => typeof subnet !== 'string' || !subnet.trim())) {
+        throw new ValidationError('At least one subnet is required')
+    }
+}
+
+function validateFargateProfileInput(input: CreateKubernetesFargateProfileInput): void {
+    if (typeof input.name !== 'string' || !input.name.trim()) throw new ValidationError('Fargate profile name is required')
+    if (typeof input.podExecutionRoleArn !== 'string' || !input.podExecutionRoleArn.trim()) throw new ValidationError('Pod execution role ARN is required')
+    if (!Array.isArray(input.selectors) || input.selectors.length === 0 || input.selectors.some((selector) => typeof selector.namespace !== 'string' || !selector.namespace.trim())) {
+        throw new ValidationError('At least one selector namespace is required')
+    }
 }

--- a/packages/api/src/cloud-spi/eksSchema.ts
+++ b/packages/api/src/cloud-spi/eksSchema.ts
@@ -28,6 +28,20 @@ export function awsEksSchema(): ServiceSchema {
         displayName: 'AWS EKS',
         fields: [],
         actions: ['list', 'inspect'],
+        capabilities: {
+            resourceActions: [
+                {name: 'list', label: 'List clusters', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'inspect', label: 'Inspect cluster', enabled: true, status: 'available', runtimeRequired: false},
+            ],
+            kubernetesActions: [
+                {name: 'listNodegroups', label: 'List nodegroups', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'createNodegroup', label: 'Create nodegroup', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'deleteNodegroup', label: 'Delete nodegroup', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'listFargateProfiles', label: 'List Fargate profiles', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'createFargateProfile', label: 'Create Fargate profile', enabled: true, status: 'available', runtimeRequired: true},
+                {name: 'deleteFargateProfile', label: 'Delete Fargate profile', enabled: true, status: 'available', runtimeRequired: true},
+            ],
+        },
         filters: eksFilters,
         columns: eksColumns,
     }

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -101,6 +101,13 @@ export type ResourceActionName =
     | 'reboot'
     | 'updateTags'
 export type ObjectActionName = 'list' | 'upload' | 'download' | 'delete' | 'createFolder' | 'copy'
+export type KubernetesActionName =
+    | 'listNodegroups'
+    | 'createNodegroup'
+    | 'deleteNodegroup'
+    | 'listFargateProfiles'
+    | 'createFargateProfile'
+    | 'deleteFargateProfile'
 export type CapabilityStatus = 'available' | 'blocked' | 'partial' | 'coming_soon'
 
 export interface CapabilitySchema<TAction extends string> {
@@ -142,6 +149,7 @@ export interface ServiceSchema {
     capabilities?: {
         resourceActions?: CapabilitySchema<ResourceActionName>[]
         objectActions?: CapabilitySchema<ObjectActionName>[]
+        kubernetesActions?: CapabilitySchema<KubernetesActionName>[]
     }
     filters: FieldSchema[]
     columns: TableColumnSchema[]
@@ -212,6 +220,57 @@ export interface NoSqlItem {
     document: Record<string, unknown>
 }
 
+/** Provider-neutral representation of a managed Kubernetes node pool. */
+export interface KubernetesNodegroup {
+    id: string
+    name: string
+    clusterId: string
+    arn: string | null
+    status: string | null
+    version: string | null
+    releaseVersion: string | null
+    createdAt: string | null
+    modifiedAt: string | null
+    capacityType: string | null
+    instanceTypes: string[]
+    subnets: string[]
+    nodeRole: string | null
+    scalingConfig: {minSize?: number; maxSize?: number; desiredSize?: number} | null
+    labels: Record<string, string>
+    tags: Record<string, string>
+}
+
+export interface CreateKubernetesNodegroupInput {
+    name: string
+    nodeRole: string
+    subnets: string[]
+    instanceTypes?: string[]
+    scalingConfig?: {minSize?: number; maxSize?: number; desiredSize?: number}
+    labels?: Record<string, string>
+    tags?: Record<string, string>
+}
+
+export interface KubernetesFargateProfile {
+    id: string
+    name: string
+    clusterId: string
+    arn: string | null
+    status: string | null
+    createdAt: string | null
+    podExecutionRoleArn: string | null
+    subnets: string[]
+    selectors: Array<{namespace: string | null; labels: Record<string, string>}>
+    tags: Record<string, string>
+}
+
+export interface CreateKubernetesFargateProfileInput {
+    name: string
+    podExecutionRoleArn: string
+    subnets?: string[]
+    selectors: Array<{namespace: string; labels?: Record<string, string>}>
+    tags?: Record<string, string>
+}
+
 export interface ResourceQuery {
     search?: string
 }
@@ -276,4 +335,10 @@ export interface CloudServiceAdapter {
     deleteCosmosItem?(databaseId: string, containerId: string, itemId: string, partitionKey?: string | null): Promise<void>
     queryCosmosItems?(databaseId: string, containerId: string, query: string): Promise<CosmosQueryResult>
     listNoSqlItems?(resourceId: string): Promise<NoSqlItem[]>
+    listKubernetesNodegroups?(clusterId: string): Promise<KubernetesNodegroup[]>
+    createKubernetesNodegroup?(clusterId: string, input: CreateKubernetesNodegroupInput): Promise<KubernetesNodegroup>
+    deleteKubernetesNodegroup?(clusterId: string, nodegroupId: string): Promise<void>
+    listKubernetesFargateProfiles?(clusterId: string): Promise<KubernetesFargateProfile[]>
+    createKubernetesFargateProfile?(clusterId: string, input: CreateKubernetesFargateProfileInput): Promise<KubernetesFargateProfile>
+    deleteKubernetesFargateProfile?(clusterId: string, profileId: string): Promise<void>
 }

--- a/packages/api/src/cloudProxy.test.ts
+++ b/packages/api/src/cloudProxy.test.ts
@@ -1,7 +1,7 @@
 import {describe, expect, test} from 'bun:test'
 import {createCloudAdapterRegistry} from './cloudProxy'
 import {isServiceType} from './cloud-spi/serviceCatalog'
-import type {CloudProvider, CloudServiceAdapter, CloudServiceType, ResourceActionName} from './cloud-spi/types'
+import type {CloudProvider, CloudServiceAdapter, CloudServiceType, KubernetesActionName, ResourceActionName} from './cloud-spi/types'
 
 /**
  * Guards the schema-to-implementation contract for every registered adapter.
@@ -27,6 +27,15 @@ const METHOD_FOR_ACTION: Record<ResourceActionName, keyof CloudServiceAdapter> =
     stop: 'stop',
     reboot: 'reboot',
     updateTags: 'updateTags',
+}
+
+const METHOD_FOR_KUBERNETES_ACTION: Record<KubernetesActionName, keyof CloudServiceAdapter> = {
+    listNodegroups: 'listKubernetesNodegroups',
+    createNodegroup: 'createKubernetesNodegroup',
+    deleteNodegroup: 'deleteKubernetesNodegroup',
+    listFargateProfiles: 'listKubernetesFargateProfiles',
+    createFargateProfile: 'createKubernetesFargateProfile',
+    deleteFargateProfile: 'deleteKubernetesFargateProfile',
 }
 
 const registry = createCloudAdapterRegistry()
@@ -81,12 +90,23 @@ describe('registered adapters honour their schema', () => {
                     `${label} advertises ${capability.name} as available but has no ${String(method)}()`,
                 ).toBe('function')
             }
+
+            const kubernetesCapabilities = adapter.schema().capabilities?.kubernetesActions ?? []
+            const kubernetesClaims = kubernetesCapabilities.filter((capability) => capability.status === 'available')
+            for (const capability of kubernetesClaims) {
+                const method = METHOD_FOR_KUBERNETES_ACTION[capability.name]
+                expect(
+                    typeof adapter[method],
+                    `${label} advertises ${capability.name} as available but has no ${String(method)}()`,
+                ).toBe('function')
+            }
         })
 
         test(`${label} explains every capability it does not fully support`, () => {
             const capabilities = [
                 ...(adapter.schema().capabilities?.resourceActions ?? []),
                 ...(adapter.schema().capabilities?.objectActions ?? []),
+                ...(adapter.schema().capabilities?.kubernetesActions ?? []),
             ]
 
             for (const capability of capabilities) {

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -3,6 +3,7 @@ import {Hono} from 'hono'
 import {NotImplementedByRuntimeError, RuntimeUnavailableError, ValidationError} from '../cloud-spi/errors'
 import {azureDatabaseSchema} from '../cloud-spi/databaseSchema'
 import {awsDynamoDbSchema} from '../cloud-spi/dynamodbSchema'
+import {awsEksSchema} from '../cloud-spi/eksSchema'
 import {awsStorageSchema, azureStorageSchema, gcpStorageSchema} from '../cloud-spi/storageSchema'
 import type {CloudProvider, CloudResource, CloudServiceAdapter, CosmosContainer, CosmosItem, CosmosQueryResult, CreateResourceInput, NoSqlItem} from '../cloud-spi/types'
 import {CloudAdapterRegistry} from '../registry/CloudAdapterRegistry'
@@ -623,5 +624,65 @@ describe('per-service status', () => {
     test('rejects an unknown service slug', async () => {
         const res = await appWithRoutes().request('/api/clouds/aws/services/queue/status')
         expect(res.status).toBe(404)
+    })
+
+    test('routes nested EKS nodegroup and Fargate actions through the cloud adapter', async () => {
+        const calls: string[] = []
+        const app = appWithRoutes([mockAdapter('aws', {
+            service: 'k8s',
+            schema: awsEksSchema,
+            listKubernetesNodegroups: async (clusterId) => [{
+                id: 'workers', name: 'workers', clusterId, arn: null, status: 'ACTIVE', version: null,
+                releaseVersion: null, createdAt: null, modifiedAt: null, capacityType: null,
+                instanceTypes: ['t3.medium'], subnets: ['subnet-a'], nodeRole: null,
+                scalingConfig: null, labels: {}, tags: {},
+            }],
+            createKubernetesNodegroup: async (clusterId, input) => {
+                calls.push(`create-nodegroup:${clusterId}:${input.name}`)
+                return {
+                    id: input.name, name: input.name, clusterId, arn: null, status: null, version: null,
+                    releaseVersion: null, createdAt: null, modifiedAt: null, capacityType: null,
+                    instanceTypes: [], subnets: input.subnets, nodeRole: input.nodeRole,
+                    scalingConfig: null, labels: {}, tags: {},
+                }
+            },
+            deleteKubernetesNodegroup: async (clusterId, nodegroupId) => {
+                calls.push(`delete-nodegroup:${clusterId}:${nodegroupId}`)
+            },
+            listKubernetesFargateProfiles: async (clusterId) => [{
+                id: 'default', name: 'default', clusterId, arn: null, status: 'ACTIVE', createdAt: null,
+                podExecutionRoleArn: null, subnets: [], selectors: [], tags: {},
+            }],
+            createKubernetesFargateProfile: async (clusterId, input) => {
+                calls.push(`create-fargate:${clusterId}:${input.name}`)
+                return {
+                    id: input.name, name: input.name, clusterId, arn: null, status: null, createdAt: null,
+                    podExecutionRoleArn: input.podExecutionRoleArn, subnets: input.subnets ?? [], selectors: [], tags: {},
+                }
+            },
+            deleteKubernetesFargateProfile: async (clusterId, profileId) => {
+                calls.push(`delete-fargate:${clusterId}:${profileId}`)
+            },
+        })])
+
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/nodegroups')).status).toBe(200)
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/nodegroups', {
+            method: 'POST', headers: {'content-type': 'application/json'},
+            body: JSON.stringify({name: 'workers', nodeRole: 'role', subnets: ['subnet-a']}),
+        })).status).toBe(201)
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/nodegroups/workers', {method: 'DELETE'})).status).toBe(200)
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/fargate-profiles')).status).toBe(200)
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/fargate-profiles', {
+            method: 'POST', headers: {'content-type': 'application/json'},
+            body: JSON.stringify({name: 'default', podExecutionRoleArn: 'role', selectors: [{namespace: 'default'}]}),
+        })).status).toBe(201)
+        expect((await app.request('/api/clouds/aws/services/k8s/resources/demo/fargate-profiles/default', {method: 'DELETE'})).status).toBe(200)
+
+        expect(calls).toEqual([
+            'create-nodegroup:demo:workers',
+            'delete-nodegroup:demo:workers',
+            'create-fargate:demo:default',
+            'delete-fargate:demo:default',
+        ])
     })
 })

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -149,6 +149,66 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         })
     })
 
+    app.get('/:cloud/services/k8s/resources/:id/nodegroups', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const nodegroups = await svc(c).listKubernetesNodegroups(cloud, c.req.param('id'))
+            return c.json(nodegroups)
+        })
+    })
+
+    app.post('/:cloud/services/k8s/resources/:id/nodegroups', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const nodegroup = await svc(c).createKubernetesNodegroup(cloud, c.req.param('id'), await c.req.json())
+            return c.json(nodegroup, 201)
+        })
+    })
+
+    app.delete('/:cloud/services/k8s/resources/:id/nodegroups/:nodegroupId', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            await svc(c).deleteKubernetesNodegroup(cloud, c.req.param('id'), c.req.param('nodegroupId'))
+            return c.json({ok: true})
+        })
+    })
+
+    app.get('/:cloud/services/k8s/resources/:id/fargate-profiles', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const profiles = await svc(c).listKubernetesFargateProfiles(cloud, c.req.param('id'))
+            return c.json(profiles)
+        })
+    })
+
+    app.post('/:cloud/services/k8s/resources/:id/fargate-profiles', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const profile = await svc(c).createKubernetesFargateProfile(cloud, c.req.param('id'), await c.req.json())
+            return c.json(profile, 201)
+        })
+    })
+
+    app.delete('/:cloud/services/k8s/resources/:id/fargate-profiles/:profileId', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            await svc(c).deleteKubernetesFargateProfile(cloud, c.req.param('id'), c.req.param('profileId'))
+            return c.json({ok: true})
+        })
+    })
+
     app.get('/:cloud/services/:service/resources/:id', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         const serviceType = c.req.param('service') as CloudServiceType

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -10,7 +10,11 @@ import type {
     CosmosContainer,
     CosmosItem,
     CosmosQueryResult,
+    CreateKubernetesFargateProfileInput,
+    CreateKubernetesNodegroupInput,
     CreateResourceInput,
+    KubernetesFargateProfile,
+    KubernetesNodegroup,
     NoSqlItem,
     ResourceQuery,
     ServerlessInvokeResult,
@@ -292,6 +296,42 @@ async invokeResource(
         return adapter.listNoSqlItems(resourceId)
     }
 
+    async listKubernetesNodegroups(cloud: CloudProvider, clusterId: string): Promise<KubernetesNodegroup[]> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.listKubernetesNodegroups) throw new NotSupportedError(`Nodegroups are not supported for ${cloud}/k8s`)
+        return adapter.listKubernetesNodegroups(clusterId)
+    }
+
+    async createKubernetesNodegroup(cloud: CloudProvider, clusterId: string, input: CreateKubernetesNodegroupInput): Promise<KubernetesNodegroup> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.createKubernetesNodegroup) throw new NotSupportedError(`Nodegroup creation is not supported for ${cloud}/k8s`)
+        return adapter.createKubernetesNodegroup(clusterId, input)
+    }
+
+    async deleteKubernetesNodegroup(cloud: CloudProvider, clusterId: string, nodegroupId: string): Promise<void> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.deleteKubernetesNodegroup) throw new NotSupportedError(`Nodegroup deletion is not supported for ${cloud}/k8s`)
+        await adapter.deleteKubernetesNodegroup(clusterId, nodegroupId)
+    }
+
+    async listKubernetesFargateProfiles(cloud: CloudProvider, clusterId: string): Promise<KubernetesFargateProfile[]> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.listKubernetesFargateProfiles) throw new NotSupportedError(`Fargate profiles are not supported for ${cloud}/k8s`)
+        return adapter.listKubernetesFargateProfiles(clusterId)
+    }
+
+    async createKubernetesFargateProfile(cloud: CloudProvider, clusterId: string, input: CreateKubernetesFargateProfileInput): Promise<KubernetesFargateProfile> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.createKubernetesFargateProfile) throw new NotSupportedError(`Fargate profile creation is not supported for ${cloud}/k8s`)
+        return adapter.createKubernetesFargateProfile(clusterId, input)
+    }
+
+    async deleteKubernetesFargateProfile(cloud: CloudProvider, clusterId: string, profileId: string): Promise<void> {
+        const adapter = this.requireAdapter(cloud, 'k8s')
+        if (!adapter.deleteKubernetesFargateProfile) throw new NotSupportedError(`Fargate profile deletion is not supported for ${cloud}/k8s`)
+        await adapter.deleteKubernetesFargateProfile(clusterId, profileId)
+    }
+
     private requireAdapter(cloud: CloudProvider, service: CloudServiceType) {
         const adapter = this.registry.get(cloud, service)
         if (!adapter) throw new NotSupportedError(`No adapter registered for ${cloud}/${service}`)
@@ -308,4 +348,3 @@ function unavailableReason(
     if (availability === 'available') return undefined
     return `No ${cloud.toUpperCase()} adapter is registered for ${displayName} yet.`
 }
-

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -51,6 +51,18 @@ export const apiEndpointKeys = {
         list: "clouds.services.nosql.items.list",
       },
     },
+    k8s: {
+      nodegroups: {
+        list: "clouds.services.k8s.nodegroups.list",
+        create: "clouds.services.k8s.nodegroups.create",
+        delete: "clouds.services.k8s.nodegroups.delete",
+      },
+      fargateProfiles: {
+        list: "clouds.services.k8s.fargate-profiles.list",
+        create: "clouds.services.k8s.fargate-profiles.create",
+        delete: "clouds.services.k8s.fargate-profiles.delete",
+      },
+    },
   },
   aws: {
     eks: {
@@ -367,6 +379,54 @@ export const endpointRegistry: EndpointRegistry = new Map([
     {
       path: "/clouds/:cloud/services/nosql/resources/:id/items",
       method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.nodegroups.list,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/nodegroups",
+      method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.nodegroups.create,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/nodegroups",
+      method: "POST",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.nodegroups.delete,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/nodegroups/:nodegroupId",
+      method: "DELETE",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.fargateProfiles.list,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/fargate-profiles",
+      method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.fargateProfiles.create,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/fargate-profiles",
+      method: "POST",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.k8s.fargateProfiles.delete,
+    {
+      path: "/clouds/:cloud/services/k8s/resources/:id/fargate-profiles/:profileId",
+      method: "DELETE",
       telemetry: { service: "cloud-proxy" },
     },
   ],

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -7,7 +7,18 @@ import type {
   CloudServiceType,
   CloudStatus,
 } from "@/types/cloud";
-import type { CloudResource, CosmosContainer, CosmosItem, CosmosQueryResult, NoSqlItem, StorageObjectList } from "@/types/resource";
+import type {
+  CloudResource,
+  CosmosContainer,
+  CosmosItem,
+  CosmosQueryResult,
+  CreateKubernetesFargateProfileInput,
+  CreateKubernetesNodegroupInput,
+  KubernetesFargateProfile,
+  KubernetesNodegroup,
+  NoSqlItem,
+  StorageObjectList,
+} from "@/types/resource";
 import type { ServiceSchema } from "@/types/schema";
 import { getAccountId } from "@/lib/accountStore";
 
@@ -355,6 +366,82 @@ export async function listNoSqlItems(
     { cloud, id: resourceId },
   );
   return res.data;
+}
+
+export async function listKubernetesNodegroups(
+  cloud: CloudProvider,
+  clusterId: string,
+  signal?: AbortSignal,
+): Promise<KubernetesNodegroup[]> {
+  const res = await apiClient.call<KubernetesNodegroup[]>(
+    apiEndpointKeys.clouds.k8s.nodegroups.list,
+    requestOptions(cloud, "k8s", {signal}),
+    {cloud, id: clusterId},
+  )
+  return res.data
+}
+
+export async function createKubernetesNodegroup(
+  cloud: CloudProvider,
+  clusterId: string,
+  input: CreateKubernetesNodegroupInput,
+): Promise<KubernetesNodegroup> {
+  const res = await apiClient.call<KubernetesNodegroup, CreateKubernetesNodegroupInput>(
+    apiEndpointKeys.clouds.k8s.nodegroups.create,
+    requestOptions(cloud, "k8s", {body: input}),
+    {cloud, id: clusterId},
+  )
+  return res.data
+}
+
+export async function deleteKubernetesNodegroup(
+  cloud: CloudProvider,
+  clusterId: string,
+  nodegroupId: string,
+): Promise<void> {
+  await apiClient.call<void>(
+    apiEndpointKeys.clouds.k8s.nodegroups.delete,
+    requestOptions(cloud, "k8s"),
+    {cloud, id: clusterId, nodegroupId},
+  )
+}
+
+export async function listKubernetesFargateProfiles(
+  cloud: CloudProvider,
+  clusterId: string,
+  signal?: AbortSignal,
+): Promise<KubernetesFargateProfile[]> {
+  const res = await apiClient.call<KubernetesFargateProfile[]>(
+    apiEndpointKeys.clouds.k8s.fargateProfiles.list,
+    requestOptions(cloud, "k8s", {signal}),
+    {cloud, id: clusterId},
+  )
+  return res.data
+}
+
+export async function createKubernetesFargateProfile(
+  cloud: CloudProvider,
+  clusterId: string,
+  input: CreateKubernetesFargateProfileInput,
+): Promise<KubernetesFargateProfile> {
+  const res = await apiClient.call<KubernetesFargateProfile, CreateKubernetesFargateProfileInput>(
+    apiEndpointKeys.clouds.k8s.fargateProfiles.create,
+    requestOptions(cloud, "k8s", {body: input}),
+    {cloud, id: clusterId},
+  )
+  return res.data
+}
+
+export async function deleteKubernetesFargateProfile(
+  cloud: CloudProvider,
+  clusterId: string,
+  profileId: string,
+): Promise<void> {
+  await apiClient.call<void>(
+    apiEndpointKeys.clouds.k8s.fargateProfiles.delete,
+    requestOptions(cloud, "k8s"),
+    {cloud, id: clusterId, profileId},
+  )
 }
 
 function requestOptions<TBody = unknown>(

--- a/packages/frontend/src/features/k8s/K8sEngineDetails.tsx
+++ b/packages/frontend/src/features/k8s/K8sEngineDetails.tsx
@@ -1,19 +1,25 @@
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
 import {useState} from 'react'
 import {Plus, Trash2} from 'lucide-react'
-import type {EksFargateProfile, EksNodegroup} from '@/api/aws/eks.api'
 import {
-    useCreateEksFargateProfileMutation,
-    useCreateEksNodegroupMutation,
-    useDeleteEksFargateProfileMutation,
-    useDeleteEksNodegroupMutation,
-} from '@/api/aws/eks.mutations'
+    createKubernetesFargateProfile,
+    createKubernetesNodegroup,
+    deleteKubernetesFargateProfile,
+    deleteKubernetesNodegroup,
+    listKubernetesFargateProfiles,
+    listKubernetesNodegroups,
+} from '@/api/cloudProxyClient'
+import {cloudQueryKeys} from '@/api/queries/cloudQueries'
 import {
-    useEksFargateProfilesQuery,
-    useEksNodegroupsQuery,
-} from '@/api/aws/eks.queries'
+    type CreateKubernetesFargateProfileInput,
+    type CreateKubernetesNodegroupInput,
+    type KubernetesFargateProfile,
+    type KubernetesNodegroup,
+} from '@/types/resource'
+import type {CloudProvider} from '@/types/cloud'
 
 interface K8sEngineDetailsProps {
-    cloud: string
+    cloud: CloudProvider
     clusterName: string
 }
 
@@ -29,16 +35,29 @@ export function K8sEngineDetails({cloud, clusterName}: K8sEngineDetailsProps) {
 
     return (
         <>
-            <EksNodegroupsSection clusterName={clusterName}/>
-            <EksFargateProfilesSection clusterName={clusterName}/>
+            <EksNodegroupsSection cloud={cloud} clusterName={clusterName}/>
+            <EksFargateProfilesSection cloud={cloud} clusterName={clusterName}/>
         </>
     )
 }
 
-function EksNodegroupsSection({clusterName}: {clusterName: string}) {
-    const nodegroupsQuery = useEksNodegroupsQuery(clusterName)
-    const createNodegroup = useCreateEksNodegroupMutation()
-    const deleteNodegroup = useDeleteEksNodegroupMutation()
+function EksNodegroupsSection({cloud, clusterName}: {cloud: CloudProvider; clusterName: string}) {
+    const queryClient = useQueryClient()
+    const queryKey = ['k8s', cloud, clusterName, 'nodegroups'] as const
+    const nodegroupsQuery = useQuery({
+        queryKey,
+        queryFn: ({signal}) => listKubernetesNodegroups(cloud, clusterName, signal),
+        refetchInterval: 30_000,
+    })
+    const createNodegroup = useMutation({
+        mutationFn: (input: CreateKubernetesNodegroupInput) => createKubernetesNodegroup(cloud, clusterName, input),
+        onSuccess: () => invalidateK8sQueries(queryClient, cloud, clusterName),
+    })
+    const deleteNodegroup = useMutation({
+        mutationFn: (nodegroupId: string) => deleteKubernetesNodegroup(cloud, clusterName, nodegroupId),
+        onSuccess: () => invalidateK8sQueries(queryClient, cloud, clusterName),
+    })
+    const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null)
     const [form, setForm] = useState({
         name: '',
         nodeRole: '',
@@ -65,17 +84,14 @@ function EksNodegroupsSection({clusterName}: {clusterName: string}) {
                     if (!canCreate) return
 
                     createNodegroup.mutate({
-                        clusterName,
-                        nodegroup: {
-                            name: form.name.trim(),
-                            nodeRole: form.nodeRole.trim(),
-                            subnets: parseCsv(form.subnets),
-                            instanceTypes: parseCsv(form.instanceTypes),
-                            scalingConfig: {
-                                minSize: Number(form.minSize),
-                                desiredSize: Number(form.desiredSize),
-                                maxSize: Number(form.maxSize),
-                            },
+                        name: form.name.trim(),
+                        nodeRole: form.nodeRole.trim(),
+                        subnets: parseCsv(form.subnets),
+                        instanceTypes: parseCsv(form.instanceTypes),
+                        scalingConfig: {
+                            minSize: Number(form.minSize),
+                            desiredSize: Number(form.desiredSize),
+                            maxSize: Number(form.maxSize),
                         },
                     })
                 }}
@@ -95,20 +111,39 @@ function EksNodegroupsSection({clusterName}: {clusterName: string}) {
             {createNodegroup.isError && <p className="error-text compact-text">{errorMessage(createNodegroup.error)}</p>}
             {deleteNodegroup.isError && <p className="error-text compact-text">{errorMessage(deleteNodegroup.error)}</p>}
             <NodegroupsList
-                deletingName={deleteNodegroup.variables?.nodegroupName}
+                deleteCandidate={deleteCandidate}
+                deletingName={deleteNodegroup.variables}
                 isError={nodegroupsQuery.isError}
                 isLoading={nodegroupsQuery.isLoading}
                 nodegroups={nodegroupsQuery.data ?? []}
-                onDelete={(nodegroupName) => deleteNodegroup.mutate({clusterName, nodegroupName})}
+                onCancelDelete={() => setDeleteCandidate(null)}
+                onConfirmDelete={(nodegroupName) => {
+                    deleteNodegroup.mutate(nodegroupName)
+                    setDeleteCandidate(null)
+                }}
+                onRequestDelete={setDeleteCandidate}
             />
         </section>
     )
 }
 
-function EksFargateProfilesSection({clusterName}: {clusterName: string}) {
-    const profilesQuery = useEksFargateProfilesQuery(clusterName)
-    const createProfile = useCreateEksFargateProfileMutation()
-    const deleteProfile = useDeleteEksFargateProfileMutation()
+function EksFargateProfilesSection({cloud, clusterName}: {cloud: CloudProvider; clusterName: string}) {
+    const queryClient = useQueryClient()
+    const queryKey = ['k8s', cloud, clusterName, 'fargate-profiles'] as const
+    const profilesQuery = useQuery({
+        queryKey,
+        queryFn: ({signal}) => listKubernetesFargateProfiles(cloud, clusterName, signal),
+        refetchInterval: 30_000,
+    })
+    const createProfile = useMutation({
+        mutationFn: (input: CreateKubernetesFargateProfileInput) => createKubernetesFargateProfile(cloud, clusterName, input),
+        onSuccess: () => invalidateK8sQueries(queryClient, cloud, clusterName),
+    })
+    const deleteProfile = useMutation({
+        mutationFn: (profileId: string) => deleteKubernetesFargateProfile(cloud, clusterName, profileId),
+        onSuccess: () => invalidateK8sQueries(queryClient, cloud, clusterName),
+    })
+    const [deleteCandidate, setDeleteCandidate] = useState<string | null>(null)
     const [form, setForm] = useState({
         name: '',
         roleArn: '',
@@ -133,16 +168,13 @@ function EksFargateProfilesSection({clusterName}: {clusterName: string}) {
                     if (!canCreate) return
 
                     createProfile.mutate({
-                        clusterName,
-                        profile: {
-                            name: form.name.trim(),
-                            podExecutionRoleArn: form.roleArn.trim(),
-                            subnets: parseCsv(form.subnets),
-                            selectors: [{
-                                namespace: form.namespace.trim(),
-                                labels: parseKeyValueCsv(form.labels),
-                            }],
-                        },
+                        name: form.name.trim(),
+                        podExecutionRoleArn: form.roleArn.trim(),
+                        subnets: parseCsv(form.subnets),
+                        selectors: [{
+                            namespace: form.namespace.trim(),
+                            labels: parseKeyValueCsv(form.labels),
+                        }],
                     })
                 }}
             >
@@ -159,11 +191,17 @@ function EksFargateProfilesSection({clusterName}: {clusterName: string}) {
             {createProfile.isError && <p className="error-text compact-text">{errorMessage(createProfile.error)}</p>}
             {deleteProfile.isError && <p className="error-text compact-text">{errorMessage(deleteProfile.error)}</p>}
             <FargateProfilesList
-                deletingName={deleteProfile.variables?.profileName}
+                deleteCandidate={deleteCandidate}
+                deletingName={deleteProfile.variables}
                 isError={profilesQuery.isError}
                 isLoading={profilesQuery.isLoading}
                 profiles={profilesQuery.data ?? []}
-                onDelete={(profileName) => deleteProfile.mutate({clusterName, profileName})}
+                onCancelDelete={() => setDeleteCandidate(null)}
+                onConfirmDelete={(profileName) => {
+                    deleteProfile.mutate(profileName)
+                    setDeleteCandidate(null)
+                }}
+                onRequestDelete={setDeleteCandidate}
             />
         </section>
     )
@@ -174,13 +212,19 @@ function NodegroupsList({
     isLoading,
     isError,
     deletingName,
-    onDelete,
+    deleteCandidate,
+    onRequestDelete,
+    onConfirmDelete,
+    onCancelDelete,
 }: {
-    nodegroups: EksNodegroup[]
+    nodegroups: KubernetesNodegroup[]
     isLoading: boolean
     isError: boolean
     deletingName?: string
-    onDelete: (nodegroupName: string) => void
+    deleteCandidate: string | null
+    onRequestDelete: (nodegroupName: string) => void
+    onConfirmDelete: (nodegroupName: string) => void
+    onCancelDelete: () => void
 }) {
     if (isLoading) return <p className="muted compact-text">Loading nodegroups.</p>
     if (isError) return <p className="error-text compact-text">Failed to load nodegroups.</p>
@@ -194,15 +238,22 @@ function NodegroupsList({
                         <strong>{nodegroup.name}</strong>
                         <span>{nodegroup.instanceTypes.join(', ') || 'No instance types'} · {formatScaling(nodegroup)}</span>
                     </div>
-                    <button
-                        aria-label={`Delete ${nodegroup.name}`}
-                        className="icon-btn danger"
-                        type="button"
-                        disabled={deletingName === nodegroup.name}
-                        onClick={() => onDelete(nodegroup.name)}
-                    >
-                        <Trash2 size={13}/>
-                    </button>
+                    {deleteCandidate === nodegroup.name ? (
+                        <span className="inline-actions">
+                            <button className="button compact danger" type="button" onClick={() => onConfirmDelete(nodegroup.name)}>Delete</button>
+                            <button className="button compact" type="button" onClick={onCancelDelete}>Cancel</button>
+                        </span>
+                    ) : (
+                        <button
+                            aria-label={`Delete ${nodegroup.name}`}
+                            className="icon-btn danger"
+                            type="button"
+                            disabled={deletingName === nodegroup.name}
+                            onClick={() => onRequestDelete(nodegroup.name)}
+                        >
+                            <Trash2 size={13}/>
+                        </button>
+                    )}
                 </div>
             ))}
         </div>
@@ -214,13 +265,19 @@ function FargateProfilesList({
     isLoading,
     isError,
     deletingName,
-    onDelete,
+    deleteCandidate,
+    onRequestDelete,
+    onConfirmDelete,
+    onCancelDelete,
 }: {
-    profiles: EksFargateProfile[]
+    profiles: KubernetesFargateProfile[]
     isLoading: boolean
     isError: boolean
     deletingName?: string
-    onDelete: (profileName: string) => void
+    deleteCandidate: string | null
+    onRequestDelete: (profileName: string) => void
+    onConfirmDelete: (profileName: string) => void
+    onCancelDelete: () => void
 }) {
     if (isLoading) return <p className="muted compact-text">Loading Fargate profiles.</p>
     if (isError) return <p className="error-text compact-text">Failed to load Fargate profiles.</p>
@@ -234,15 +291,22 @@ function FargateProfilesList({
                         <strong>{profile.name}</strong>
                         <span>{profile.selectors.map((selector) => selector.namespace ?? '*').join(', ') || 'No selectors'}</span>
                     </div>
-                    <button
-                        aria-label={`Delete ${profile.name}`}
-                        className="icon-btn danger"
-                        type="button"
-                        disabled={deletingName === profile.name}
-                        onClick={() => onDelete(profile.name)}
-                    >
-                        <Trash2 size={13}/>
-                    </button>
+                    {deleteCandidate === profile.name ? (
+                        <span className="inline-actions">
+                            <button className="button compact danger" type="button" onClick={() => onConfirmDelete(profile.name)}>Delete</button>
+                            <button className="button compact" type="button" onClick={onCancelDelete}>Cancel</button>
+                        </span>
+                    ) : (
+                        <button
+                            aria-label={`Delete ${profile.name}`}
+                            className="icon-btn danger"
+                            type="button"
+                            disabled={deletingName === profile.name}
+                            onClick={() => onRequestDelete(profile.name)}
+                        >
+                            <Trash2 size={13}/>
+                        </button>
+                    )}
                 </div>
             ))}
         </div>
@@ -265,7 +329,7 @@ function parseKeyValueCsv(value: string) {
     )
 }
 
-function formatScaling(nodegroup: EksNodegroup) {
+function formatScaling(nodegroup: KubernetesNodegroup) {
     const scaling = nodegroup.scalingConfig
     if (!scaling) return 'No scaling config'
     return `${scaling.minSize ?? '?'}/${scaling.desiredSize ?? '?'}/${scaling.maxSize ?? '?'}`
@@ -274,4 +338,9 @@ function formatScaling(nodegroup: EksNodegroup) {
 function errorMessage(error: unknown) {
     if (error instanceof Error) return error.message
     return 'The EKS operation failed.'
+}
+
+function invalidateK8sQueries(queryClient: ReturnType<typeof useQueryClient>, cloud: CloudProvider, clusterName: string) {
+    void queryClient.invalidateQueries({queryKey: ['k8s', cloud, clusterName]})
+    void queryClient.invalidateQueries({queryKey: cloudQueryKeys.resources(cloud, 'k8s')})
 }

--- a/packages/frontend/src/features/k8s/K8sEngineDetails.tsx
+++ b/packages/frontend/src/features/k8s/K8sEngineDetails.tsx
@@ -342,5 +342,6 @@ function errorMessage(error: unknown) {
 
 function invalidateK8sQueries(queryClient: ReturnType<typeof useQueryClient>, cloud: CloudProvider, clusterName: string) {
     void queryClient.invalidateQueries({queryKey: ['k8s', cloud, clusterName]})
+    void queryClient.invalidateQueries({queryKey: ['cloud-resources', cloud, 'k8s']})
     void queryClient.invalidateQueries({queryKey: cloudQueryKeys.resources(cloud, 'k8s')})
 }

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -2012,6 +2012,14 @@ pre,
     font-size: 11px;
 }
 
+.snapshot-row .inline-actions {
+    display: flex;
+    flex: none;
+    gap: 6px;
+    overflow: visible;
+    white-space: normal;
+}
+
 .error-text {
     color: #f87171;
 }

--- a/packages/frontend/src/lib/capabilities.ts
+++ b/packages/frontend/src/lib/capabilities.ts
@@ -1,7 +1,7 @@
-import type {CapabilitySchema, CapabilityStatus, ObjectActionName, ResourceActionName} from '@/types/schema'
+import type {CapabilitySchema, CapabilityStatus, KubernetesActionName, ObjectActionName, ResourceActionName} from '@/types/schema'
 import type {CloudAvailability} from '@/types/cloud'
 
-export type CapabilityActionName = ResourceActionName | ObjectActionName
+export type CapabilityActionName = ResourceActionName | ObjectActionName | KubernetesActionName
 export type AnyCapability = CapabilitySchema<CapabilityActionName>
 export type CapabilityInput<TAction extends CapabilityActionName> = CapabilitySchema<TAction> | TAction
 
@@ -19,6 +19,12 @@ const actionLabels: Record<CapabilityActionName, string> = {
     stop: 'Stop',
     reboot: 'Reboot',
     updateTags: 'Edit tags',
+    listNodegroups: 'List nodegroups',
+    createNodegroup: 'Create nodegroup',
+    deleteNodegroup: 'Delete nodegroup',
+    listFargateProfiles: 'List Fargate profiles',
+    createFargateProfile: 'Create Fargate profile',
+    deleteFargateProfile: 'Delete Fargate profile',
 }
 
 export function normalizeCapabilities<TAction extends CapabilityActionName>(capabilities: Array<CapabilityInput<TAction>> = []): Array<CapabilitySchema<TAction>> {

--- a/packages/frontend/src/pages/CloudExplorerPage.tsx
+++ b/packages/frontend/src/pages/CloudExplorerPage.tsx
@@ -127,6 +127,7 @@ function ServiceInfoDialog({
                 normalizeCapabilities([
                     ...(schema.capabilities.resourceActions ?? []),
                     ...(schema.capabilities.objectActions ?? []),
+                    ...(schema.capabilities.kubernetesActions ?? []),
                 ]),
                 status?.runtime === 'reachable',
             ),

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -58,3 +58,53 @@ export interface NoSqlItem {
     key: Record<string, unknown>
     document: Record<string, unknown>
 }
+
+export interface KubernetesNodegroup {
+    id: string
+    name: string
+    clusterId: string
+    arn: string | null
+    status: string | null
+    version: string | null
+    releaseVersion: string | null
+    createdAt: string | null
+    modifiedAt: string | null
+    capacityType: string | null
+    instanceTypes: string[]
+    subnets: string[]
+    nodeRole: string | null
+    scalingConfig: {minSize?: number; maxSize?: number; desiredSize?: number} | null
+    labels: Record<string, string>
+    tags: Record<string, string>
+}
+
+export interface CreateKubernetesNodegroupInput {
+    name: string
+    nodeRole: string
+    subnets: string[]
+    instanceTypes?: string[]
+    scalingConfig?: {minSize?: number; maxSize?: number; desiredSize?: number}
+    labels?: Record<string, string>
+    tags?: Record<string, string>
+}
+
+export interface KubernetesFargateProfile {
+    id: string
+    name: string
+    clusterId: string
+    arn: string | null
+    status: string | null
+    createdAt: string | null
+    podExecutionRoleArn: string | null
+    subnets: string[]
+    selectors: Array<{namespace: string | null; labels: Record<string, string>}>
+    tags: Record<string, string>
+}
+
+export interface CreateKubernetesFargateProfileInput {
+    name: string
+    podExecutionRoleArn: string
+    subnets?: string[]
+    selectors: Array<{namespace: string; labels?: Record<string, string>}>
+    tags?: Record<string, string>
+}

--- a/packages/frontend/src/types/schema.ts
+++ b/packages/frontend/src/types/schema.ts
@@ -15,6 +15,13 @@ export type ResourceActionName =
     | 'reboot'
     | 'updateTags'
 export type ObjectActionName = 'list' | 'upload' | 'download' | 'delete' | 'createFolder' | 'copy'
+export type KubernetesActionName =
+    | 'listNodegroups'
+    | 'createNodegroup'
+    | 'deleteNodegroup'
+    | 'listFargateProfiles'
+    | 'createFargateProfile'
+    | 'deleteFargateProfile'
 export type CapabilityStatus = 'available' | 'blocked' | 'partial' | 'coming_soon'
 
 export interface CapabilitySchema<TAction extends string> {
@@ -64,6 +71,7 @@ export interface ServiceSchema {
     capabilities?: {
         resourceActions?: Array<CapabilitySchema<ResourceActionName> | ResourceActionName>
         objectActions?: Array<CapabilitySchema<ObjectActionName> | ObjectActionName>
+        kubernetesActions?: Array<CapabilitySchema<KubernetesActionName> | KubernetesActionName>
     }
     filters: FieldSchema[]
     columns: TableColumnSchema[]


### PR DESCRIPTION
Introduce provider-neutral types for Kubernetes nodegroups and Fargate profiles. Implement API routes and Cloud Proxy service methods for CRUD operations on EKS nodegroups and Fargate profiles. Update AWS EKS adapter to support these new Kubernetes actions, including input validation. Refactor frontend EKS details page to use the generic cloud proxy client. Enhance capability schema and UI to reflect new Kubernetes actions. Add comprehensive tests for API routes and adapter.

close #106 

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [X] Frontend (`packages/frontend`)
- [X] API / Cloud Proxy (`packages/api`)
- [X] Cloud Explorer adapter / schema
- [X] Build / CI / Docker

## Verification

Tested against AWS EKS via Floci core running from the current `main` branch (`http://localhost:4566`).

- Created a real local VPC and subnet through Floci EC2.
- Created an EKS cluster using AWS CLI and selected it in Cloud Explorer → AWS → EKS.
- Created a managed nodegroup from the cluster inspector.
- Confirmed the nodegroup appears in the inspector and through `aws eks list-nodegroups`.
- Created a Fargate profile from the same inspector.
- Confirmed the profile appears in the inspector and through `aws eks list-fargate-profiles`.
- Verified delete actions require explicit confirmation and remove the selected nodegroup or Fargate profile.
- Confirmed the inspector uses Cloud Proxy routes, not the legacy `/api/eks/*` endpoints.

### Automated checks

- API and frontend type-check passed.
- Frontend lint and production build passed.

### UI

Attached screenshots show:
- The selected EKS cluster with managed nodegroups and Fargate profiles.
- Create forms for both resource types.
- The inline delete confirmation state.

<!-- How did you verify this? Which cloud + service did you test against
     (e.g. AWS S3 via Floci core, Azure Blob via Floci-AZ)? -->
<!-- For UI changes, please attach before/after screenshots. -->

## Checklist

- [X] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [X] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [ ] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [X] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
