### PR TITLE
feat(ses): Add AWS SES mailbox to Cloud Explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ cd packages/api && bun run scripts/service-matrix.ts
 | Databases | DynamoDB / Cosmos DB NoSQL / NoSQL | Yes (list, create, delete, inspect) | No | No |
 | Networking | Networking | Yes (list) | No | No |
 | Integration | API Gateway | Yes (list, create, delete, inspect) | No | No |
+| Integration | SES Mailbox / Email | Yes (list, inspect) | No | No |
 | Provisioning | CloudFormation / Infrastructure as Code | Yes (list, create, delete, inspect) | No | No |
 | Security | Secrets Manager / Key Vault | Yes (legacy page) | Yes (list, create, delete, inspect) | No |
 
@@ -195,6 +196,47 @@ Current gaps:
 
 - Resources, methods, deployments, and stages are not yet exposed.
 - No Azure or GCP API Gateway adapter yet.
+
+</details>
+
+<details>
+<summary><strong>Email / SES Mailbox</strong></summary>
+
+AWS SES email capture through the unified Cloud Explorer.
+
+- Lists emails actually captured by Floci SES.
+- Filters by subject, sender, and recipient.
+- Inspects sender, recipients, timestamp, and message type.
+- Displays HTML in a sandboxed preview, text bodies, and captured raw MIME data.
+- Clears the captured inbox after an explicit confirmation.
+
+Manual verification with the AWS CLI:
+
+```bash
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+export AWS_DEFAULT_REGION=us-east-1
+
+aws ses send-email \
+  --endpoint-url http://localhost:4566 \
+  --from sender@example.test \
+  --destination 'ToAddresses=recipient@example.test' \
+  --message 'Subject={Data="Floci SES test",Charset=utf-8},Body={Text={Data="Plain-text test email.",Charset=utf-8},Html={Data="<h1>Hello from Floci</h1><p>This should render in the SES preview.</p>",Charset=utf-8}}'
+```
+
+The email is captured by the local Floci runtime; it is not delivered externally. Open
+`/cloud-explorer/aws/email` and refresh the mailbox to inspect its Preview, Text, and
+Raw views. You can also inspect the captured messages directly with:
+
+```bash
+curl http://localhost:4566/_aws/ses
+```
+
+Current gaps:
+
+- Sending a test email from the UI is not wired yet; applications continue to send through their AWS SES SDK.
+- SES identities, templates, bulk email, configuration sets, and suppression lists are not exposed yet.
+- No Azure or GCP email adapter yet.
 
 </details>
 

--- a/packages/api/src/adapter-aws/AwsSesAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsSesAdapter.test.ts
@@ -1,0 +1,99 @@
+import {describe, expect, test} from 'bun:test'
+import {AwsSesAdapter} from './AwsSesAdapter'
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), {
+        status,
+        headers: {'content-type': 'application/json'},
+    })
+}
+
+describe('AwsSesAdapter', () => {
+    test('maps captured Floci emails to normalized mailbox resources', async () => {
+        const adapter = new AwsSesAdapter('http://floci.test', async () => jsonResponse({
+            messages: [{
+                Id: 'message-1',
+                Region: 'us-east-1',
+                Source: 'sender@example.test',
+                Destination: {ToAddresses: ['recipient@example.test'], CcAddresses: ['copy@example.test']},
+                ReplyToAddresses: ['reply@example.test'],
+                Subject: 'Welcome',
+                Body: {text_part: 'Hello', html_part: '<strong>Hello</strong>'},
+                Timestamp: '2026-08-30T12:00:00.000Z',
+            }],
+        }))
+
+        const resources = await adapter.list()
+
+        expect(resources).toEqual([expect.objectContaining({
+            id: 'message-1',
+            name: 'Welcome',
+            cloud: 'aws',
+            service: 'email',
+            type: 'email',
+            region: 'us-east-1',
+            createdAt: '2026-08-30T12:00:00.000Z',
+            status: 'captured',
+            metadata: expect.objectContaining({
+                source: 'sender@example.test',
+                toAddresses: ['recipient@example.test'],
+                ccAddresses: ['copy@example.test'],
+                replyToAddresses: ['reply@example.test'],
+                textBody: 'Hello',
+                htmlBody: '<strong>Hello</strong>',
+                messageType: 'simple',
+            }),
+        })])
+    })
+
+    test('filters messages by subject, sender, and recipients', async () => {
+        const adapter = new AwsSesAdapter('http://floci.test', async () => jsonResponse({
+            messages: [
+                {Id: 'welcome', Source: 'sender@example.test', Destination: {ToAddresses: ['a@example.test']}, Subject: 'Welcome'},
+                {Id: 'invoice', Source: 'billing@example.test', Destination: {ToAddresses: ['customer@example.test']}, Subject: 'Invoice'},
+            ],
+        }))
+
+        await expect(adapter.list({search: 'CUSTOMER'})).resolves.toMatchObject([{id: 'invoice'}])
+        await expect(adapter.list({search: 'sender'})).resolves.toMatchObject([{id: 'welcome'}])
+    })
+
+    test('gets one message through Floci inspection filtering', async () => {
+        let requestedUrl = ''
+        const adapter = new AwsSesAdapter('http://floci.test/', async (input) => {
+            requestedUrl = String(input)
+            return jsonResponse({messages: [{Id: 'message with space', Subject: 'Test'}]})
+        })
+
+        const message = await adapter.get('message with space')
+
+        expect(requestedUrl).toBe('http://floci.test/_aws/ses?id=message%20with%20space')
+        expect(message).toMatchObject({id: 'message with space', name: 'Test'})
+    })
+
+    test('clears the captured inbox through the Floci inspection endpoint', async () => {
+        let requestedUrl = ''
+        let method = ''
+        const adapter = new AwsSesAdapter('http://floci.test', async (input, init) => {
+            requestedUrl = String(input)
+            method = init?.method ?? ''
+            return new Response(null, {status: 200})
+        })
+
+        await adapter.clearEmailInbox()
+
+        expect(requestedUrl).toBe('http://floci.test/_aws/ses')
+        expect(method).toBe('DELETE')
+    })
+
+    test('returns the SES mailbox schema', () => {
+        const adapter = new AwsSesAdapter()
+
+        expect(adapter.schema()).toMatchObject({
+            cloud: 'aws',
+            service: 'email',
+            displayName: 'SES Mailbox',
+            actions: ['list', 'inspect'],
+        })
+    })
+})

--- a/packages/api/src/adapter-aws/AwsSesAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsSesAdapter.ts
@@ -1,0 +1,154 @@
+import {httpStatusToCloudError, NotSupportedError, RuntimeError, RuntimeUnavailableError} from '../cloud-spi/errors'
+import {awsSesEmailSchema} from '../cloud-spi/emailSchema'
+import type {CloudResource, CloudServiceAdapter, CreateResourceInput, ResourceQuery, ServiceSchema} from '../cloud-spi/types'
+
+interface FlociSesMessage {
+    Id?: string
+    Region?: string | null
+    Source?: string
+    Destination?: {
+        ToAddresses?: string[]
+        CcAddresses?: string[]
+        BccAddresses?: string[]
+    }
+    ReplyToAddresses?: string[]
+    Subject?: string
+    Body?: {
+        text_part?: string | null
+        html_part?: string | null
+    }
+    RawData?: string
+    Timestamp?: string
+}
+
+interface FlociSesInbox {
+    messages?: FlociSesMessage[]
+}
+
+type FetchLike = (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>
+
+/**
+ * Adapts Floci's documented SES inspection surface to normalized email resources.
+ * It deliberately does not send email: applications under test keep using the
+ * AWS SES SDK, and this mailbox shows exactly what the runtime captured.
+ */
+export class AwsSesAdapter implements CloudServiceAdapter {
+    readonly cloud = 'aws' as const
+    readonly service = 'email' as const
+
+    constructor(
+        private readonly endpoint = process.env.FLOCI_ENDPOINT ?? 'http://localhost:4566',
+        private readonly fetcher: FetchLike = globalThis.fetch,
+    ) {}
+
+    schema(): ServiceSchema {
+        return awsSesEmailSchema()
+    }
+
+    async list(query: ResourceQuery = {}): Promise<CloudResource[]> {
+        const messages = await this.fetchInbox()
+        const resources = messages.map(messageToResource)
+        return filterBySearch(resources, query.search)
+    }
+
+    async get(id: string): Promise<CloudResource | null> {
+        const messages = await this.fetchInbox(id)
+        const message = messages.find((entry) => entry.Id === id)
+        return message ? messageToResource(message) : null
+    }
+
+    async create(_input: CreateResourceInput): Promise<CloudResource> {
+        throw new NotSupportedError('Sending email from the mailbox is not implemented yet')
+    }
+
+    async delete(_id: string): Promise<void> {
+        throw new NotSupportedError('Deleting individual captured emails is not supported by Floci SES')
+    }
+
+    async clearEmailInbox(): Promise<void> {
+        await this.request('/_aws/ses', {method: 'DELETE'})
+    }
+
+    private async fetchInbox(id?: string): Promise<FlociSesMessage[]> {
+        const search = id ? `?id=${encodeURIComponent(id)}` : ''
+        const response = await this.request(`/_aws/ses${search}`, {method: 'GET'})
+        let body: FlociSesInbox
+        try {
+            body = await response.json() as FlociSesInbox
+        } catch (error) {
+            throw new RuntimeError('Floci SES inspection returned invalid JSON', {cause: error})
+        }
+        if (!Array.isArray(body.messages)) {
+            throw new RuntimeError('Floci SES inspection response did not contain messages')
+        }
+        return body.messages
+    }
+
+    private async request(path: string, init: RequestInit): Promise<Response> {
+        let response: Response
+        try {
+            response = await this.fetcher(`${this.endpoint.replace(/\/$/, '')}${path}`, init)
+        } catch (error) {
+            throw new RuntimeUnavailableError(`Cannot reach Floci SES at ${this.endpoint}`, {cause: error})
+        }
+        if (response.ok) return response
+
+        const detail = await response.text().catch(() => '')
+        throw httpStatusToCloudError(
+            response.status,
+            detail || `Floci SES inspection returned HTTP ${response.status}`,
+        )
+    }
+}
+
+function messageToResource(message: FlociSesMessage): CloudResource {
+    const id = message.Id ?? ''
+    const raw = typeof message.RawData === 'string'
+    return {
+        id,
+        name: message.Subject?.trim() || '(no subject)',
+        cloud: 'aws',
+        service: 'email',
+        type: 'email',
+        region: message.Region ?? null,
+        createdAt: message.Timestamp ?? null,
+        status: 'captured',
+        metadata: {
+            provider: 'aws',
+            emailService: 'ses',
+            source: message.Source ?? null,
+            toAddresses: message.Destination?.ToAddresses ?? [],
+            ccAddresses: message.Destination?.CcAddresses ?? [],
+            bccAddresses: message.Destination?.BccAddresses ?? [],
+            replyToAddresses: message.ReplyToAddresses ?? [],
+            textBody: message.Body?.text_part ?? null,
+            htmlBody: message.Body?.html_part ?? null,
+            rawData: message.RawData ?? null,
+            messageType: raw ? 'raw' : 'simple',
+        },
+    }
+}
+
+function filterBySearch(resources: CloudResource[], search?: string): CloudResource[] {
+    const normalized = search?.trim().toLowerCase()
+    if (!normalized) return resources
+    return resources.filter((resource) => {
+        const metadata = resource.metadata
+        const searchable = [
+            resource.name,
+            stringValue(metadata.source),
+            ...stringList(metadata.toAddresses),
+            ...stringList(metadata.ccAddresses),
+            ...stringList(metadata.bccAddresses),
+        ].join(' ').toLowerCase()
+        return searchable.includes(normalized)
+    })
+}
+
+function stringValue(value: unknown): string {
+    return typeof value === 'string' ? value : ''
+}
+
+function stringList(value: unknown): string[] {
+    return Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === 'string') : []
+}

--- a/packages/api/src/cloud-spi/emailSchema.ts
+++ b/packages/api/src/cloud-spi/emailSchema.ts
@@ -1,0 +1,36 @@
+import type {CapabilitySchema, CloudProvider, FieldSchema, ResourceActionName, ServiceSchema, TableColumnSchema} from './types'
+
+const emailColumns: TableColumnSchema[] = [
+    {name: 'name', label: 'Subject'},
+    {name: 'source', label: 'From', path: 'metadata.source', format: 'code'},
+    {name: 'to', label: 'To', path: 'metadata.toAddresses', format: 'list'},
+    {name: 'messageType', label: 'Type', path: 'metadata.messageType', format: 'badge'},
+    {name: 'createdAt', label: 'Captured At', format: 'datetime'},
+]
+
+const emailFilters: FieldSchema[] = [
+    {name: 'search', label: 'Search', type: 'text', required: false},
+]
+
+const emailResourceActions: CapabilitySchema<ResourceActionName>[] = [
+    {name: 'list', label: 'List captured emails', enabled: true, status: 'available', runtimeRequired: true},
+    {name: 'inspect', label: 'Inspect email content', enabled: true, status: 'available', runtimeRequired: false},
+]
+
+export function awsSesEmailSchema(): ServiceSchema {
+    return {
+        cloud: 'aws',
+        service: 'email',
+        displayName: 'SES Mailbox',
+        fields: [],
+        actions: ['list', 'inspect'],
+        capabilities: {resourceActions: emailResourceActions},
+        filters: emailFilters,
+        columns: emailColumns,
+    }
+}
+
+export function emailSchemaFor(cloud: CloudProvider): ServiceSchema | null {
+    if (cloud === 'aws') return awsSesEmailSchema()
+    return null
+}

--- a/packages/api/src/cloud-spi/serviceCatalog.ts
+++ b/packages/api/src/cloud-spi/serviceCatalog.ts
@@ -84,6 +84,13 @@ export const SERVICE_CATALOG = {
     },
     networking: {displayName: 'Networking', iconKey: 'networking', group: 'Networking', order: 10},
     apigateway: {displayName: 'API Gateway', iconKey: 'apigateway', group: 'Integration', order: 10},
+    email: {
+        displayName: 'Email',
+        displayNameByCloud: {aws: 'SES Mailbox'},
+        iconKey: 'email',
+        group: 'Integration',
+        order: 20,
+    },
     secrets: {
         displayName: 'Secrets Manager',
         displayNameByCloud: {azure: 'Key Vault'},

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -152,7 +152,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'dynamodb-table' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret' | 'rest-api' | 'stack'
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'dynamodb-table' | 'instance' | 'image' | 'vpc' | 'lambda' | 'azure-function' | 'gcp-function' | 'secret' | 'rest-api' | 'stack' | 'email'
     region: string | null
     createdAt: string | null
     status?: string | null
@@ -276,4 +276,6 @@ export interface CloudServiceAdapter {
     deleteCosmosItem?(databaseId: string, containerId: string, itemId: string, partitionKey?: string | null): Promise<void>
     queryCosmosItems?(databaseId: string, containerId: string, query: string): Promise<CosmosQueryResult>
     listNoSqlItems?(resourceId: string): Promise<NoSqlItem[]>
+    /** Clears the provider's locally captured email inbox, if it exposes one. */
+    clearEmailInbox?(): Promise<void>
 }

--- a/packages/api/src/cloudProxy.ts
+++ b/packages/api/src/cloudProxy.ts
@@ -18,6 +18,7 @@ import {AzureKeyVaultAdapter} from './adapter-azure/AzureKeyVaultAdapter'
 import {AwsServerlessAdapter} from './adapter-aws/AwsServerlessAdapter'
 import {AwsApiGatewayAdapter} from './adapter-aws/AwsApiGatewayAdapter'
 import {AwsCloudFormationAdapter} from './adapter-aws/AwsCloudFormationAdapter'
+import {AwsSesAdapter} from './adapter-aws/AwsSesAdapter'
 import {awsClientsForAccount, resolveAccountId} from './aws'
 import {createEc2Service} from './services/ec2'
 import {createEksService} from './services/eks'
@@ -46,6 +47,7 @@ export function createCloudAdapterRegistry(accountId?: string | null): CloudAdap
         new AwsServerlessAdapter(clients.lambda),
         new AwsApiGatewayAdapter(clients.apiGateway),
         new AwsCloudFormationAdapter(clients.cloudformation),
+        new AwsSesAdapter(),
         new AzureStorageAdapter(),
         new AzureDatabaseAdapter(),
         new AzureComputeAdapter(),

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -4,6 +4,7 @@ import {NotImplementedByRuntimeError, RuntimeUnavailableError, ValidationError} 
 import {azureDatabaseSchema} from '../cloud-spi/databaseSchema'
 import {awsDynamoDbSchema} from '../cloud-spi/dynamodbSchema'
 import {awsStorageSchema, azureStorageSchema, gcpStorageSchema} from '../cloud-spi/storageSchema'
+import {awsSesEmailSchema} from '../cloud-spi/emailSchema'
 import type {CloudProvider, CloudResource, CloudServiceAdapter, CosmosContainer, CosmosItem, CosmosQueryResult, CreateResourceInput, NoSqlItem} from '../cloud-spi/types'
 import {CloudAdapterRegistry} from '../registry/CloudAdapterRegistry'
 import {CloudProxyService} from '../service/CloudProxyService'
@@ -240,6 +241,23 @@ describe('cloud schema routes', () => {
         expect(res.status).toBe(200)
         expect(body[0].key).toEqual({pk: 'item-1'})
         expect(body[0].document.table).toBe('orders')
+    })
+
+    test('clears the SES mailbox through the email adapter', async () => {
+        let cleared = false
+        const app = appWithRoutes([mockAdapter('aws', {
+            service: 'email',
+            schema: awsSesEmailSchema,
+            clearEmailInbox: async () => {
+                cleared = true
+            },
+        })])
+
+        const res = await app.request('/api/clouds/aws/services/email/inbox', {method: 'DELETE'})
+
+        expect(res.status).toBe(200)
+        expect(await res.json()).toEqual({ok: true})
+        expect(cleared).toBeTrue()
     })
 
     test('creates and deletes Cosmos databases through the cloud database adapter', async () => {

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -149,6 +149,16 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         })
     })
 
+    app.delete('/:cloud/services/email/inbox', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            await svc(c).clearEmailInbox(cloud)
+            return c.json({ok: true})
+        })
+    })
+
     app.get('/:cloud/services/:service/resources/:id', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         const serviceType = c.req.param('service') as CloudServiceType

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -292,6 +292,12 @@ async invokeResource(
         return adapter.listNoSqlItems(resourceId)
     }
 
+    async clearEmailInbox(cloud: CloudProvider): Promise<void> {
+        const adapter = this.requireAdapter(cloud, 'email')
+        if (!adapter.clearEmailInbox) throw new NotSupportedError(`Inbox clearing is not supported for ${cloud}/email`)
+        await adapter.clearEmailInbox()
+    }
+
     private requireAdapter(cloud: CloudProvider, service: CloudServiceType) {
         const adapter = this.registry.get(cloud, service)
         if (!adapter) throw new NotSupportedError(`No adapter registered for ${cloud}/${service}`)
@@ -308,4 +314,3 @@ function unavailableReason(
     if (availability === 'available') return undefined
     return `No ${cloud.toUpperCase()} adapter is registered for ${displayName} yet.`
 }
-

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -51,6 +51,11 @@ export const apiEndpointKeys = {
         list: "clouds.services.nosql.items.list",
       },
     },
+    email: {
+      inbox: {
+        clear: "clouds.services.email.inbox.clear",
+      },
+    },
   },
   aws: {
     eks: {
@@ -367,6 +372,14 @@ export const endpointRegistry: EndpointRegistry = new Map([
     {
       path: "/clouds/:cloud/services/nosql/resources/:id/items",
       method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.email.inbox.clear,
+    {
+      path: "/clouds/:cloud/services/email/inbox",
+      method: "DELETE",
       telemetry: { service: "cloud-proxy" },
     },
   ],

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -130,6 +130,17 @@ export async function deleteCloudResource(
     { cloud, service, id },
   );
 }
+
+export async function clearEmailInbox(
+  cloud: CloudProvider,
+  signal?: AbortSignal,
+): Promise<void> {
+  await apiClient.call<void>(
+    apiEndpointKeys.clouds.email.inbox.clear,
+    requestOptions(cloud, "email", { signal }),
+    { cloud },
+  );
+}
 export interface ServerlessInvokeResult {
   statusCode: number;
   payload: string;

--- a/packages/frontend/src/components/DynamicResourceView.tsx
+++ b/packages/frontend/src/components/DynamicResourceView.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
-import { ChevronDown, ChevronUp, Info, Loader2, Plus, RefreshCw } from "lucide-react";
+import { ChevronDown, ChevronUp, Info, Loader2, Plus, RefreshCw, Trash2 } from "lucide-react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   createCloudResource,
+  clearEmailInbox,
   deleteCloudResource,
   getServiceSchema,
   listCloudResources,
@@ -60,6 +61,7 @@ export function DynamicResourceView({
     StorageObject | undefined
   >();
   const [createOpen, setCreateOpen] = useState(false);
+  const [clearConfirm, setClearConfirm] = useState(false);
   const resourcesKey = useMemo(
     () => ["cloud-resources", cloud, service, search],
     [cloud, service, search],
@@ -102,10 +104,22 @@ export function DynamicResourceView({
     },
   });
 
+  const clearInboxMut = useMutation({
+    mutationFn: () => clearEmailInbox(cloud),
+    onSuccess: () => {
+      setSelected(undefined);
+      setClearConfirm(false);
+      void qc.invalidateQueries({
+        queryKey: ["cloud-resources", cloud, service],
+      });
+    },
+  });
+
   useEffect(() => {
     setSelected(undefined);
     setSelectedObject(undefined);
     setCreateOpen(false);
+    setClearConfirm(false);
     setSearch("");
   }, [cloud, service]);
 
@@ -213,21 +227,51 @@ export function DynamicResourceView({
                   onChange={(event) => setSearch(event.target.value)}
                   placeholder="Filter resources"
                 />
-                <button
-                  className="button"
-                  type="button"
-                  disabled={!canCreateResource}
-                  title={createCapability?.reason}
-                  onClick={() => setCreateOpen((open) => !open)}
-                >
-                  <Plus size={14} />
-                  {createResourceLabel}
-                  {createOpen ? (
-                    <ChevronUp size={13} />
+                {service === "email" && (
+                  clearConfirm ? (
+                    <>
+                      <button
+                        className="button danger"
+                        type="button"
+                        disabled={!canUseRuntime || clearInboxMut.isPending}
+                        onClick={() => clearInboxMut.mutate()}
+                      >
+                        <Trash2 size={14} />
+                        {clearInboxMut.isPending ? "Clearing" : "Confirm clear"}
+                      </button>
+                      <button className="button" type="button" disabled={clearInboxMut.isPending} onClick={() => setClearConfirm(false)}>
+                        Cancel
+                      </button>
+                    </>
                   ) : (
-                    <ChevronDown size={13} />
-                  )}
-                </button>
+                    <button
+                      className="button danger"
+                      type="button"
+                      disabled={!canUseRuntime}
+                      onClick={() => setClearConfirm(true)}
+                    >
+                      <Trash2 size={14} />
+                      Clear inbox
+                    </button>
+                  )
+                )}
+                {canCreate && (
+                  <button
+                    className="button"
+                    type="button"
+                    disabled={!canCreateResource}
+                    title={createCapability?.reason}
+                    onClick={() => setCreateOpen((open) => !open)}
+                  >
+                    <Plus size={14} />
+                    {createResourceLabel}
+                    {createOpen ? (
+                      <ChevronUp size={13} />
+                    ) : (
+                      <ChevronDown size={13} />
+                    )}
+                  </button>
+                )}
                 <button
                   className="button"
                   type="button"
@@ -239,6 +283,13 @@ export function DynamicResourceView({
                 </button>
               </div>
             </div>
+            {service === "email" && clearInboxMut.isError && (
+              <p className="error-text compact-text" style={{ margin: "0 12px 10px" }}>
+                {clearInboxMut.error instanceof Error
+                  ? clearInboxMut.error.message
+                  : "Unable to clear the inbox."}
+              </p>
+            )}
             {canCreate && createOpen && (
               <div className="resource-create-inline">
                 {/*

--- a/packages/frontend/src/components/ResourceInspector.tsx
+++ b/packages/frontend/src/components/ResourceInspector.tsx
@@ -1,3 +1,4 @@
+import {useState} from 'react'
 import { useCreateRdsSnapshotMutation } from "@/api/aws/rds.mutations";
 import { useRdsSnapshotsQuery } from "@/api/aws/rds.queries";
 import { K8sEngineDetails } from "@/features/k8s/K8sEngineDetails";
@@ -46,6 +47,10 @@ export function ResourceInspector({
         <MetadataPanel metadata={object.metadata} />
       </aside>
     );
+  }
+
+  if (resource.type === 'email') {
+    return <EmailInspector key={resource.id} resource={resource} />
   }
 
   const tags = getTags(resource.metadata.tags);
@@ -175,6 +180,63 @@ export function ResourceInspector({
       <MetadataPanel metadata={resource.metadata} />
     </aside>
   );
+}
+
+function EmailInspector({resource}: {resource: CloudResource}) {
+  const [tab, setTab] = useState<'preview' | 'text' | 'raw'>('preview')
+  const source = getStringMetadata(resource.metadata.source) ?? '-'
+  const toAddresses = getStringList(resource.metadata.toAddresses)
+  const ccAddresses = getStringList(resource.metadata.ccAddresses)
+  const bccAddresses = getStringList(resource.metadata.bccAddresses)
+  const replyToAddresses = getStringList(resource.metadata.replyToAddresses)
+  const textBody = getStringMetadata(resource.metadata.textBody)
+  const htmlBody = getStringMetadata(resource.metadata.htmlBody)
+  const rawData = getStringMetadata(resource.metadata.rawData)
+  const hasPreview = Boolean(htmlBody || textBody)
+  const activeTab = tab === 'preview' && !hasPreview ? (rawData ? 'raw' : 'text') : tab
+
+  return (
+    <aside className="resource-inspector">
+      <div className="widget-header">
+        <h3 title={resource.name}>{resource.name}</h3>
+        <span className="badge neutral">{getStringMetadata(resource.metadata.messageType) ?? 'email'}</span>
+      </div>
+      <div className="inspector-grid">
+        <InspectorItem label="From" value={source} />
+        <InspectorItem label="To" value={toAddresses.join(', ') || '-'} />
+        {ccAddresses.length > 0 && <InspectorItem label="Cc" value={ccAddresses.join(', ')} />}
+        {bccAddresses.length > 0 && <InspectorItem label="Bcc" value={bccAddresses.join(', ')} />}
+        {replyToAddresses.length > 0 && <InspectorItem label="Reply-To" value={replyToAddresses.join(', ')} />}
+        <InspectorItem label="Captured At" value={resource.createdAt ?? '-'} />
+      </div>
+      <section className="inspector-section">
+        <div className="drawer-tabs" style={{marginBottom: 10}}>
+          <button className={`drawer-tab ${activeTab === 'preview' ? 'active' : ''}`} disabled={!hasPreview} onClick={() => setTab('preview')}>Preview</button>
+          <button className={`drawer-tab ${activeTab === 'text' ? 'active' : ''}`} disabled={!textBody} onClick={() => setTab('text')}>Text</button>
+          <button className={`drawer-tab ${activeTab === 'raw' ? 'active' : ''}`} disabled={!rawData} onClick={() => setTab('raw')}>Raw</button>
+        </div>
+        {activeTab === 'preview' && htmlBody ? (
+          <iframe
+            title="Email HTML preview"
+            sandbox=""
+            referrerPolicy="no-referrer"
+            srcDoc={safeEmailDocument(htmlBody)}
+            style={{width: '100%', minHeight: 260, border: '1px solid var(--border)', borderRadius: 4, background: '#fff'}}
+          />
+        ) : activeTab === 'preview' ? (
+          <pre className="metadata-block" style={{whiteSpace: 'pre-wrap', margin: 0}}>{textBody ?? 'No preview content captured.'}</pre>
+        ) : activeTab === 'text' ? (
+          <pre className="metadata-block" style={{whiteSpace: 'pre-wrap', margin: 0}}>{textBody ?? 'No text body captured.'}</pre>
+        ) : (
+          <pre className="metadata-block" style={{whiteSpace: 'pre-wrap', wordBreak: 'break-all', margin: 0}}>{rawData ?? 'No raw MIME data captured.'}</pre>
+        )}
+      </section>
+    </aside>
+  )
+}
+
+function safeEmailDocument(html: string): string {
+  return `<!doctype html><html><head><meta charset="utf-8"><meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src data:; style-src 'unsafe-inline'"></head><body>${html}</body></html>`
 }
 
 function ProviderDatabaseSection({ cloud }: { cloud: string }) {
@@ -367,6 +429,12 @@ function humanizeKey(value: string): string {
 
 function getStringMetadata(value: unknown): string | null {
   return typeof value === "string" ? value : null;
+}
+
+function getStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string")
+    : [];
 }
 
 function getBooleanMetadata(value: unknown): boolean | null {

--- a/packages/frontend/src/components/serviceIcons.ts
+++ b/packages/frontend/src/components/serviceIcons.ts
@@ -39,6 +39,7 @@ const SERVICE_ICONS: Record<string, LucideIcon> = {
     secrets: KeyRound,
     iac: Layers,
     messaging: MessageSquare,
+    email: MessageSquare,
     queue: MessageSquare,
     logs: ScrollText,
     iam: ShieldCheck,

--- a/packages/frontend/src/types/cloud.ts
+++ b/packages/frontend/src/types/cloud.ts
@@ -10,6 +10,7 @@ export type KnownCloudServiceType =
     | 'serverless'
     | 'secrets'
     | 'iac'
+    | 'email'
 
 /**
  * Deliberately open where the API's own type is closed.

--- a/packages/frontend/src/types/resource.ts
+++ b/packages/frontend/src/types/resource.ts
@@ -5,7 +5,7 @@ export interface CloudResource {
     name: string
     cloud: CloudProvider
     service: CloudServiceType
-    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'dynamodb-table' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret' | 'rest-api' | 'stack';
+    type: 'bucket' | 'container' | 'cluster' | 'db-instance' | 'cosmos-database' | 'dynamodb-table' | 'instance' | 'image' | 'vpc' | 'lambda' | "azure-function" | 'gcp-function' | 'secret' | 'rest-api' | 'stack' | 'email';
     region: string | null
     createdAt: string | null
     status?: string | null


### PR DESCRIPTION
Implement backend adapter for AWS SES email capture. Expose API to list, inspect, and clear captured emails. Introduce frontend UI for email resource inspection with preview, text, and raw views. Update service catalog, resource types, and documentation.

close #130 

## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [ ] Bug fix (`fix:`)
- [X] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [X] Frontend (`packages/frontend`)
- [X] API / Cloud Proxy (`packages/api`)
- [X] Cloud Explorer adapter / schema
- [X] Build / CI / Docker

## Verification

Tested against AWS SES via Floci core (`http://localhost:4566`).

- Sent a real local SES email with AWS CLI using `aws ses send-email`.
- Confirmed Floci captured it through `GET /_aws/ses`.
- Opened Cloud Explorer → AWS → SES Mailbox.
- Verified the captured email appears in the resource table with subject, sender, recipient, type, and timestamp.
- Verified the resource inspector renders the HTML Preview, Text, and Raw views.
- Verified Clear inbox removes captured messages only after explicit confirmation.

### UI

Attached screenshots show:
- The AWS CLI `MessageId` response.
- The captured message returned by Floci.
- The SES Mailbox table and HTML preview in Floci UI.

## Checklist

- [X] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [X] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [X] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [X] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
