### PR TITLE
feat(nosql): add record creation

### DIFF
--- a/packages/api/src/adapter-aws/AwsDynamoDbAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsDynamoDbAdapter.test.ts
@@ -4,12 +4,13 @@ import {
     DeleteTableCommand,
     DescribeTableCommand,
     ListTablesCommand,
+    PutItemCommand,
     ScanCommand,
     type DynamoDBClient,
 } from '@aws-sdk/client-dynamodb'
 import {AwsDynamoDbAdapter} from './AwsDynamoDbAdapter'
 
-type Command = CreateTableCommand | DeleteTableCommand | DescribeTableCommand | ListTablesCommand | ScanCommand
+type Command = CreateTableCommand | DeleteTableCommand | DescribeTableCommand | ListTablesCommand | PutItemCommand | ScanCommand
 
 function fakeClient(send: (command: Command) => Promise<unknown>): DynamoDBClient {
     return {send} as unknown as DynamoDBClient
@@ -247,6 +248,87 @@ describe('AwsDynamoDbAdapter', () => {
 
         expect(result).toHaveLength(100)
         expect(scanCount).toBe(1)
+    })
+
+    test('puts a record using the table key types', async () => {
+        let captured: PutItemCommand | undefined
+        const client = fakeClient(async (command) => {
+            if (command instanceof DescribeTableCommand) {
+                return {Table: {
+                    KeySchema: [
+                        {AttributeName: 'accountId', KeyType: 'HASH'},
+                        {AttributeName: 'sequence', KeyType: 'RANGE'},
+                    ],
+                    AttributeDefinitions: [
+                        {AttributeName: 'accountId', AttributeType: 'S'},
+                        {AttributeName: 'sequence', AttributeType: 'N'},
+                    ],
+                }}
+            }
+            if (command instanceof PutItemCommand) {
+                captured = command
+                return {}
+            }
+            throw new Error('Unexpected command')
+        })
+
+        const result = await new AwsDynamoDbAdapter(client).putNoSqlItem('orders', {
+            accountId: 'acct-1',
+            sequence: '9007199254740993',
+            active: true,
+        })
+
+        expect(captured?.input).toEqual({
+            TableName: 'orders',
+            Item: {
+                accountId: {S: 'acct-1'},
+                sequence: {N: '9007199254740993'},
+                active: {BOOL: true},
+            },
+        })
+        expect(result).toEqual({
+            id: '{"accountId":"acct-1","sequence":"9007199254740993"}',
+            key: {accountId: 'acct-1', sequence: '9007199254740993'},
+            document: {accountId: 'acct-1', sequence: '9007199254740993', active: true},
+        })
+    })
+
+    test('accepts base64 for binary keys', async () => {
+        let captured: PutItemCommand | undefined
+        const client = fakeClient(async (command) => {
+            if (command instanceof DescribeTableCommand) {
+                return {Table: {
+                    KeySchema: [{AttributeName: 'id', KeyType: 'HASH'}],
+                    AttributeDefinitions: [{AttributeName: 'id', AttributeType: 'B'}],
+                }}
+            }
+            captured = command as PutItemCommand
+            return {}
+        })
+
+        const result = await new AwsDynamoDbAdapter(client).putNoSqlItem('blobs', {id: 'aGVsbG8=', name: 'hello'})
+
+        expect(captured?.input.Item?.id.B).toEqual(Buffer.from('hello'))
+        expect(result.key).toEqual({id: 'aGVsbG8='})
+    })
+
+    test('validates required and typed keys before putting a record', async () => {
+        let putCalls = 0
+        const client = fakeClient(async (command) => {
+            if (command instanceof DescribeTableCommand) {
+                return {Table: {
+                    KeySchema: [{AttributeName: 'id', KeyType: 'HASH'}],
+                    AttributeDefinitions: [{AttributeName: 'id', AttributeType: 'N'}],
+                }}
+            }
+            putCalls += 1
+            return {}
+        })
+        const adapter = new AwsDynamoDbAdapter(client)
+
+        await expect(adapter.putNoSqlItem('orders', {})).rejects.toThrow('Key attribute id is required')
+        await expect(adapter.putNoSqlItem('orders', {id: 'not-a-number'})).rejects.toThrow('Key attribute id must be a number')
+        expect(putCalls).toBe(0)
     })
 
     test('returns the AWS DynamoDB schema', () => {

--- a/packages/api/src/adapter-aws/AwsDynamoDbAdapter.test.ts
+++ b/packages/api/src/adapter-aws/AwsDynamoDbAdapter.test.ts
@@ -328,6 +328,7 @@ describe('AwsDynamoDbAdapter', () => {
 
         await expect(adapter.putNoSqlItem('orders', {})).rejects.toThrow('Key attribute id is required')
         await expect(adapter.putNoSqlItem('orders', {id: 'not-a-number'})).rejects.toThrow('Key attribute id must be a number')
+        await expect(adapter.putNoSqlItem('orders', {id: 9007199254740992})).rejects.toThrow('must quote integers outside JavaScript\'s safe range')
         expect(putCalls).toBe(0)
     })
 

--- a/packages/api/src/adapter-aws/AwsDynamoDbAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsDynamoDbAdapter.ts
@@ -3,6 +3,7 @@ import {
     DeleteTableCommand,
     DescribeTableCommand,
     ListTablesCommand,
+    PutItemCommand,
     ScanCommand,
     type AttributeDefinition,
     type AttributeValue,
@@ -11,8 +12,8 @@ import {
     type ScalarAttributeType,
     type TableDescription,
 } from '@aws-sdk/client-dynamodb'
-import {unmarshall} from '@aws-sdk/util-dynamodb'
-import {ValidationError} from '../cloud-spi/errors'
+import {marshall, unmarshall} from '@aws-sdk/util-dynamodb'
+import {RuntimeError, ValidationError} from '../cloud-spi/errors'
 import {dynamodb as defaultDynamoDb} from '../aws'
 import {awsDynamoDbSchema} from '../cloud-spi/dynamodbSchema'
 import type {
@@ -104,11 +105,8 @@ export class AwsDynamoDbAdapter implements CloudServiceAdapter {
     }
 
     async listNoSqlItems(resourceId: string): Promise<NoSqlItem[]> {
-        const description = await this.dynamodb.send(new DescribeTableCommand({TableName: resourceId}))
-        if (!description.Table) throw new Error(`DynamoDB did not return a description for table ${resourceId}`)
-        const keyNames = (description.Table.KeySchema ?? [])
-            .map((key) => key.AttributeName)
-            .filter((name): name is string => Boolean(name))
+        const table = await this.describeTable(resourceId)
+        const keyNames = keyAttributes(table).map(({name}) => name)
         const items: NoSqlItem[] = []
         let exclusiveStartKey: Record<string, AttributeValue> | undefined
 
@@ -130,6 +128,25 @@ export class AwsDynamoDbAdapter implements CloudServiceAdapter {
         return items
     }
 
+    async putNoSqlItem(resourceId: string, document: Record<string, unknown>): Promise<NoSqlItem> {
+        if (!document || typeof document !== 'object' || Array.isArray(document)) {
+            throw new ValidationError('Item must be a JSON object.')
+        }
+
+        const table = await this.describeTable(resourceId)
+        const keys = keyAttributes(table)
+        if (keys.length === 0) throw new RuntimeError(`DynamoDB table ${resourceId} has no key schema`)
+        const untypedKey = keys.find(({type}) => !type)
+        if (untypedKey) throw new RuntimeError(`DynamoDB table ${resourceId} has no type definition for key ${untypedKey.name}`)
+
+        const item = marshalDocument(document, keys)
+        await this.dynamodb.send(new PutItemCommand({TableName: resourceId, Item: item}))
+
+        const normalizedDocument = normalizeDocument(unmarshall(item, {wrapNumbers: normalizeNumber}))
+        const key = Object.fromEntries(keys.map(({name}) => [name, normalizedDocument[name]]))
+        return {id: JSON.stringify(key), key, document: normalizedDocument}
+    }
+
     private async listTableNames(): Promise<string[]> {
         const tableNames: string[] = []
         let exclusiveStartTableName: string | undefined
@@ -146,10 +163,72 @@ export class AwsDynamoDbAdapter implements CloudServiceAdapter {
     }
 
     private async describe(tableName: string): Promise<CloudResource> {
-        const response = await this.dynamodb.send(new DescribeTableCommand({TableName: tableName}))
-        if (!response.Table) throw new Error(`DynamoDB did not return a description for table ${tableName}`)
-        return toResource(response.Table)
+        return toResource(await this.describeTable(tableName))
     }
+
+    private async describeTable(tableName: string): Promise<TableDescription> {
+        const response = await this.dynamodb.send(new DescribeTableCommand({TableName: tableName}))
+        if (!response.Table) throw new RuntimeError(`DynamoDB did not return a description for table ${tableName}`)
+        return response.Table
+    }
+}
+
+interface KeyAttribute {
+    name: string
+    type?: ScalarAttributeType
+}
+
+function keyAttributes(table: TableDescription): KeyAttribute[] {
+    const attributeTypes = new Map(
+        (table.AttributeDefinitions ?? [])
+            .filter((definition): definition is AttributeDefinition & {AttributeName: string} => Boolean(definition.AttributeName))
+            .map((definition) => [definition.AttributeName, definition.AttributeType]),
+    )
+    return (table.KeySchema ?? [])
+        .filter((key): key is KeySchemaElement & {AttributeName: string} => Boolean(key.AttributeName))
+        .map((key) => ({name: key.AttributeName, type: attributeTypes.get(key.AttributeName)}))
+}
+
+function marshalDocument(document: Record<string, unknown>, keys: KeyAttribute[]): Record<string, AttributeValue> {
+    for (const {name} of keys) {
+        if (!Object.prototype.hasOwnProperty.call(document, name)) {
+            throw new ValidationError(`Key attribute ${name} is required.`)
+        }
+    }
+
+    let item: Record<string, AttributeValue>
+    try {
+        item = marshall(document)
+    } catch (error) {
+        throw new ValidationError(error instanceof Error ? error.message : 'Item contains a value DynamoDB cannot store.', {cause: error})
+    }
+
+    for (const key of keys) item[key.name] = marshalKey(key, document[key.name])
+    return item
+}
+
+function marshalKey(key: KeyAttribute, value: unknown): AttributeValue {
+    if (key.type === 'N') {
+        const number = typeof value === 'number' || typeof value === 'string' ? String(value) : ''
+        if (!isDynamoNumber(number)) throw new ValidationError(`Key attribute ${key.name} must be a number.`)
+        return {N: number}
+    }
+    if (key.type === 'B') {
+        if (typeof value !== 'string' || !isBase64(value)) {
+            throw new ValidationError(`Binary key attribute ${key.name} must be a non-empty base64 string.`)
+        }
+        return {B: Buffer.from(value, 'base64')}
+    }
+    if (typeof value !== 'string' || !value) throw new ValidationError(`Key attribute ${key.name} must be a non-empty string.`)
+    return {S: value}
+}
+
+function isDynamoNumber(value: string): boolean {
+    return /^[+-]?(?:\d+(?:\.\d*)?|\.\d+)(?:[Ee][+-]?\d+)?$/.test(value)
+}
+
+function isBase64(value: string): boolean {
+    return value.length > 0 && value.length % 4 === 0 && /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)
 }
 
 function normalizeDocument(document: Record<string, unknown>): Record<string, unknown> {

--- a/packages/api/src/adapter-aws/AwsDynamoDbAdapter.ts
+++ b/packages/api/src/adapter-aws/AwsDynamoDbAdapter.ts
@@ -195,6 +195,9 @@ function marshalDocument(document: Record<string, unknown>, keys: KeyAttribute[]
             throw new ValidationError(`Key attribute ${name} is required.`)
         }
     }
+    const marshalledKeys = Object.fromEntries(
+        keys.map((key) => [key.name, marshalKey(key, document[key.name])]),
+    )
 
     let item: Record<string, AttributeValue>
     try {
@@ -203,12 +206,14 @@ function marshalDocument(document: Record<string, unknown>, keys: KeyAttribute[]
         throw new ValidationError(error instanceof Error ? error.message : 'Item contains a value DynamoDB cannot store.', {cause: error})
     }
 
-    for (const key of keys) item[key.name] = marshalKey(key, document[key.name])
-    return item
+    return {...item, ...marshalledKeys}
 }
 
 function marshalKey(key: KeyAttribute, value: unknown): AttributeValue {
     if (key.type === 'N') {
+        if (typeof value === 'number' && Number.isInteger(value) && !Number.isSafeInteger(value)) {
+            throw new ValidationError(`Key attribute ${key.name} must quote integers outside JavaScript's safe range.`)
+        }
         const number = typeof value === 'number' || typeof value === 'string' ? String(value) : ''
         if (!isDynamoNumber(number)) throw new ValidationError(`Key attribute ${key.name} must be a number.`)
         return {N: number}

--- a/packages/api/src/cloud-spi/types.ts
+++ b/packages/api/src/cloud-spi/types.ts
@@ -389,6 +389,7 @@ export interface CloudServiceAdapter {
     listSqlTables?(serverId: string, connection: SqlConnectionInput): Promise<SqlTable[]>
     querySql?(serverId: string, connection: SqlConnectionInput, query: string): Promise<SqlQueryResult>
     listNoSqlItems?(resourceId: string): Promise<NoSqlItem[]>
+    putNoSqlItem?(resourceId: string, document: Record<string, unknown>): Promise<NoSqlItem>
     listKubernetesNodegroups?(clusterId: string): Promise<KubernetesNodegroup[]>
     createKubernetesNodegroup?(clusterId: string, input: CreateKubernetesNodegroupInput): Promise<KubernetesNodegroup>
     deleteKubernetesNodegroup?(clusterId: string, nodegroupId: string): Promise<void>

--- a/packages/api/src/routes/clouds.test.ts
+++ b/packages/api/src/routes/clouds.test.ts
@@ -259,6 +259,29 @@ describe('cloud schema routes', () => {
         expect(body[0].document.table).toBe('orders')
     })
 
+    test('puts a DynamoDB record through the nosql adapter', async () => {
+        const calls: Array<{resourceId: string; document: Record<string, unknown>}> = []
+        const app = appWithRoutes([mockAdapter('aws', {
+            service: 'nosql',
+            schema: awsDynamoDbSchema,
+            putNoSqlItem: async (resourceId, document): Promise<NoSqlItem> => {
+                calls.push({resourceId, document})
+                return {id: JSON.stringify({pk: document.pk}), key: {pk: document.pk}, document}
+            },
+        })])
+
+        const res = await app.request('/api/clouds/aws/services/nosql/resources/orders/items', {
+            method: 'POST',
+            headers: {'content-type': 'application/json'},
+            body: JSON.stringify({pk: 'item-1', name: 'First item'}),
+        })
+        const body = await res.json()
+
+        expect(res.status).toBe(201)
+        expect(body.key).toEqual({pk: 'item-1'})
+        expect(calls).toEqual([{resourceId: 'orders', document: {pk: 'item-1', name: 'First item'}}])
+    })
+
     test('clears the SES mailbox through the email adapter', async () => {
         let cleared = false
         const app = appWithRoutes([mockAdapter('aws', {

--- a/packages/api/src/routes/clouds.ts
+++ b/packages/api/src/routes/clouds.ts
@@ -183,6 +183,17 @@ export function createCloudRoutes(injectedService?: CloudProxyService) {
         })
     })
 
+    app.post('/:cloud/services/nosql/resources/:id/items', async (c) => {
+        const cloud = c.req.param('cloud') as CloudProvider
+        if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)
+
+        return withRuntime(c, async () => {
+            const document = await c.req.json<Record<string, unknown>>()
+            const item = await svc(c).putNoSqlItem(cloud, c.req.param('id'), document)
+            return c.json(item, 201)
+        })
+    })
+
     app.delete('/:cloud/services/email/inbox', async (c) => {
         const cloud = c.req.param('cloud') as CloudProvider
         if (!isCloudProvider(cloud)) return c.json({error: 'Unknown cloud'}, 404)

--- a/packages/api/src/service/CloudProxyService.ts
+++ b/packages/api/src/service/CloudProxyService.ts
@@ -318,6 +318,12 @@ async invokeResource(
         return adapter.listNoSqlItems(resourceId)
     }
 
+    async putNoSqlItem(cloud: CloudProvider, resourceId: string, document: Record<string, unknown>): Promise<NoSqlItem> {
+        const adapter = this.requireAdapter(cloud, 'nosql')
+        if (!adapter.putNoSqlItem) throw new NotSupportedError(`Item creation is not supported for ${cloud}/nosql`)
+        return adapter.putNoSqlItem(resourceId, document)
+    }
+
     async listKubernetesNodegroups(cloud: CloudProvider, clusterId: string): Promise<KubernetesNodegroup[]> {
         const adapter = this.requireAdapter(cloud, 'k8s')
         if (!adapter.listKubernetesNodegroups) throw new NotSupportedError(`Nodegroups are not supported for ${cloud}/k8s`)

--- a/packages/frontend/src/api/api.ts
+++ b/packages/frontend/src/api/api.ts
@@ -47,6 +47,7 @@ export const apiEndpointKeys = {
       },
       items: {
         list: "clouds.services.nosql.items.list",
+        put: "clouds.services.nosql.items.put",
       },
     },
     database: {
@@ -413,6 +414,14 @@ export const endpointRegistry: EndpointRegistry = new Map([
     {
       path: "/clouds/:cloud/services/nosql/resources/:id/items",
       method: "GET",
+      telemetry: { service: "cloud-proxy" },
+    },
+  ],
+  [
+    apiEndpointKeys.clouds.nosql.items.put,
+    {
+      path: "/clouds/:cloud/services/nosql/resources/:id/items",
+      method: "POST",
       telemetry: { service: "cloud-proxy" },
     },
   ],

--- a/packages/frontend/src/api/cloudProxyClient.ts
+++ b/packages/frontend/src/api/cloudProxyClient.ts
@@ -456,6 +456,20 @@ export async function listNoSqlItems(
   return res.data;
 }
 
+export async function putNoSqlItem(
+  cloud: CloudProvider,
+  resourceId: string,
+  document: Record<string, unknown>,
+  signal?: AbortSignal,
+): Promise<NoSqlItem> {
+  const res = await apiClient.call<NoSqlItem, Record<string, unknown>>(
+    apiEndpointKeys.clouds.nosql.items.put,
+    requestOptions(cloud, "nosql", { signal, body: document }),
+    { cloud, id: resourceId },
+  );
+  return res.data;
+}
+
 export async function listKubernetesNodegroups(
   cloud: CloudProvider,
   clusterId: string,

--- a/packages/frontend/src/components/CosmosNoSqlPanel.tsx
+++ b/packages/frontend/src/components/CosmosNoSqlPanel.tsx
@@ -1,6 +1,7 @@
 import {FormEvent, useEffect, useMemo, useState} from 'react'
 import {Code2, Database, Play, Plus, RefreshCw, Table2, Trash2, type LucideIcon} from 'lucide-react'
 import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {JsonRecordModal} from '@/components/JsonRecordModal'
 import {
     createCosmosContainer,
     deleteCosmosContainer,
@@ -28,6 +29,7 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
     const [documentText, setDocumentText] = useState('{\n  "id": ""\n}')
     const [documentError, setDocumentError] = useState<string | null>(null)
     const [selectedItem, setSelectedItem] = useState<CosmosItem | undefined>()
+    const [addRecordOpen, setAddRecordOpen] = useState(false)
     const [sql, setSql] = useState('SELECT * FROM c')
     const [confirmContainer, setConfirmContainer] = useState<string | null>(null)
     const [confirmItem, setConfirmItem] = useState<string | null>(null)
@@ -72,6 +74,7 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
     const upsertItemMut = useMutation({
         mutationFn: (document: Record<string, unknown>) => upsertCosmosItem(cloud, databaseId ?? '', selectedContainerId ?? '', document),
         onSuccess: (item) => {
+            setAddRecordOpen(false)
             setSelectedItem(item)
             setDocumentError(null)
             setDocumentText(JSON.stringify(item.document, null, 2))
@@ -97,6 +100,7 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
     useEffect(() => {
         setSelectedContainerId(undefined)
         setSelectedItem(undefined)
+        setAddRecordOpen(false)
         setDocumentText('{\n  "id": ""\n}')
         setDocumentError(null)
         setSql('SELECT * FROM c')
@@ -104,6 +108,7 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
 
     useEffect(() => {
         setSelectedItem(undefined)
+        setAddRecordOpen(false)
         setDocumentText('{\n  "id": ""\n}')
         setDocumentError(null)
     }, [selectedContainerId])
@@ -202,6 +207,18 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
             <div className="cosmos-column cosmos-column--wide">
                 <PanelHeader icon={Table2} eyebrow="Documents" title={selectedContainer?.name ?? 'Select container'} detail={`${itemsQuery.data?.length ?? 0} items`}/>
                 <div className="cosmos-toolbar">
+                    <button
+                        className="button primary"
+                        type="button"
+                        disabled={!selectedContainerId || !runtimeReachable}
+                        onClick={() => {
+                            upsertItemMut.reset()
+                            setAddRecordOpen(true)
+                        }}
+                    >
+                        <Plus size={14}/>
+                        Add record
+                    </button>
                     <button className="button" type="button" disabled={!selectedContainerId || itemsQuery.isFetching} onClick={() => itemsQuery.refetch()}>
                         <RefreshCw size={14}/>
                         Refresh
@@ -244,20 +261,18 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
             </div>
 
             <div className="cosmos-column">
-                <PanelHeader icon={Code2} eyebrow="Document editor" title={selectedItem ? `Update ${selectedItem.id}` : 'Create document'} detail={selectedItem ? 'Edits replace the selected document' : 'Create a JSON document'}/>
-                <form className="cosmos-editor" onSubmit={submitDocument}>
-                    <textarea className="textarea code-textarea" value={documentText} onChange={(event) => setDocumentText(event.target.value)} spellCheck={false}/>
-                    {selectedItem && (
-                        <button className="button" type="button" onClick={resetDocumentEditor}>
-                            New document
+                <PanelHeader icon={Code2} eyebrow="Document editor" title={selectedItem ? `Update ${selectedItem.id}` : 'Select document'} detail={selectedItem ? 'Edits replace the selected document' : 'Choose a document to inspect or update'}/>
+                {selectedItem ? (
+                    <form className="cosmos-editor" onSubmit={submitDocument}>
+                        <textarea className="textarea code-textarea" value={documentText} onChange={(event) => setDocumentText(event.target.value)} spellCheck={false}/>
+                        <button className="button primary" type="submit" disabled={!selectedContainerId || upsertItemMut.isPending}>
+                            {upsertItemMut.isPending ? 'Saving' : 'Update document'}
                         </button>
-                    )}
-                    <button className="button primary" type="submit" disabled={!selectedContainerId || upsertItemMut.isPending}>
-                        <Plus size={14}/>
-                        {upsertItemMut.isPending ? 'Saving' : selectedItem ? 'Update document' : 'Create document'}
-                    </button>
-                    {saveError && <div className="form-error">{saveError}</div>}
-                </form>
+                        {saveError && <div className="form-error">{saveError}</div>}
+                    </form>
+                ) : (
+                    <div className="empty compact"><h3>Select a document</h3><p>Its JSON contents appear here.</p></div>
+                )}
 
                 <PanelHeader icon={Play} eyebrow="SQL query" title="Cosmos SQL" detail="Runs against selected container"/>
                 <div className="cosmos-query">
@@ -280,6 +295,17 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
                     )}
                 </div>
             </div>
+
+            <JsonRecordModal
+                open={addRecordOpen}
+                title={`Add record to ${selectedContainer?.name ?? 'container'}`}
+                description={cosmosModalDescription(selectedContainer?.partitionKeyPath)}
+                initialValue={JSON.stringify(cosmosRecordTemplate(selectedContainer?.partitionKeyPath), null, 2)}
+                isPending={upsertItemMut.isPending}
+                submitError={upsertItemMut.error instanceof Error ? upsertItemMut.error.message : undefined}
+                onClose={() => setAddRecordOpen(false)}
+                onSubmit={(document) => upsertItemMut.mutate(document)}
+            />
         </section>
     )
 
@@ -295,6 +321,26 @@ export function CosmosNoSqlPanel({cloud, resource, runtimeReachable}: CosmosNoSq
         setDocumentError(null)
         setConfirmItem(null)
     }
+}
+
+function cosmosRecordTemplate(partitionKeyPath = '/id'): Record<string, unknown> {
+    const document: Record<string, unknown> = {id: ''}
+    const segments = partitionKeyPath.replace(/^\//, '').split('/').filter(Boolean)
+    if (segments.length === 0 || segments.length === 1 && segments[0] === 'id') return document
+
+    let target = document
+    for (const segment of segments.slice(0, -1)) {
+        const child: Record<string, unknown> = {}
+        target[segment] = child
+        target = child
+    }
+    target[segments[segments.length - 1] ?? 'id'] = ''
+    return document
+}
+
+function cosmosModalDescription(partitionKeyPath = '/id'): string {
+    const required = partitionKeyPath === '/id' ? 'Include id.' : `Include id and partition key ${partitionKeyPath}.`
+    return `${required} A matching id and partition key replaces the existing record.`
 }
 
 function PanelHeader({icon, eyebrow, title, detail}: {icon: LucideIcon; eyebrow: string; title: string; detail: string}) {

--- a/packages/frontend/src/components/DynamoDbTableExplorer.tsx
+++ b/packages/frontend/src/components/DynamoDbTableExplorer.tsx
@@ -1,7 +1,8 @@
 import {useEffect, useMemo, useState} from 'react'
-import {Braces, RefreshCw, TableProperties} from 'lucide-react'
-import {useQuery} from '@tanstack/react-query'
-import {listNoSqlItems} from '@/api/cloudProxyClient'
+import {Braces, Plus, RefreshCw, TableProperties} from 'lucide-react'
+import {useMutation, useQuery, useQueryClient} from '@tanstack/react-query'
+import {listNoSqlItems, putNoSqlItem} from '@/api/cloudProxyClient'
+import {JsonRecordModal} from '@/components/JsonRecordModal'
 import type {CloudProvider} from '@/types/cloud'
 import type {CloudResource, NoSqlItem} from '@/types/resource'
 
@@ -12,9 +13,12 @@ interface DynamoDbTableExplorerProps {
 }
 
 export function DynamoDbTableExplorer({cloud, resource, runtimeReachable}: DynamoDbTableExplorerProps) {
+    const qc = useQueryClient()
     const tableName = resource?.id
     const [selectedItemId, setSelectedItemId] = useState<string>()
+    const [addRecordOpen, setAddRecordOpen] = useState(false)
     const itemsKey = useMemo(() => ['nosql-items', cloud, tableName], [cloud, tableName])
+    const keyFields = useMemo(() => dynamoKeyFields(resource), [resource])
     const itemsQuery = useQuery({
         queryKey: itemsKey,
         queryFn: ({signal}) => listNoSqlItems(cloud, tableName ?? '', signal),
@@ -22,9 +26,18 @@ export function DynamoDbTableExplorer({cloud, resource, runtimeReachable}: Dynam
     })
     const items = itemsQuery.data ?? []
     const selectedItem = items.find((item) => item.id === selectedItemId)
+    const putItemMut = useMutation({
+        mutationFn: (document: Record<string, unknown>) => putNoSqlItem(cloud, tableName ?? '', document),
+        onSuccess: (item) => {
+            setAddRecordOpen(false)
+            setSelectedItemId(item.id)
+            void qc.invalidateQueries({queryKey: itemsKey})
+        },
+    })
 
     useEffect(() => {
         setSelectedItemId(undefined)
+        setAddRecordOpen(false)
     }, [tableName])
 
     if (!tableName) {
@@ -43,6 +56,18 @@ export function DynamoDbTableExplorer({cloud, resource, runtimeReachable}: Dynam
             <div className="cosmos-column cosmos-column--wide">
                 <PanelHeader icon={<TableProperties size={15}/>} eyebrow="Table explorer" title={tableName} detail={`${items.length} records`}/>
                 <div className="cosmos-toolbar">
+                    <button
+                        className="button primary"
+                        type="button"
+                        disabled={!runtimeReachable}
+                        onClick={() => {
+                            putItemMut.reset()
+                            setAddRecordOpen(true)
+                        }}
+                    >
+                        <Plus size={14}/>
+                        Add record
+                    </button>
                     <button className="button" type="button" disabled={itemsQuery.isFetching} onClick={() => itemsQuery.refetch()}>
                         <RefreshCw size={14}/>
                         {itemsQuery.isFetching ? 'Loading' : 'Refresh'}
@@ -79,8 +104,51 @@ export function DynamoDbTableExplorer({cloud, resource, runtimeReachable}: Dynam
                     <div className="empty compact"><h3>Select a record</h3><p>Full record contents appear here.</p></div>
                 )}
             </div>
+
+            <JsonRecordModal
+                open={addRecordOpen}
+                title={`Add record to ${tableName}`}
+                description={dynamoModalDescription(keyFields)}
+                initialValue={JSON.stringify(Object.fromEntries(keyFields.map(({name, type}) => [name, type === 'N' ? 0 : ''])), null, 2)}
+                isPending={putItemMut.isPending}
+                submitError={putItemMut.error instanceof Error ? putItemMut.error.message : undefined}
+                onClose={() => setAddRecordOpen(false)}
+                onSubmit={(document) => putItemMut.mutate(document)}
+            />
         </section>
     )
+}
+
+interface DynamoKeyField {
+    name: string
+    type?: 'S' | 'N' | 'B'
+}
+
+function dynamoKeyFields(resource?: CloudResource): DynamoKeyField[] {
+    const keySchema = Array.isArray(resource?.metadata.keySchema) ? resource.metadata.keySchema : []
+    const definitions = Array.isArray(resource?.metadata.attributeDefinitions) ? resource.metadata.attributeDefinitions : []
+    const types = new Map(definitions.flatMap((definition) => {
+        if (!definition || typeof definition !== 'object') return []
+        const {AttributeName, AttributeType} = definition as {AttributeName?: unknown; AttributeType?: unknown}
+        return typeof AttributeName === 'string' && isDynamoKeyType(AttributeType) ? [[AttributeName, AttributeType] as const] : []
+    }))
+
+    return keySchema.flatMap((key) => {
+        if (!key || typeof key !== 'object') return []
+        const name = (key as {AttributeName?: unknown}).AttributeName
+        return typeof name === 'string' ? [{name, type: types.get(name)}] : []
+    })
+}
+
+function dynamoModalDescription(keyFields: DynamoKeyField[]): string {
+    const keys = keyFields.map(({name, type}) => `${name}${type ? ` (${type})` : ''}`).join(', ')
+    const binaryHint = keyFields.some(({type}) => type === 'B') ? ' Binary keys use base64.' : ''
+    const numberHint = keyFields.some(({type}) => type === 'N') ? ' Quote large number keys to preserve precision.' : ''
+    return `Required keys: ${keys || 'the table key attributes'}.${binaryHint}${numberHint} A matching key replaces the existing record.`
+}
+
+function isDynamoKeyType(value: unknown): value is 'S' | 'N' | 'B' {
+    return value === 'S' || value === 'N' || value === 'B'
 }
 
 function PanelHeader({icon, eyebrow, title, detail}: {icon: React.ReactNode; eyebrow: string; title: string; detail: string}) {

--- a/packages/frontend/src/components/JsonRecordModal.tsx
+++ b/packages/frontend/src/components/JsonRecordModal.tsx
@@ -1,0 +1,94 @@
+import {FormEvent, useEffect, useState} from 'react'
+import {X} from 'lucide-react'
+
+interface JsonRecordModalProps {
+    open: boolean
+    title: string
+    description: string
+    initialValue: string
+    isPending: boolean
+    submitError?: string
+    onClose: () => void
+    onSubmit: (document: Record<string, unknown>) => void
+}
+
+export function JsonRecordModal({
+    open,
+    title,
+    description,
+    initialValue,
+    isPending,
+    submitError,
+    onClose,
+    onSubmit,
+}: JsonRecordModalProps) {
+    const [value, setValue] = useState(initialValue)
+    const [validationError, setValidationError] = useState<string>()
+
+    useEffect(() => {
+        if (!open) return
+        setValue(initialValue)
+        setValidationError(undefined)
+    }, [initialValue, open])
+
+    useEffect(() => {
+        if (!open) return
+        const closeOnEscape = (event: KeyboardEvent) => {
+            if (event.key === 'Escape' && !isPending) onClose()
+        }
+        window.addEventListener('keydown', closeOnEscape)
+        return () => window.removeEventListener('keydown', closeOnEscape)
+    }, [isPending, onClose, open])
+
+    if (!open) return null
+
+    function submit(event: FormEvent<HTMLFormElement>) {
+        event.preventDefault()
+        try {
+            const parsed = JSON.parse(value) as unknown
+            if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+                setValidationError('Record must be a JSON object.')
+                return
+            }
+            setValidationError(undefined)
+            onSubmit(parsed as Record<string, unknown>)
+        } catch (error) {
+            setValidationError(error instanceof Error ? error.message : 'Invalid JSON.')
+        }
+    }
+
+    return (
+        <div className="modal-overlay" onClick={(event) => event.target === event.currentTarget && !isPending && onClose()}>
+            <form className="record-modal" role="dialog" aria-modal="true" aria-label={title} onSubmit={submit}>
+                <div className="record-modal-header">
+                    <div>
+                        <h3>{title}</h3>
+                        <p>{description}</p>
+                    </div>
+                    <button className="icon-btn" type="button" aria-label="Close" disabled={isPending} onClick={onClose}>
+                        <X size={15}/>
+                    </button>
+                </div>
+                <textarea
+                    className={`textarea code-textarea record-modal-editor ${validationError ? 'invalid' : ''}`}
+                    aria-label="Record JSON"
+                    value={value}
+                    onChange={(event) => {
+                        setValue(event.target.value)
+                        setValidationError(undefined)
+                    }}
+                    spellCheck={false}
+                    autoFocus
+                    disabled={isPending}
+                />
+                {(validationError || submitError) && <div className="form-error">{validationError ?? submitError}</div>}
+                <div className="modal-footer">
+                    <button className="button" type="button" disabled={isPending} onClick={onClose}>Cancel</button>
+                    <button className="button primary" type="submit" disabled={isPending}>
+                        {isPending ? 'Adding' : 'Add record'}
+                    </button>
+                </div>
+            </form>
+        </div>
+    )
+}

--- a/packages/frontend/src/index.css
+++ b/packages/frontend/src/index.css
@@ -3536,6 +3536,49 @@ button.console-service-card {
     justify-content: flex-end;
 }
 
+.record-modal {
+    width: min(640px, calc(100vw - 32px));
+    max-height: calc(100vh - 32px);
+    display: grid;
+    gap: 14px;
+    overflow: auto;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.5);
+    padding: 20px;
+}
+
+.record-modal-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 16px;
+}
+
+.record-modal-header h3,
+.record-modal-header p {
+    margin: 0;
+}
+
+.record-modal-header h3 {
+    color: var(--text-bright);
+    font-size: 15px;
+    font-weight: 600;
+}
+
+.record-modal-header p {
+    margin-top: 5px;
+    color: var(--text-2);
+    font-size: 11px;
+    line-height: 1.5;
+}
+
+.record-modal-editor {
+    min-height: 300px;
+    resize: vertical;
+}
+
 /* ─── Shared drawer tabs ─────────────────────────────────────────────────── */
 .sns-tabs {
     display: flex;


### PR DESCRIPTION
## Summary

- add shared JSON `Add record` modal for DynamoDB and Cosmos DB NoSQL
- add generic NoSQL item creation route and DynamoDB `PutItem` adapter support
- validate DynamoDB `S`, `N`, and `B` keys while preserving large numeric keys
- keep Cosmos document editor focused on updates and prefill required create fields

## Testing

- `pnpm lint`
- `pnpm type-check`
- `pnpm build`
- focused API tests: 57 passed
- `pnpm test`: 728 passed; 1 pre-existing Windows-only ZIP test failure from CRLF parsing of `unzip -Z1` output

Closes #207

<img width="814" height="558" alt="image" src="https://github.com/user-attachments/assets/e93f9c1c-2c29-40a9-89d2-a0a3d744f60e" />
<img width="717" height="202" alt="image" src="https://github.com/user-attachments/assets/badebe7e-796b-48fa-8d90-3dac69598682" />
