### PR TITLE
fix(frontend): align dynamic form fields to top

### DIFF
--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -1287,7 +1287,7 @@ pre,
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
     gap: 8px 16px;
-    align-items: end;
+    align-items: start;
     padding: 0;
 }
 


### PR DESCRIPTION
## Summary

<!-- What does this PR do? Link any related issues with "Closes #N" -->

## Type of change

- [x] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [ ] Docs / chore

## Area

- [x] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification
I was exploring  floci UI, but when I explored aws s3 storage, the bucket and the region form fields were misaligned.
i fixed the css to align them properly.

BEFORE
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/625f6dc2-6b57-4636-885f-ce7f3c176d6c" />



AFTER
![image](https://github.com/user-attachments/assets/7b710b72-8f01-42bb-9dc7-4c9c595cc7c6)

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [ ] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)
