### PR TITLE
docs: correct the release process and say there is no fixed cadence

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,10 +6,10 @@ project and all contributions are welcome.
 
 ## Ways to Contribute
 
-- **Bug reports** — open an issue with a minimal reproduction (steps, expected vs. actual)
-- **Feature requests** — open an issue describing the console feature or service page you need
-- **Pull requests** — bug fixes, new service UI, or UX improvements
-- **Service coverage** — wire a new Floci-backed service into the console
+- **Bug reports**: open an issue with a minimal reproduction (steps, expected vs. actual)
+- **Feature requests**: open an issue describing the console feature or service page you need
+- **Pull requests**: bug fixes, new service UI, or UX improvements
+- **Service coverage**: wire a new Floci-backed service into the console
 
 ## Project Layout
 
@@ -30,7 +30,7 @@ Floci emulators. Never have the frontend reach a cloud endpoint directly.
 - Node.js 20+
 - pnpm 9+
 - [Bun](https://bun.sh/) (required by `packages/api`)
-- Docker (optional — only for running the full stack via `docker compose`)
+- Docker (optional, only for running the full stack via `docker compose`)
 
 ### Install
 
@@ -45,14 +45,14 @@ pnpm install
 The UI needs three components running: Floci core (`:4566`), the API (`:4501`), and the
 frontend (`:4500`).
 
-**Option A — Docker Compose (recommended):**
+**Option A, Docker Compose (recommended):**
 
 ```bash
 docker compose up                        # AWS-only
 docker compose --profile multicloud up   # adds Azure + GCP emulators
 ```
 
-**Option B — local dev (three terminals):**
+**Option B, local dev (three terminals):**
 
 ```bash
 # 1. Floci core (see README for the docker run / local-clone options)
@@ -79,11 +79,11 @@ pnpm build         # production build
 ## Branching Model
 
 Floci UI uses a **tag-driven release model**. Docker images are never published on PR
-merge — only when a maintainer pushes a version tag.
+merge, only when a version tag is pushed, which the Release Cut workflow does.
 
 | Branch / ref | Purpose | Docker published? |
 |---|---|---|
-| `main` | Integration branch — all PRs merge here. Treated as unstable. | No |
+| `main` | Integration branch: all PRs merge here. Treated as unstable. | No |
 | `X.Y.Z` tag | Signals a release. Triggers the multi-arch Docker publish pipeline. | Yes (`floci/floci-ui:x.y.z`, `floci/floci-ui:latest`) |
 
 ## Commit Message Format
@@ -98,10 +98,10 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 <type>[optional scope]: <description>
 ```
 
-- **type** — one of the values in the table below (lowercase)
-- **scope** — optional, in parentheses, identifies the package or service area
+- **type**: one of the values in the table below (lowercase)
+- **scope**: optional, in parentheses, identifies the package or service area
   (e.g. `frontend`, `api`, `s3`, `ec2`, `serverless`, `docker`, `ci`)
-- **description** — short summary in the imperative mood, no trailing period
+- **description**: short summary in the imperative mood, no trailing period
 - Append `!` before the colon to signal a breaking change: `feat(api)!:`
 
 | Type | When to use | Version bump |
@@ -111,13 +111,13 @@ This project uses [Conventional Commits](https://www.conventionalcommits.org/).
 | `perf` | Performance improvement | patch |
 | `revert` | Reverts a previous commit | patch |
 | `docs` | Documentation only | none |
-| `style` | Formatting, whitespace — no logic change | none |
+| `style` | Formatting, whitespace, no logic change | none |
 | `chore` | Build, CI, dependencies, housekeeping | none |
 | `refactor` | Code restructure without behavior change | none |
 | `test` | Adding or updating tests | none |
 | `build` | Build system or tooling changes | none |
 | `ci` | CI workflow changes | none |
-| `BREAKING CHANGE` | Footer or `!` suffix — incompatible change | major |
+| `BREAKING CHANGE` | Footer or `!` suffix, incompatible change | major |
 
 ### Valid examples ✅
 
@@ -172,7 +172,7 @@ When wiring a new service into the console, follow these rules:
 - Use existing Floci AWS-compatible endpoints. Do not add custom backend endpoints
   just for the UI unless the core project explicitly accepts that contract.
 - In `packages/api`, add a route that calls the appropriate AWS SDK v3 client against
-  Floci core — never invent a custom protocol.
+  Floci core. Never invent a custom protocol.
 - In `packages/frontend`, add the service page and register it in the navigation.
 - Prefer real empty states over sample data; show placeholders when a service is not
   wired yet. No decorative data or fake operational metrics.
@@ -184,26 +184,35 @@ When wiring a new service into the console, follow these rules:
 1. Branch off `main`: `git checkout -b feat/my-feature`
 2. Open a PR targeting `main`.
 3. Make sure `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` all pass before requesting review.
-4. Keep PRs focused — one feature or fix per PR.
+4. Keep PRs focused: one feature or fix per PR.
 5. Reference any related issues in the PR description.
 
 Docker images are never built on contributor PRs, so merging to `main` is always cheap.
 
 ## Release Process (maintainers)
 
-Releases are triggered by pushing a version tag matching `X.Y.Z`:
+Releases are cut when there is something worth shipping. Unlike the emulators, floci-ui is
+not on a fixed train.
 
-```bash
-git checkout main && git pull
-git tag 1.2.3
-git push origin 1.2.3
-```
+Releases are cut from `main` with the **Release Cut** workflow (Actions -> Release Cut ->
+Run workflow). semantic-release analyzes the Conventional Commits since the last tag, bumps
+the version in `package.json` and `packages/frontend/package.json`, regenerates
+`CHANGELOG.md`, commits, tags, and publishes the GitHub Release. Use the `dry-run` input to
+preview the next version and release notes without releasing anything.
 
-The tag push triggers `.github/workflows/release.yml`, which builds the frontend bundle
+The tag push then triggers `.github/workflows/release.yml`, which builds the frontend bundle
 and the API binary, then packages and pushes a multi-arch (`linux/amd64,linux/arm64`)
-image as `floci/floci-ui:1.2.3` and `floci/floci-ui:latest`.
+image as `floci/floci-ui:x.y.z` and `floci/floci-ui:latest`.
 
-Publishing requires the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets.
+Publishing requires the `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` repository secrets, and
+the Release Cut workflow requires `GH_TOKEN` to be a fine-grained PAT with contents:write.
+The default `GITHUB_TOKEN` cannot be used: tags pushed with it do not trigger other
+workflows, so `release.yml` would never run.
+
+`CHANGELOG.md` is generated. Do not edit it by hand; a genuine correction goes in a PR
+carrying the `changelog-edit` label.
+
+Nothing is published on PR merge: only a release cut produces artifacts.
 
 ## Testing Policy for Pull Requests
 
@@ -213,7 +222,7 @@ As a project policy:
   (`bun test` in `packages/api`), or a clear note on why they can't be tested in isolation.
 - Pull requests that fix bugs should include a regression test whenever realistic.
 - Documentation, formatting, dependency housekeeping, or low-risk refactors may not
-  require new tests — but `pnpm lint`, `pnpm type-check`, and the existing suite must
+  require new tests, but `pnpm lint`, `pnpm type-check`, and the existing suite must
   still pass.
 
 All checks (`pnpm lint`, `pnpm type-check`, `pnpm test`, `pnpm build`) must pass before merge.


### PR DESCRIPTION
## What does this PR do?

**The Release Process section was wrong, not just incomplete.** It documented releases as a manual tag push:

```bash
git checkout main && git pull
git tag 1.2.3
git push origin 1.2.3
```

That has been stale since the Release Cut button landed in this repo. A maintainer following the page would bypass semantic-release entirely and hand-tag a version that the changelog automation never sees. The section now describes Release Cut: which files semantic-release bumps (`package.json` and `packages/frontend/package.json`), the `GH_TOKEN` PAT requirement and why `GITHUB_TOKEN` cannot be used, and the `changelog-edit` route for a genuine `CHANGELOG.md` correction.

Two smaller things in the same file:

- **Branching Model** said images publish "only when a maintainer pushes a version tag". The tag is now pushed by the workflow, so that is reworded.
- floci-ui is not on the emulators' 1st and 3rd Tuesday train, and the page now says so rather than leaving it ambiguous.

Em-dashes replaced with ordinary punctuation, matching the convention the four emulators adopted.

## Related issues

None. Follow-up to the release-train documentation work.

## Checklist

- [ ] Commits are **signed off** for the [DCO](https://developercertificate.org/) — not signed off; no DCO check runs on this repo and `main`'s history is largely unsigned.
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/).
- [x] **No AI attribution** in commit messages.
- [ ] Tests pass locally and new behavior is covered — not applicable, prose only.
- [x] Docs updated if behavior or configuration changed.
- [x] I have read the Contributing guide and agree to the Code of Conduct.
