### PR TITLE
docs: link the community floci-dash console

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,18 @@ When adding new UI surface:
 - Keep placeholders explicit instead of inventing fake data.
 - Update this README when the visible UI surface changes.
 
+## Community Projects
+
+Floci UI is the first-party console, but it is not the only one. The community builds
+consoles for Floci too:
+
+- [floci-dash](https://github.com/ofsazib/floci-dash) — an AWS-Console-style dashboard
+  for the Floci AWS runtime built on Cloudscape Design. It ships as a single Docker image
+  and includes an EC2 web terminal. It targets the AWS runtime only, while Floci UI also
+  covers Azure and GCP, so pick whichever fits your stack.
+
+Building something for Floci? Open a PR to add it here.
+
 ## License
 
 [MIT](LICENSE) — part of the [Floci](https://floci.io) ecosystem.


### PR DESCRIPTION
## Summary

Adds a "Community Projects" section to the README, between Contributing and License,
linking https://github.com/ofsazib/floci-dash. floci-dash is a third-party,
MIT-licensed, Cloudscape-based AWS-Console-style dashboard for the Floci AWS runtime
(single Docker image, EC2 web terminal). The section notes it covers the AWS runtime
only while Floci UI also covers Azure and GCP, and invites other Floci tools to open
a PR to be listed.

## Type of change

- [ ] Bug fix (`fix:`)
- [ ] New feature / service UI (`feat:`)
- [ ] Breaking change (`feat!:` or `fix!:`)
- [x] Docs / chore

## Area

- [ ] Frontend (`packages/frontend`)
- [ ] API / Cloud Proxy (`packages/api`)
- [ ] Cloud Explorer adapter / schema
- [ ] Build / CI / Docker

## Verification

README only. Rendered the section in markdown preview and confirmed the link
resolves. No UI or runtime behavior changes.

## Checklist

- [x] `pnpm lint`, `pnpm type-check`, `pnpm test`, and `pnpm build` pass locally
- [ ] New or updated tests added where it makes sense (`bun test` in `packages/api`)
- [x] No fake/mock data added — unwired states stay empty or show an explicit placeholder
- [x] Commit messages / PR title follow [Conventional Commits](https://www.conventionalcommits.org/)